### PR TITLE
AlertDialog.Builder.create is redudant

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -139,7 +139,6 @@ public class CordovaChromeClient extends WebChromeClient {
                     return true;
             }
         });
-        dlg.create();
         dlg.show();
         return true;
     }
@@ -188,7 +187,6 @@ public class CordovaChromeClient extends WebChromeClient {
                     return true;
             }
         });
-        dlg.create();
         dlg.show();
         return true;
     }
@@ -280,7 +278,6 @@ public class CordovaChromeClient extends WebChromeClient {
                             res.cancel();
                         }
                     });
-            dlg.create();
             dlg.show();
         }
         return true;


### PR DESCRIPTION
because AlertDialog.Builder.show() will create an AlertDialog before  it show.This is the source code snippet:

```
    /**
     * Creates a {@link AlertDialog} with the arguments supplied to this builder and
     * {@link Dialog#show()}'s the dialog.
     */
    public AlertDialog show() {
        AlertDialog dialog = create();
        dialog.show();
        return dialog;
    }
```
