### PR TITLE
InAppBrowser fixes: CB-2308, CB-1957

### DIFF
--- a/framework/src/org/apache/cordova/InAppBrowser.java
+++ b/framework/src/org/apache/cordova/InAppBrowser.java
@@ -231,6 +231,7 @@ public class InAppBrowser extends CordovaPlugin {
      */
     private void closeDialog() {
         try {
+            this.inAppWebView.loadUrl("about:blank");
             JSONObject obj = new JSONObject();
             obj.put("type", EXIT_EVENT);
 


### PR DESCRIPTION
Added error channel for InAppBrowser (CB-2308)
This branch also fixes CB-1957, by navigating to about:blank before dismissing the InAppBrowser dialog.
