### PR TITLE
Fix the DroidGap activity Lifecycle broken issue onDestroy.

### DIFF
--- a/framework/src/org/apache/cordova/DroidGap.java
+++ b/framework/src/org/apache/cordova/DroidGap.java
@@ -717,7 +717,7 @@ public class DroidGap extends Activity implements CordovaInterface {
             appView.handleDestroy();
         }
         else {
-            this.endActivity();
+            this.activityState = ACTIVITY_EXITING; 
         }
     }
 


### PR DESCRIPTION
This request is trying to fix the issue that a DroidGap derived Activity is restarted by the system in an incorrect order due to the finish() invocation onDestroy() upon say, device Config Changes*.

Upon device Config Changes, onDestroy is followed by a onCreate as promised in:
- http://developer.android.com/reference/android/app/Activity.html#ConfigurationChanges

Please check attached log snapshots of the issue.

---

Attempting to invoke the Activity's finish() onDestroy breaks an Activity's lifecycle
flag. OnDestroy can be called by the system, for instance, on restarting an Activity,
it's definitely different from a normal finish().
Finish() incorrectly in onDestroy results in another DroidGap derived activity
is started, while the original one is not yet onDestroy. This issue could be
found when the system is trying to restart the activity upon, for instance,
receiving immediately successive device Config changes.

---

![error](https://f.cloud.github.com/assets/4023588/323304/504dbfdc-9aab-11e2-9ba3-7933ad111543.gif)

The corresponding device "Config Changes" notifications
![error_configchanged](https://f.cloud.github.com/assets/4023588/323306/6526262e-9aab-11e2-8d63-38978337685d.gif)
