### PR TITLE
[CB-861] Header support for FileTransfer download

### DIFF
--- a/framework/src/org/apache/cordova/FileTransfer.java
+++ b/framework/src/org/apache/cordova/FileTransfer.java
@@ -158,6 +158,25 @@ public class FileTransfer extends CordovaPlugin {
         return false;
     }
 
+    private static void addHeadersToRequest(URLConnection connection, JSONObject headers) {
+        try {
+            for (Iterator<?> iter = headers.keys(); iter.hasNext(); ) {
+                String headerKey = iter.next().toString();
+                JSONArray headerValues = headers.optJSONArray(headerKey);
+                if (headerValues == null) {
+                    headerValues = new JSONArray();
+                    headerValues.put(headers.getString(headerKey));
+                }
+                connection.setRequestProperty(headerKey, headerValues.getString(0));
+                for (int i = 1; i < headerValues.length(); ++i) {
+                    connection.addRequestProperty(headerKey, headerValues.getString(i));
+                }
+            }
+        } catch (JSONException e1) {
+          // No headers to be manipulated!
+        }
+    }
+
     /**
      * Uploads the specified file to the server URL provided using an HTTP multipart request.
      * @param source        Full path of the file on the file system
@@ -272,22 +291,7 @@ public class FileTransfer extends CordovaPlugin {
 
                     // Handle the other headers
                     if (headers != null) {
-                        try {
-                            for (Iterator<?> iter = headers.keys(); iter.hasNext(); ) {
-                                String headerKey = iter.next().toString();
-                                JSONArray headerValues = headers.optJSONArray(headerKey);
-                                if (headerValues == null) {
-                                    headerValues = new JSONArray();
-                                    headerValues.put(headers.getString(headerKey));
-                                }
-                                conn.setRequestProperty(headerKey, headerValues.getString(0));
-                                for (int i = 1; i < headerValues.length(); ++i) {
-                                    conn.addRequestProperty(headerKey, headerValues.getString(i));
-                                }
-                            }
-                        } catch (JSONException e1) {
-                          // No headers to be manipulated!
-                        }
+                        addHeadersToRequest(conn, headers);
                     }
 
                     /*
@@ -615,9 +619,8 @@ public class FileTransfer extends CordovaPlugin {
         Log.d(LOG_TAG, "download " + source + " to " +  target);
 
         final boolean trustEveryone = args.optBoolean(2);
-        final JSONObject headers = args.optJSONObject(3);
-        Log.d(LOG_TAG, "headers: " + headers);
-        final String objectId = args.getString(4);
+        final String objectId = args.getString(3);
+        final JSONObject headers = args.optJSONObject(4);
 
         final URL url;
         try {
@@ -698,22 +701,7 @@ public class FileTransfer extends CordovaPlugin {
 
                     // Handle the other headers
                     if (headers != null) {
-                        try {
-                            for (Iterator<?> iter = headers.keys(); iter.hasNext(); ) {
-                                String headerKey = iter.next().toString();
-                                JSONArray headerValues = headers.optJSONArray(headerKey);
-                                if (headerValues == null) {
-                                    headerValues = new JSONArray();
-                                    headerValues.put(headers.getString(headerKey));
-                                }
-                                connection.setRequestProperty(headerKey, headerValues.getString(0));
-                                for (int i = 1; i < headerValues.length(); ++i) {
-                                    connection.addRequestProperty(headerKey, headerValues.getString(i));
-                                }
-                            }
-                        } catch (JSONException e1) {
-                          // No headers to be manipulated!
-                        }
+                        addHeadersToRequest(connection, headers);
                     }
     
                     connection.connect();


### PR DESCRIPTION
Added support for an optional options object as the final arg. Currently only handles the options.headers object (as per the issue).

`FileTransfer.download(source, target, successCallback, errorCallback, trustAllHosts, options)`

This is needed for using FileTransfer.download with Basic Authentication, etc. Sadly since Android 2.x doesn't support XHR2, this is needed in FileTransfer.

I have only added support to Android and iOS (see other PR's). It might be that the JS args need to be in a different order or handled differently so that it doesn't impact the other platforms. I am hoping I can get advice on that from someone.

If there is anything else I need to do, just let me know.

//cc @agrieve - for suggesting I do this myself
