### PR TITLE
custom_rules.xml breaks library references

### DIFF
--- a/bin/templates/project/custom_rules.xml
+++ b/bin/templates/project/custom_rules.xml
@@ -4,8 +4,8 @@
         <!-- Fix library references due to bug in build.xml: See: https://groups.google.com/forum/#!topic/android-developers/0ivH-YqCjzg -->
         <pathconvert property="fixedJarsPath" refid="project.all.jars.path">
           <filtermapper>
-            <replacestring from="/bin/" to="/ant-build/"/>
-            <replacestring from="\bin\" to="\ant-build\"/>
+            <replacestring from="/CordovaLib/bin/" to="/CordovaLib/ant-build/"/>
+            <replacestring from="\CordovaLib\bin\" to="\CordovaLib\ant-build\"/>
           </filtermapper>
         </pathconvert>
         <path id="project.all.jars.path">


### PR DESCRIPTION
If the cordova project lives under another another directory called 'bin' then it will also be replaced with 'ant-build' which results in build failure. This fix ensures that only the instance of 'CordovaLib/bin' is changed to 'CordovaLib/ant-build'
