### PR TITLE
CB-7493 Adds test-build command to package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: android
+install: npm install
+script:
+    - npm test
+    - npm run test-build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "apache"
     ],
     "scripts": {
-        "test": "jasmine-node --color spec"
+        "test": "jasmine-node --color spec",
+        "test-build": "rm -rf \"test create\"; ./bin/create \"test create\" com.test.app Test && \"./test create/cordova/build\" && rm -rf \"test create\""
     },
     "author": "Apache Software Foundation",
     "license": "Apache version 2.0",


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CB-7493

\+ bonus - travis configuration file.
Succesful build log: https://travis-ci.org/vladimir-kotikov/cordova-android
