### PR TITLE
[CB-7371][Android] Fixed: app crash after phone language change

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -427,7 +427,7 @@ public class CordovaWebView extends WebView {
         if (LOG.isLoggable(LOG.DEBUG) && !url.startsWith("javascript:")) {
             LOG.d(TAG, ">>> loadUrlNow()");
         }
-        if (url.startsWith("file://") || url.startsWith("javascript:") || whitelist.isUrlWhiteListed(url)) {
+        if (url.startsWith("file://") || url.startsWith("javascript:") || (whitelist.isUrlWhiteListed(url) && !url.equals("about:blank"))) {
             super.loadUrl(url);
         }
     }


### PR DESCRIPTION
The main reason of this behavior is the config.xml, origin="*" tag, specifies access to all kind of resources on the network and makes the whiteList object on the WhiteList class a null object, indicating that when origin="", there's no whiteList, all is allowed.

When it tries to resume the application it checks:
if (url.startsWith("file://") || url.startsWith("javascript:") || whitelist.isUrlWhiteListed(url))
This condition passes and triggers the load for 'about:blank'
The condition passes because, whitelist.isUrlWhiteListed(url) statement returns true.
When the origin="*" is processed by the WhiteList class, it sets a null to the whiteList object, which it should contain the access to resources allowed, however when whitelist.isUrlWhiteListed(url) it returns a true if the whiteList object is null, therefore the condition passes and continues to the loadurl method on webClient, stopping the application, because of the 'about:blank' url.

Adding another condition along with that statement for when whiteList = null, but url= about:blank, in that way it won't be able to load the url.
