### PR TITLE
Fixed javascript not loading when activity restarted after exiting with Back button

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -573,6 +573,12 @@ public class CordovaActivity extends Activity implements CordovaInterface {
 
         LOG.d(TAG, "Paused the application!");
 
+        // If they pressed Back button to exit, make sure we actually exit! 
+        // Otherwise things won't properly resume and JS won't run (JS resume event never fires, timers never resume, etc).
+        if (isFinishing()) {
+            this.activityState = ACTIVITY_EXITING;
+        }
+
         // Don't process pause if shutting down, since onDestroy() will be called
         if (this.activityState == ACTIVITY_EXITING) {
             return;


### PR DESCRIPTION
I was having some issues with my app (local javascript SPA):
1. Start app. Everything works normally.
2. Press Back button to exit. Activity exits and is destroyed.
3. Start app again. Now the HTML shows up, but the Javascript never runs, so nothing works.
4. Press Home button, activity goes to background (with non-working Javascript).
5. Start app again. Now Javascript loads and resumes properly. Everything starts working.

This is on KitKat 4.4.4 on a Nexus 5. "KeepRunning" = "false" in the config file.

Pretty simple fix, once I could figure it out. Please let me know if this has other consequences; sorry I can't provide a test case; my app is quite huge.
