### PR TITLE
Added Log.e when Config is not initialised but accessed

### DIFF
--- a/framework/src/org/apache/cordova/Config.java
+++ b/framework/src/org/apache/cordova/Config.java
@@ -199,6 +199,7 @@ public class Config {
      */
     public static void addWhiteListEntry(String origin, boolean subdomains) {
         if (self == null) {
+            Log.e(TAG, "Config was not initialised. Did you forget to Config.init(this)?");
             return;
         }
         self.whitelist.addWhiteListEntry(origin, subdomains);
@@ -212,6 +213,7 @@ public class Config {
      */
     public static boolean isUrlWhiteListed(String url) {
         if (self == null) {
+            Log.e(TAG, "Config was not initialised. Did you forget to Config.init(this)?");
             return false;
         }
         return self.whitelist.isUrlWhiteListed(url);


### PR DESCRIPTION
I spent few days trying to make CordovaWebView on my own activity. 

I had issues that not network calls were made. 

Problem was that I forget to do Config.init(activity).

So I put log message for developers to notice. 
