### PR TITLE
CB-7575 Fixes 'run' failure with --nobuild option specified.

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -265,7 +265,7 @@ var builders = {
         },
         build: function() {
             console.log('Skipping build...');
-            return Q();
+            return Q([]);
         },
         clean: function() {
             return Q();


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CB-7575

`cordova run android -- --nobuild` fails on cordova 3.6.3 due to `none` builder's `build` method that return undefined instead of array.
