### PR TITLE
[CB-7104] Fix for the missing plugin message

### DIFF
--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -299,12 +299,19 @@ public class NativeToJsMessageQueue {
     /** Uses online/offline events to tell the JS when to poll for messages. */
     private class OnlineEventsBridgeMode extends BridgeMode {
         boolean online = false;
+        boolean lastOnline = false;
+
         final Runnable runnable = new Runnable() {
             public void run() {
-                if (!queue.isEmpty()) {
-                    webView.setNetworkAvailable(online);
+                if(lastOnline) {
+                    webView.setNetworkAvailable(false);
+                    lastOnline = false;
                 }
-            }                
+                if (!queue.isEmpty()) {
+                    webView.setNetworkAvailable(true);
+                    lastOnline = true;
+                }
+            }
         };
         OnlineEventsBridgeMode() {
             webView.setNetworkAvailable(true);


### PR DESCRIPTION
Please have a look at this. This might not be the cleanest fix for [CB-7104], but it does the job. It will toggle only when messages are in the queue.
