### PR TITLE
Implemented logic to allow video duration to be supported on the Android platform.

### DIFF
--- a/framework/src/org/apache/cordova/Capture.java
+++ b/framework/src/org/apache/cordova/Capture.java
@@ -219,7 +219,7 @@ public class Capture extends CordovaPlugin {
         Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
 
         if(Build.VERSION.SDK_INT > 8){
-            intent.putExtra(android.provider.MediaStore.EXTRA_DURATION_LIMIT, duration);
+            intent.putExtra("android.intent.extra.durationLimit", duration);
         }
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, CAPTURE_VIDEO);
     }


### PR DESCRIPTION
The logic implemented, doesn't reply on any SDK specific classes, which is why the string literal value is used instead of the constant provided by the Android platform.

My initial reaction to support this feature was to extend Capture and override the captureVideo method, but this method was marked private and called from multiple sources. If I were to override the calling methods as well, they replied on private state which had no accessors.

Please see this patch as being beneficial to the PhoneGap project and merge it into the core.

Cheers,
Richard L. Burton III
