### PR TITLE
Allow subdomains flag in Whitelist xml for backcompat

### DIFF
--- a/framework/src/org/apache/cordova/Whitelist.java
+++ b/framework/src/org/apache/cordova/Whitelist.java
@@ -136,6 +136,14 @@ public class Whitelist {
                         } else {
                             whiteList.add(new URLPattern(scheme, host, port, path));
                         }
+
+                        if( subdomains ){
+                            // Support the `subdomains="true"` XML attribute in the whitelist
+                            if( scheme == null) scheme = "";
+                            String sub = scheme + "*." + host;
+                            addWhiteListEntry(sub, false);
+                        }
+
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
With the new Whitelist implementation, the `subdomains="true"` flag for the whitelist is being ignored even though the attribute is still parsed from XML and passed around our code. I think that we might as well allow this flag for backwards compatibility. 
https://issues.apache.org/jira/browse/CB-4096
