### PR TITLE
Fixing URL transformation algorithm

### DIFF
--- a/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
@@ -57,7 +57,7 @@ public class IceCreamCordovaWebViewClient extends CordovaWebViewClient {
             if(niceUrl.contains("?")){
                 niceUrl = niceUrl.split("\\?")[0];
             }
-            else if(niceUrl.contains("#"))
+            if(niceUrl.contains("#"))
             {
                 niceUrl = niceUrl.split("#")[0];
             }


### PR DESCRIPTION
It didn't work with URL like this:
http://host.com/path/to/file.txt#/foo?bar=baz
When hash sign is in front of question mark - it only strips the question mark, leaving the hash and breaking the whole app.
