### PR TITLE
CB-6511 Fixes build for android when app name contains unicode characters

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -211,9 +211,11 @@ exports.createProject = function(project_path, package_name, project_name, proje
                            project_template_dir : 
                            path.join(ROOT, 'bin', 'templates', 'project');
 
-    var safe_activity_name = project_name.replace(/\W/g, '');
     var package_as_path = package_name.replace(/\./g, path.sep);
     var activity_dir    = path.join(project_path, 'src', package_as_path);
+    // safe_activity_name is being hardcoded to avoid issues with unicode app name (https://issues.apache.org/jira/browse/CB-6511)
+    // TODO: provide option to specify activity name via CLI (proposal: https://issues.apache.org/jira/browse/CB-7231)
+    var safe_activity_name = "CordovaApp";
     var activity_path   = path.join(activity_dir, safe_activity_name + '.java');
     var target_api      = check_reqs.get_target();
     var manifest_path   = path.join(project_path, 'AndroidManifest.xml');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ],
     "scripts": {
         "test": "jasmine-node --color spec",
-        "test-build": "rm -rf \"test create\"; ./bin/create \"test create\" com.test.app Test && \"./test create/cordova/build\" && rm -rf \"test create\""
+        "test-build": "rm -rf \"test create\"; ./bin/create \"test create\" com.test.app 応用 && \"./test create/cordova/build\" && rm -rf \"test create\""
     },
     "author": "Apache Software Foundation",
     "license": "Apache version 2.0",


### PR DESCRIPTION
Fix for issue: https://issues.apache.org/jira/browse/CB-6511
Use hardcoded Activity/class name to avoid problems with unicode names. Future improvement - use additional option for cli to specify custom activity/class name (https://issues.apache.org/jira/browse/CB-7231)

More info in threads: http://callback.markmail.org/thread/o7w52dbpiikcivwp and http://callback.markmail.org/thread/2iaojpftpggrmcj6
