### PR TITLE
Bugfix: Config parser for plugins with onload param.

### DIFF
--- a/framework/src/org/apache/cordova/api/PluginManager.java
+++ b/framework/src/org/apache/cordova/api/PluginManager.java
@@ -138,7 +138,7 @@ public class PluginManager {
                     else if (paramType.equals("package") || paramType.equals("android-package"))
                         pluginClass = xml.getAttributeValue(null,"value");
                     else if (paramType.equals("onload"))
-                        onload = "true".equals(xml.getAttributeValue(null, "onload"));
+                        onload = "true".equals(xml.getAttributeValue(null, "value"));
                 }
             }
             else if (eventType == XmlResourceParser.END_TAG)


### PR DESCRIPTION
The functionality was broken in the move from plugins to feature tags.
