### PR TITLE
start-emulator script doesn't fail (exit) early on fatal emulator errors

### DIFF
--- a/bin/templates/cordova/lib/start-emulator
+++ b/bin/templates/cordova/lib/start-emulator
@@ -24,7 +24,24 @@ function dot {
     echo -n "."
 }
 
-function wait_for_emulator {
+function wait_for_emulator() {
+    local emulator_log_path=$1
+    local error_string
+    local status
+
+    # Try to detect fatal errors early
+    sleep 1.5
+    error_string=$(grep -F "ERROR: " ${emulator_log_path})
+    status=$?
+
+    if [ $status -eq 0 ]; then
+        echo "Emulator failed to start, fatal error detected"
+        echo "Error: ${error_string}"
+        echo "Full log available at: ${emulator_log_path}"
+        echo "Exiting..."
+        exit 1
+    fi
+
     local i="0"
     echo -n "Waiting for emulator"
     emulator_string=$($DIR/list-started-emulators)
@@ -83,9 +100,11 @@ if [[ "$#" -eq 1 ]] ; then
     fi
 else
     # start first emulator
+    log_path=$(mktemp)
+    echo "Saving emulator log to: ${log_path}"
     read -ra emulator_list <<< "$emulator_images"
     #xterm -e emulator -avd ${emulator_list[0]} &
-    emulator -avd ${emulator_list[0]} 1> /dev/null 2>&1 &
+    emulator -avd ${emulator_list[0]} 1> ${log_path} 2>&1 &
 fi
 
-wait_for_emulator
+wait_for_emulator $log_path


### PR DESCRIPTION
## Problem

Currently `start-emulator` script doesn't exist early on Linux if a fatal error happens. 

This means you need to wait 300 seconds (default timeout) before you receive first feedback from the cli tool that something is wrong. An even then (after a timeout), it's hard to debug the problem because `adb` stdout and stderr are simply redirected `/dev/null`. This makes it for a bad UI and a frustrated user.

For example:

``` bash
....
Waiting for emulator.....
```

If I run the emulator manually I see it produces a fatal error:

``` bash
emulator: ERROR: unknown skin name 'WVGA800'
```
## Proposed Solution

This branch does the following:
1. Modify the emulator start script to redirect log to a temporary file. This way it's easier to debug actual issues.
2. Modify `wait_for_emulator` function to exit immediately and print an error if a fatal error is detected while starting the emulator

Example output with my change:

``` bash
Saving emulator log to: /tmp/tmp.VTOblrPktV

Emulator failed to start, fatal error detected
Error: emulator: ERROR: unknown skin name 'WVGA800'
Full log available at: /tmp/tmp.VTOblrPktV
Exiting...
```

(I'll also open appropriate JIRA ticket later on)
