### PR TITLE
Fix potential null pointer error issue.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaResourceApi.java
+++ b/framework/src/org/apache/cordova/CordovaResourceApi.java
@@ -270,6 +270,7 @@ public class CordovaResourceApi {
             case URI_TYPE_RESOURCE: {
                 String mimeType = contentResolver.getType(uri);
                 AssetFileDescriptor assetFd = contentResolver.openAssetFileDescriptor(uri, "r");
+                if (assetFd == null) break;
                 InputStream inputStream = assetFd.createInputStream();
                 long length = assetFd.getLength();
                 return new OpenForReadResult(uri, inputStream, mimeType, length, assetFd);


### PR DESCRIPTION
I am writing a Google Play APK expansion library.

All the libraries I have seen so far store version data inside the content provider's tag as meta-data, and again inside a separate .xml file. This is wrong, but they are forced to do this because it is very difficult to figure out the code to source all data from one xml file. I have done this, but it does require telling Cordova not to extract the zip file before the plugin file is ready.

To do that, I return a null value from APEZProvider (extends ContentProvider for APKs) if the APK expansion plugin class instance didn't run yet. That of course causes Cordova to crash because it doesn't have the null test I am proposing.
