### PR TITLE
[CB-2668] ICS asset URLs with spaces workaround

### DIFF
--- a/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
@@ -42,7 +42,7 @@ public class IceCreamCordovaWebViewClient extends CordovaWebViewClient {
 
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if(url.contains("?") || url.contains("#")){
+        if(url.contains("?") || url.contains("#") || needsSpaceInAssetUrlFix(url)){
             return generateWebResourceResponse(url);
         } else {
             return super.shouldInterceptRequest(view, url);
@@ -78,6 +78,20 @@ public class IceCreamCordovaWebViewClient extends CordovaWebViewClient {
             }
         }
         return null;
+    }
+    
+    private static boolean needsIceCreamSpaceInAssetUrlFix(String url) {
+        if (!url.contains("%20")){
+            return false;
+        }
+
+        switch(android.os.Build.VERSION.SDK_INT){
+            case android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH:
+            case android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1:
+                return true;
+            default:
+                return false;
+        }
     }
     
 }


### PR DESCRIPTION
The WebView in Ice Cream Sandwich breaks loading asset URLs with spaces in them, so that loading file:///android_asset/my%20page.html fails. This means that any assets in the www folder with spaces in their path won't load on API level 14 or 15 devices.

This was the most elegant fix I could come up with. Comments are welcome.
