### PR TITLE
Displaying error when regex does not match.

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -84,7 +84,7 @@ module.exports.check_android = function() {
         if (stderr.match(/command\snot\sfound/)) {
             return Q.reject(new Error('The command \"android\" failed. Make sure you have the latest Android SDK installed, and the \"android\" command (inside the tools/ folder) is added to your path.'));
         } else {
-            return Q.reject(new Error('An error occurred while listing Android targets'));
+            return Q.reject(new Error('An error occurred while listing Android targets. Error: ' + stderr ));
         }
     });
 }


### PR DESCRIPTION
On my ubuntu when `android` was not found typical output is:

```
   /bin/sh: 1: android: not found
```
