### PR TITLE
CB-4280 handle invalid bridge mode request

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -228,8 +228,13 @@ public class CordovaChromeClient extends WebChromeClient {
 
         // Sets the native->JS bridge mode. 
         else if (reqOk && defaultValue != null && defaultValue.equals("gap_bridge_mode:")) {
-            this.appView.exposedJsApi.setNativeToJsBridgeMode(Integer.parseInt(message));
-            result.confirm("");
+        	try {
+                this.appView.exposedJsApi.setNativeToJsBridgeMode(Integer.parseInt(message));
+                result.confirm("");
+        	} catch (NumberFormatException e){
+                result.confirm("");
+                e.printStackTrace();
+        	}
         }
 
         // Polling for JavaScript messages 


### PR DESCRIPTION
During the older mobilespec bridge tests, a bridge mode was requested that did not exist. This results in attempting to parse 'undefined' to get an integer, producing an untrapped numeric exception - terminating the app.

This adds a try-catch to the parse.
