### PR TITLE
CB-7265: Fix crash in shouldOverrideUrlLoading on Android < 4.0.3

### DIFF
--- a/framework/src/org/apache/cordova/CordovaUriHelper.java
+++ b/framework/src/org/apache/cordova/CordovaUriHelper.java
@@ -21,8 +21,10 @@ package org.apache.cordova;
 
 import org.json.JSONException;
 
+import android.annotation.TargetApi;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 import android.webkit.WebView;
 
@@ -69,6 +71,7 @@ public class CordovaUriHelper {
      * @param url           The url to be loaded.
      * @return              true to override, false for default behavior
      */
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // The WebView should support http and https when going on the Internet
         if(url.startsWith("http:") || url.startsWith("https:"))
@@ -100,7 +103,9 @@ public class CordovaUriHelper {
                 intent.setData(Uri.parse(url));
                 intent.addCategory(Intent.CATEGORY_BROWSABLE);
                 intent.setComponent(null);
-                intent.setSelector(null);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+                    intent.setSelector(null);
+                }
                 this.cordova.getActivity().startActivity(intent);
             } catch (android.content.ActivityNotFoundException e) {
                 LOG.e(TAG, "Error loading url " + url, e);


### PR DESCRIPTION
Application built with Cordova 3.5.1 running on a device with Android < 4.0.3 crashes when the webview is redirected to a custom url scheme. See https://issues.apache.org/jira/browse/CB-7265
More easily reproducible by adding the following line in JS: 
`window.location="custom://";`
