### PR TITLE
Fix a problem with the Windows jscript runtime

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -190,7 +190,8 @@ if(fso.FolderExists(PROJECT_PATH)) {
 }
 
 var PACKAGE_AS_PATH=PACKAGE.replace(/\./g, '\\');
-var ACTIVITY_PATH=PROJECT_PATH+'\\src\\'+PACKAGE_AS_PATH+'\\'+ACTIVITY+'.java';
+var ACTIVITY_DIR=PROJECT_PATH + '\\src\\' + PACKAGE_AS_PATH;
+var ACTIVITY_PATH=ACTIVITY_DIR+'\\'+ACTIVITY+'.java';
 var MANIFEST_PATH=PROJECT_PATH+'\\AndroidManifest.xml';
 var TARGET=setTarget();
 var API_LEVEL=setApiLevel();
@@ -215,7 +216,8 @@ Log("Copying template files...");
 exec('%comspec% /c xcopy "'+ ROOT + '\\bin\\templates\\project\\res" "'+PROJECT_PATH+'\\res\\" /E /Y');
 exec('%comspec% /c xcopy "'+ ROOT + '\\bin\\templates\\project\\assets" "'+PROJECT_PATH+'\\assets\\" /E /Y');
 exec('%comspec% /c copy "'+ROOT+'\\bin\\templates\\project\\AndroidManifest.xml" "' + PROJECT_PATH + '\\AndroidManifest.xml" /Y');
-exec('%comspec% /c copy "'+ROOT+'\\bin\\templates\\project\\Activity.java" "'+ ACTIVITY_PATH +'" /Y');
+exec('%comspec% /c mkdir ' + ACTIVITY_DIR);
+exec('%comspec% /c copy "' + ROOT + '"\\bin\\templates\\project\\Activity.java ' + ACTIVITY_PATH + ' /Y');
 
 // check if we have the source or the distro files
 Log("Copying js, jar & config.xml files...");


### PR DESCRIPTION
The problem is with this line in "create.js":

var ACTIVITY_PATH=PROJECT_PATH+'\src\'+PACKAGE_AS_PATH+'\'+ACTIVITY+'.java';
[...]
exec('%comspec% /c copy "'+ROOT+'"\bin\templates\project\Activity.java '+ ACTIVITY_PATH +' /Y');

The Windows "copy" command will not create directories that don't exist, so the command above fails because "src\PACKAGE_AS_PATH" doesn't exist.  This can be fixed with:
