### PR TITLE
Fix for shouldInterceptRequest method in IceCreamCordovaWebViewClient

### DIFF
--- a/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
@@ -65,8 +65,9 @@ public class IceCreamCordovaWebViewClient extends CordovaWebViewClient {
                 OpenForReadResult result = resourceApi.openForRead(remappedUri, true);
                 return new WebResourceResponse(result.mimeType, "UTF-8", result.inputStream);
             }
-            // If we don't need to special-case the request, let the browser load it.
-            return null;
+            // If we don't need to special-case the request, let the super class(s) handle it. 
+            // The default implementation would simply ask the browser to load the given url.
+            return super.shouldInterceptRequest(view, url);
         } catch (IOException e) {
             if (!(e instanceof FileNotFoundException)) {
                 LOG.e("IceCreamCordovaWebViewClient", "Error occurred while loading a file (returning a 404).", e);


### PR DESCRIPTION
From: http://callback.markmail.org/thread/45xdpomxjbmgwtpe

Probably a good idea. If you want to send a pull-request, or at least file an issue, we can take a look at this.

On Tue, Jul 15, 2014 at 3:08 AM, atta ur rehman atta...@gmail.com wrote:

Hi folks,

Thank you very much for Cordova!

Is this the right place to ask why the line number 69 in the class https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java returns null instead of return super.shouldInterceptRequest(view, url);

For the sake of argument, let's assume that I'm on Android 4.x and later, and I have changed the class hierarchy in Cordova source where CordovaWebViewClient extends from my XWebViewClient instead of stock android framework WebViewClient.

In this case, I think ICCWVC should bubble the calls of shouldInterceptRequest that it doesn't want to handle to give super classes a change to handle them.

Any comments, please.

Thanks.

ATTA 
