### PR TITLE
added android:installLocation="preferExternal"

### DIFF
--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -18,7 +18,7 @@
        under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:windowSoftInputMode="adjustPan"
-      package="__PACKAGE__" android:versionName="1.0" android:versionCode="1" android:hardwareAccelerated="true">
+      package="__PACKAGE__" android:versionName="1.0" android:versionCode="1" android:hardwareAccelerated="true" android:installLocation="preferExternal">
     <supports-screens
         android:largeScreens="true"
         android:normalScreens="true"


### PR DESCRIPTION
for phones with small amounts of internal storage (512MB and even 1GB, android 2.2 and 2.3 and even some 4.0) the user wont be able to install the app (or keep it) unless you let them put it on the sdcard instead of the internal phone storage. Very few cordova apps are the kind of app which shouldn't be on external storage.

more details:
http://developer.android.com/guide/topics/data/install-location.html#Should
