### PR TITLE
[CB-5080] Fix for Cordova trying to get config.xml from the wrong namespace

### DIFF
--- a/framework/src/org/apache/cordova/Config.java
+++ b/framework/src/org/apache/cordova/Config.java
@@ -68,10 +68,15 @@ public class Config {
             return;
         }
 
+        // First checking the class namespace for config.xml
         int id = action.getResources().getIdentifier("config", "xml", action.getClass().getPackage().getName());
         if (id == 0) {
-            LOG.i("CordovaLog", "config.xml missing. Ignoring...");
-            return;
+            // If we couldn't find config.xml there, we'll look in the namespace from AndroidManifest.xml
+            id = action.getResources().getIdentifier("config", "xml", action.getPackageName());
+            if (id == 0) {
+                LOG.i("CordovaLog", "config.xml missing. Ignoring...");
+                return;
+            }
         }
 
         // Add implicitly allowed URLs

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -110,11 +110,16 @@ public class PluginManager {
      * Load plugins from res/xml/config.xml
      */
     public void loadPlugins() {
+        // First checking the class namespace for config.xml
         int id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getClass().getPackage().getName());
         if (id == 0) {
-            this.pluginConfigurationMissing();
-            //We have the error, we need to exit without crashing!
-            return;
+            // If we couldn't find config.xml there, we'll look in the namespace from AndroidManifest.xml
+            id = this.ctx.getActivity().getResources().getIdentifier("config", "xml", this.ctx.getActivity().getPackageName());
+            if (id == 0) {
+                this.pluginConfigurationMissing();
+                //We have the error, we need to exit without crashing!
+                return;
+            }
         }
         XmlResourceParser xml = this.ctx.getActivity().getResources().getXml(id);
         int eventType = -1;


### PR DESCRIPTION
Cordova is wrongfully omitting namespaces from projects with a different AndroidManifest.xml namespace than code namespace.

Example:
no.hnilsen.cordova <-- Java namespace
no.hnilsen.cordova.paid <-- AndroidManifest.xml namespace

This is integral in the way Android is built, especially using the new Android build system Android Gradle.

This commit will handle both use cases, and hopefully solve the issues for users that will use the java namespace or AndroidManifest.xml namespace.
