### PR TITLE
Ignore --device option in Android build

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -340,6 +340,10 @@ function parseOpts(options, resolvedTarget) {
                 case 'nobuild' :
                     ret.buildMethod = 'none';
                     break;
+                case 'device':
+                    // Unused here, but this is valid on iOS. Catch it to prevent an error
+                    // when running `cordova build --device` with multiple platforms
+                    break;
                 default :
                     return Q.reject('Build option \'' + options[i] + '\' not recognized.');
             }


### PR DESCRIPTION
iOS uses the `--device` flag to indicate that it should build for the device rather than the simulator. Until recently, Android simply ignored this option. Now it throws an error.

This causes problems for people targeting multiple platforms with the CLI tools, because a command like `cordova build --release --device` will now fail on Android, rather than building both Android and iOS versions of the app.

**Simple test case:**

``` bash
$ cordova init myapp
$ cd ./myapp
$ cordova platform add ios android
$ cordova build --release --device --verbose
```
