### PR TITLE
[CB-6837][Android 4.0.x branch] Fix: leaked window when hitting back button while alert being rendered

### DIFF
--- a/framework/src/org/apache/cordova/AndroidChromeClient.java
+++ b/framework/src/org/apache/cordova/AndroidChromeClient.java
@@ -65,6 +65,9 @@ public class AndroidChromeClient extends WebChromeClient {
     // the video progress view
     private View mVideoProgressView;
     
+    //Keep track of last AlertDialog showed
+    private AlertDialog lastHandledDialog;
+
     // File Chooser
     protected ValueCallback<Uri> mUploadMessage;
     
@@ -113,7 +116,7 @@ public class AndroidChromeClient extends WebChromeClient {
                     return true;
             }
         });
-        dlg.show();
+        lastHandledDialog = dlg.show();
         return true;
     }
 
@@ -162,7 +165,7 @@ public class AndroidChromeClient extends WebChromeClient {
                     return true;
             }
         });
-        dlg.show();
+        lastHandledDialog = dlg.show();
         return true;
     }
 
@@ -206,7 +209,7 @@ public class AndroidChromeClient extends WebChromeClient {
                             res.cancel();
                         }
                     });
-            dlg.show();
+            lastHandledDialog = dlg.show();
         }
         return true;
     }
@@ -314,4 +317,11 @@ public class AndroidChromeClient extends WebChromeClient {
         this.cordova.getActivity().startActivityForResult(Intent.createChooser(i, "File Browser"),
                 FILECHOOSER_RESULTCODE);
     }
+
+    public void destroyLastDialog(){
+        if(lastHandledDialog != null){
+                lastHandledDialog.cancel();
+        }
+    }
+
 }

--- a/framework/src/org/apache/cordova/AndroidWebView.java
+++ b/framework/src/org/apache/cordova/AndroidWebView.java
@@ -603,6 +603,9 @@ public class AndroidWebView extends WebView implements CordovaWebView {
 
         // Load blank page so that JavaScript onunload is called
         this.loadUrl("about:blank");
+        
+        //Remove last AlertDialog
+        this.chromeClient.destroyLastDialog();
 
         // Forward to plugins
         if (this.pluginManager != null) {


### PR DESCRIPTION
CB-6837
It is basically:
https://github.com/apache/cordova-android/pull/122 
Only this is refactored for 4.0.x branch.

Description:
Keep track of the last AlertDialog showed.
The last dialog showed that is rendered while hitting back button it causes a leaked window.
Instead of perform a full track of all dialogs created, only destroy the last one showed, this fixes the problem.

Tested on 4.4.2.
