### PR TITLE
CB-3480: update now uses cordova.js not cordova-<ver>.js

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -45,9 +45,9 @@ fi
 
 # cleanup after exit and/or on error
 function on_exit {
-    if [ -f "$BUILD_PATH"/framework/assets/www/cordova-$VERSION.js ]
+    if [ -f "$BUILD_PATH"/framework/assets/www/cordova.js ]
     then
-        rm "$BUILD_PATH"/framework/assets/www/cordova-$VERSION.js
+        rm "$BUILD_PATH"/framework/assets/www/cordova.js
     fi
     if [ -f "$BUILD_PATH"/framework/cordova-$VERSION.jar ]
     then
@@ -122,10 +122,10 @@ fi
 # copy cordova.js, cordova.jar and res/xml
 if [ -d "$BUILD_PATH"/framework ]
 then
-    cp "$BUILD_PATH"/framework/assets/www/cordova-$VERSION.js "$PROJECT_PATH"/assets/www/cordova-$VERSION.js
+    cp "$BUILD_PATH"/framework/assets/www/cordova.js "$PROJECT_PATH"/assets/www/cordova.js
     cp "$BUILD_PATH"/framework/cordova-$VERSION.jar "$PROJECT_PATH"/libs/cordova-$VERSION.jar
 else
-    cp "$BUILD_PATH"/cordova-$VERSION.js "$PROJECT_PATH"/assets/www/cordova-$VERSION.js
+    cp "$BUILD_PATH"/cordova.js "$PROJECT_PATH"/assets/www/cordova.js
     cp "$BUILD_PATH"/cordova-$VERSION.jar "$PROJECT_PATH"/libs/cordova-$VERSION.jar
 fi
 


### PR DESCRIPTION
This fixes the update scripts and should be in 2.8.x
