### PR TITLE
Fixing a null pointer exception in activity callback

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -863,7 +863,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
                 this.activityResultCallback = appView.pluginManager.getPlugin(initCallbackClass);
                 callback = activityResultCallback;
                 LOG.d(TAG, "We have a callback to send this result to");
-                callback.onActivityResult(requestCode, resultCode, intent);
+                if(callback != null) {
+                    callback.onActivityResult(requestCode, resultCode, intent);
+                }
             }
         }
         else


### PR DESCRIPTION
I had a situation where the camera application would actually fail and it seems that the onActivityResult method would fall into an unusual state and throw an exception.

The simple fix was to ensure that if the plugin manager returned null for a callback, we didn't then attempt to use the callback.
