### PR TITLE
Problem with create script if ant not installed

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -59,10 +59,10 @@ function on_exit {
 }
 
 function createAppInfoJar {
-    (cd "$BUILD_PATH"/bin/templates/cordova/ApplicationInfo &&
-     javac ApplicationInfo.java &&
-     jar -cfe ../appinfo.jar ApplicationInfo ApplicationInfo.class
-    )
+    pushd "$BUILD_PATH"/bin/templates/cordova/ApplicationInfo > /dev/null
+    javac ApplicationInfo.java
+    jar -cfe ../appinfo.jar ApplicationInfo ApplicationInfo.class
+    popd > /dev/null
 }
 
 function on_error {
@@ -108,7 +108,7 @@ fi
 # if this a distribution release no need to build a jar
 if [ ! -e "$BUILD_PATH"/cordova-$VERSION.jar ] && [ -d "$BUILD_PATH"/framework ]
 then
-# update the cordova-android framework for the desired target
+    # update the cordova-android framework for the desired target
     "$ANDROID_BIN" update project --target $TARGET --path "$BUILD_PATH"/framework &> /dev/null
 
     if [ ! -e "$BUILD_PATH"/framework/libs/commons-codec-1.7.jar ]; then
@@ -121,8 +121,10 @@ then
         rm commons-codec-1.7-bin.zip && rm -rf commons-codec-1.7
     fi
 
-# compile cordova.js and cordova.jar
-    (cd "$BUILD_PATH"/framework && ant jar &> /dev/null )
+    # compile cordova.js and cordova.jar
+    pushd "$BUILD_PATH"/framework > /dev/null
+    ant jar > /dev/null
+    popd > /dev/null
 fi
 
 # create new android project


### PR DESCRIPTION
If you don't have ant installed when you run the create script, you get a misleading message telling you something like this:

```
An unexpected error occurred: [ ! -e "$BUILD_PATH"/framework/libs/commons-codec-1.7.jar ] exited with 1
Deleting project...
```

The reason appears to be that the error trap set up for `on_error` doesn't play nicely with running the ant command in a subshell. The subshell appears to be used to preserve the current working directory. If `pushd` and `popd` are used instead, then a more helpful error is given, something like:

```
./create: line 119: ant: command not found
An unexpected error occurred: ant jar > /dev/null exited with 127
Deleting project...
```
