### PR TITLE
CB-7172 Force window to have focus after resume

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -605,6 +605,10 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         }
 
         this.appView.handleResume(this.keepRunning, this.activityResultKeepRunning);
+        
+        // Force window to have focus, so application always
+        // receive user input. Workaround for some devices (Samsung Galaxy Note 3 at least)
+        this.getWindow().getDecorView().requestFocus();
 
         // If app doesn't want to run in background
         if (!this.keepRunning || this.activityResultKeepRunning) {


### PR DESCRIPTION
Force window to have focus, so application always receive user input. Workaround for some devices (Samsung Galaxy Note 3 at least)
