### PR TITLE
CB-3038: Avoid crash when no path can be resolved

### DIFF
--- a/framework/src/org/apache/cordova/FileHelper.java
+++ b/framework/src/org/apache/cordova/FileHelper.java
@@ -121,6 +121,9 @@ public class FileHelper {
      */
     public static String getMimeType(String uriString, CordovaInterface cordova) {
         String mimeType = null;
+        if (uriString == null) {
+            return null;
+        }
 
         if (uriString.startsWith("content://")) {
             Uri uri = Uri.parse(uriString);


### PR DESCRIPTION
With this pull request, the `error` callback from `navigator.camera.getPicture` will be invoked with the error `Unable to retrieve path to picture!`
