### PR TITLE
[CB-5258] use exit library

### DIFF
--- a/bin/android_sdk_version
+++ b/bin/android_sdk_version
@@ -20,10 +20,11 @@
 */
 
 var android_sdk_version = require('./lib/android_sdk_version');
+var exit = require('exit');
 
 android_sdk_version.run().done(null, function(err) {
     console.log(err);
-    process.exit(2);
+    exit(2);
 });
 
 

--- a/bin/check_reqs
+++ b/bin/check_reqs
@@ -20,12 +20,13 @@
 */
 
 var check_reqs = require('./lib/check_reqs');
+var exit = require('exit');
 
 check_reqs.run().done(
     function success() {
         console.log('Looks like your environment fully supports cordova-android development!');
     }, function fail(err) {
         console.log(err);
-        process.exit(2);
+        exit(2);
     }
 );

--- a/bin/create
+++ b/bin/create
@@ -19,6 +19,7 @@
        under the License.
 */
 var path = require('path');
+var exit = require('exit');
 var create = require('./lib/create');
 var args  = require('./lib/simpleargs').getArgs(process.argv);
 
@@ -29,7 +30,7 @@ if (args['--help'] || args._.length === 0) {
     console.log('    <project_name>: Project name');
     console.log('    <template_path>: Path to a custom application template to use');
     console.log('    --shared will use the CordovaLib project directly instead of making a copy.');
-    process.exit(1);
+    exit(1);
 }
 
 create.createProject(args._[0], args._[1], args._[2], args._[3], args['--shared']).done();

--- a/bin/package.json
+++ b/bin/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "shelljs" : "0.2.6",
+        "exit": "0.1.1",
         "q": "~0.9"
     },
     "devDependencies": {

--- a/bin/templates/cordova/build
+++ b/bin/templates/cordova/build
@@ -21,6 +21,7 @@
 
 var build = require('./lib/build'),
     reqs  = require('./lib/check_reqs'),
+    exit  = require('exit'),
     args  = process.argv;
 
 // Support basic help commands
@@ -32,6 +33,6 @@ if(args[2] == '--help' || args[2] == '/?' || args[2] == '-h' ||
         return build.run(args[2]);
     }).done(null, function(err) {
         console.error(err);
-        process.exit(2);
+        exit(2);
     });
 }

--- a/bin/templates/cordova/clean
+++ b/bin/templates/cordova/clean
@@ -21,6 +21,7 @@
 
 var clean = require('./lib/clean'),
     reqs  = require('./lib/check_reqs'),
+    exit  = require('exit'),
     args  = process.argv;
 
 // Usage support for when args are given
@@ -31,6 +32,6 @@ if(args.length > 2) {
         return clean.run();
     }, function(err) {
         console.error('ERROR: ' + err);
-        process.exit(2);
+        exit(2);
     });
 }

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -21,6 +21,7 @@
 
 var shell   = require('shelljs'),
     exec    = require('./exec'),
+    exit    = require('exit'),
     Q       = require('q'),
     clean   = require('./clean'),
     path    = require('path'),
@@ -70,10 +71,10 @@ module.exports.get_apk = function() {
             }
         }
         console.error('ERROR : No .apk found in \'bin\' folder');
-        process.exit(2);
+        exit(2);
     } else {
         console.error('ERROR : unable to find project bin folder, could not locate .apk');
-        process.exit(2);
+        exit(2);
     }
 }
 
@@ -83,5 +84,5 @@ module.exports.help = function() {
     console.log('    \'--debug\': Default build, will build project in using ant debug');
     console.log('    \'--release\': will build project using ant release');
     console.log('    \'--nobuild\': will skip build process (can be used with run command)');
-    process.exit(0);
+    exit(0);
 }

--- a/bin/templates/cordova/lib/clean.js
+++ b/bin/templates/cordova/lib/clean.js
@@ -20,6 +20,7 @@
 */
 
 var exec  = require('./exec'),
+    exit  = require('exit'),
     path  = require('path'),
     ROOT = path.join(__dirname, '..', '..');
 
@@ -34,5 +35,5 @@ module.exports.run = function() {
 module.exports.help = function() {
     console.log('Usage: ' + path.relative(process.cwd(), process.argv[1]));
     console.log('Cleans the project directory.');
-    process.exit(0);
+    exit(0);
 }

--- a/bin/templates/cordova/lib/install-device
+++ b/bin/templates/cordova/lib/install-device
@@ -20,6 +20,7 @@
 */
 
 var device = require('./device'),
+    exit   = require('exit'),
     args   = process.argv;
 
 if(args.length > 2) {
@@ -28,15 +29,15 @@ if(args.length > 2) {
         install_target = args[2].substring(9, args[2].length);
         device.install(install_target).done(null, function(err) {
             console.error('ERROR: ' + err);
-            process.exit(2);
+            exit(2);
         });
      } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
-        process.exit(2);
+        exit(2);
      }
 } else {
     device.install().done(null, function(err) {
         console.error('ERROR: ' + err);
-        process.exit(2);
+        exit(2);
     });
 }

--- a/bin/templates/cordova/lib/install-emulator
+++ b/bin/templates/cordova/lib/install-emulator
@@ -20,6 +20,7 @@
 */
 
 var emulator = require('./emulator'),
+    exit     = require('exit'),
     args     = process.argv;
 
 var install_target;
@@ -28,11 +29,11 @@ if(args.length > 2) {
         install_target = args[2].substring(9, args[2].length);
      } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
-        process.exit(2);
+        exit(2);
      }
 }
 
 emulator.install(install_target).done(null, function(err) {
     console.error('ERROR: ' + err);
-    process.exit(2);
+    exit(2);
 });

--- a/bin/templates/cordova/lib/list-devices
+++ b/bin/templates/cordova/lib/list-devices
@@ -20,6 +20,7 @@
 */
 
 var devices = require('./device');
+var exit    = require('exit');
 
 // Usage support for when args are given
 devices.list().done(function(device_list) {
@@ -28,6 +29,6 @@ devices.list().done(function(device_list) {
     });
 }, function(err) {
     console.error('ERROR: ' + err);
-    process.exit(2);
+    exit(2);
 });
 

--- a/bin/templates/cordova/lib/list-emulator-images
+++ b/bin/templates/cordova/lib/list-emulator-images
@@ -20,6 +20,7 @@
 */
 
 var emulators = require('./emulator');
+var exit    = require('exit');
 
 // Usage support for when args are given
 emulators.list_images().done(function(emulator_list) {
@@ -28,5 +29,5 @@ emulators.list_images().done(function(emulator_list) {
     });
 }, function(err) {
     console.error('ERROR: ' + err);
-    process.exit(2);
+    exit(2);
 });

--- a/bin/templates/cordova/lib/list-started-emulators
+++ b/bin/templates/cordova/lib/list-started-emulators
@@ -20,6 +20,7 @@
 */
 
 var emulators = require('./emulator');
+var exit    = require('exit');
 
 // Usage support for when args are given
 emulators.list_started().done(function(emulator_list) {
@@ -28,5 +29,5 @@ emulators.list_started().done(function(emulator_list) {
     });
 }, function(err) {
     console.error('ERROR: ' + err);
-    process.exit(2);
+    exit(2);
 });

--- a/bin/templates/cordova/lib/log.js
+++ b/bin/templates/cordova/lib/log.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file
@@ -20,6 +19,7 @@
 */
 
 var shell = require('shelljs'),
+    exit  = require('exit'),
     path  = require('path'),
     Q     = require('q'),
     child_process = require('child_process'),
@@ -53,5 +53,5 @@ module.exports.run = function() {
 module.exports.help = function() {
     console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'cordova', 'log')));
     console.log('Gives the logcat output on the command line.');
-    process.exit(0);
+    exit(0);
 }

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -20,6 +20,7 @@
 */
 
 var path  = require('path'),
+    exit  = require('exit'),
     build = require('./build'),
     emulator = require('./emulator'),
     device   = require('./device'),
@@ -51,7 +52,7 @@ var path  = require('path'),
             install_target = args[i].substring(9, args[i].length);
         } else {
             console.error('ERROR : Run option \'' + args[i] + '\' not recognized.');
-            process.exit(2);
+            exit(2);
         }
     }
 
@@ -135,5 +136,5 @@ module.exports.help = function() {
     console.log('    --device : Will deploy the built project to a device');
     console.log('    --emulator : Will deploy the built project to an emulator if one exists');
     console.log('    --target=<target_id> : Installs to the target with the specified id.');
-    process.exit(0);
+    exit(0);
 }

--- a/bin/templates/cordova/lib/start-emulator
+++ b/bin/templates/cordova/lib/start-emulator
@@ -20,6 +20,7 @@
 */
 
 var emulator = require('./emulator'),
+    exit     = require('exit'),
       args   = process.argv;
 
 var install_target;
@@ -28,12 +29,12 @@ if(args.length > 2) {
         install_target = args[2].substring(9, args[2].length);
      } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
-        process.exit(2);
+        exit(2);
      }
 }
 
 emulator.start(install_target).done(null, function(err) {
     console.error('ERROR: ' + err);
-    process.exit(2);
+    exit(2);
 });
 

--- a/bin/templates/cordova/log
+++ b/bin/templates/cordova/log
@@ -21,6 +21,7 @@
 
 var log  = require('./lib/log'),
     reqs = require('./lib/check_reqs'),
+    exit  = require('exit'),
     args = process.argv;
 
 // Usage support for when args are given
@@ -31,6 +32,6 @@ if(args.length > 2) {
         return log.run();
     }, function(err) {
         console.error('ERROR: ' + err);
-        process.exit(2);
+        exit(2);
     });
 }

--- a/bin/templates/cordova/run
+++ b/bin/templates/cordova/run
@@ -21,6 +21,7 @@
 
 var run  = require('./lib/run'),
     reqs = require('./lib/check_reqs'),
+    exit  = require('exit'),
     args = process.argv;
 
 // Support basic help commands
@@ -32,6 +33,6 @@ if (args[2] == '--help' || args[2] == '/?' || args[2] == '-h' ||
         return run.run(args);
     }, function(err) {
         console.error('ERROR: ' + err);
-        process.exit(2);
+        exit(2);
     });
 }

--- a/bin/update
+++ b/bin/update
@@ -19,13 +19,15 @@
        under the License.
 */
 var path   = require('path');
+var exit  = require('exit');
+var args  = process.argv;
 var create = require('./lib/create');
 var args  = require('./lib/simpleargs').getArgs(process.argv);
 
 if (args['--help'] || args._.length === 0) {
     console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'update')) + ' <path_to_project> [--shared]');
     console.log('    --shared will use the CordovaLib project directly instead of making a copy.');
-    process.exit(1);
+    exit(1);
 }
 create.updateProject(args._[0], args['--shared']).done();
 


### PR DESCRIPTION
On Windows, if you have pending bits in pipes and you exit, they
generally do not get delivered.

To avoid this, you need to change process.exit() to something
which actually ensures that buffers are flushed before it exits,
this is handled by the 'exit' module/function.
