### PR TITLE
add option to clear InAppBrowser cache on startup

### DIFF
--- a/framework/src/org/apache/cordova/InAppBrowser.java
+++ b/framework/src/org/apache/cordova/InAppBrowser.java
@@ -379,7 +379,7 @@ public class InAppBrowser extends CordovaPlugin {
             }else{
                 Log.d(LOG_TAG, "clear session cache");
                 cache = features.get(CLEAR_SESSION_CACHE);
-                if(cache!=null)clearSessionCache=features.get(CLEAR_SESSION_CACHE);
+                if(cache!=null)clearSessionCache=cache.booleanValue();
             }
         }
         


### PR DESCRIPTION
usage: 
   same as option 'location=no"
   if add option "clearcache=yes" in window.open(url, random_string, 'option'), it will clear the cache. 
