### PR TITLE
THRIFT-2292 fix of android build when too big output stops build with er...

### DIFF
--- a/bin/templates/cordova/lib/exec.js
+++ b/bin/templates/cordova/lib/exec.js
@@ -28,7 +28,7 @@ var child_process = require('child_process'),
 module.exports = function(cmd, opt_cwd) {
     var d = Q.defer();
     try {
-        child_process.exec(cmd, {cwd: opt_cwd}, function(err, stdout, stderr) {
+        child_process.exec(cmd, {cwd: opt_cwd, maxBuffer: 1024000}, function(err, stdout, stderr) {
             if (err) d.reject('Error executing "' + cmd + '": ' + stderr);
             else d.resolve(stdout);
         });

--- a/test/cordova/lib/exec.js
+++ b/test/cordova/lib/exec.js
@@ -29,7 +29,7 @@ module.exports = function(cmd, opt_cwd) {
     var d = Q.defer();
     console.log('exec: ' + cmd);
     try {
-        child_process.exec(cmd, {cwd: opt_cwd}, function(err, stdout, stderr) {
+        child_process.exec(cmd, {cwd: opt_cwd, maxBuffer: 1024000}, function(err, stdout, stderr) {
             console.log([cmd, err, stdout, stderr]);
             if (err) d.reject('Error executing "' + cmd + '": ' + stderr);
             else d.resolve(stdout);


### PR DESCRIPTION
In some cases if build produce too many output from ant cordova build fails due to buffer overflow. This changes fix this problem by overriding buffer size to value much bigger than default.
