### PR TITLE
Fallback to the current activity's package name when calling getIdentifier

### DIFF
--- a/framework/src/org/apache/cordova/Config.java
+++ b/framework/src/org/apache/cordova/Config.java
@@ -77,6 +77,16 @@ public class Config {
             id = action.getResources().getIdentifier("cordova", "xml", action.getPackageName());
             LOG.i("CordovaLog", "config.xml missing, reverting to cordova.xml");
         }
+        if(id == 0)
+        {
+            id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getClass().getPackage().getName());
+            LOG.i(TAG, "Using config.xml from class name instead of the package name's config.xml.");
+        }
+        if(id == 0)
+        {
+            id = this.ctx.getActivity().getResources().getIdentifier("cordova", "xml", this.ctx.getActivity().getClass().getPackage().getName());
+            LOG.i(TAG, "Using cordova.xml from class name instead of the package name's cordova.xml.");
+        }
         if (id == 0) {
             LOG.i("CordovaLog", "cordova.xml missing. Ignoring...");
             return;

--- a/framework/src/org/apache/cordova/api/PluginManager.java
+++ b/framework/src/org/apache/cordova/api/PluginManager.java
@@ -94,11 +94,21 @@ public class PluginManager {
      * Load plugins from res/xml/plugins.xml
      */
     public void loadPlugins() {
-        int id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getClass().getPackage().getName());
+        int id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getPackageName());
+        if(id == 0)
+        {
+            id = this.ctx.getActivity().getResources().getIdentifier("plugins", "xml", this.ctx.getActivity().getPackageName());
+            LOG.i(TAG, "Using plugins.xml instead of config.xml.  plugins.xml will eventually be deprecated");
+        }
+        if(id == 0)
+        {
+            id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getClass().getPackage().getName());
+            LOG.i(TAG, "Using config.xml from class name instead of the package name's config.xml.");
+        }
         if(id == 0)
         {
             id = this.ctx.getActivity().getResources().getIdentifier("plugins", "xml", this.ctx.getActivity().getClass().getPackage().getName());
-            LOG.i(TAG, "Using plugins.xml instead of config.xml.  plugins.xml will eventually be deprecated");
+            LOG.i(TAG, "Using plugins.xml from class name instead of the package name's plugins.xml. plugins.xml will eventually be deprecated");
         }
         if (id == 0) {
             this.pluginConfigurationMissing();


### PR DESCRIPTION
When you build an app using aapt's --rename-manifest-package argument, it searches for all of the resources in the wrong location. This fix makes it so that it can fallback to look at the package name of the current activity instead of the package name of the application (which was changed at build-time).
