### PR TITLE
CB-4133 add main thread warning for plugins that run too long

### DIFF
--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -227,7 +227,10 @@ public class PluginManager {
         }
         try {
             CallbackContext callbackContext = new CallbackContext(callbackId, app);
+            long now = System.currentTimeMillis();
             boolean wasValidAction = plugin.execute(action, rawArgs, callbackContext);
+            long duration = System.currentTimeMillis()-now;
+            if(duration>50) Log.d(TAG,"THREAD WARNING: exec() call to "+service+" took "+duration+" ms");
             if (!wasValidAction) {
                 PluginResult cr = new PluginResult(PluginResult.Status.INVALID_ACTION);
                 app.sendPluginResult(cr, callbackId);


### PR DESCRIPTION
Check the time that plugins  on the main thread and log if the elapsed time is greater than 50ms
