### PR TITLE
Remove 2 X console.log from exec.js

### DIFF
--- a/bin/templates/cordova/lib/exec.js
+++ b/bin/templates/cordova/lib/exec.js
@@ -27,10 +27,8 @@ var child_process = require('child_process'),
 // rejects with an error message and the stderr.
 module.exports = function(cmd, opt_cwd) {
     var d = Q.defer();
-    console.log('exec: ' + cmd);
     try {
         child_process.exec(cmd, {cwd: opt_cwd}, function(err, stdout, stderr) {
-            console.log([cmd, err, stdout, stderr]);
             if (err) d.reject('Error executing "' + cmd + '": ' + stderr);
             else d.resolve(stdout);
         });


### PR DESCRIPTION
With these console.log statements the output from commands such as 'list-devices' is very messy and hence difficult to parse the output programatically.
