### PR TITLE
CB-7881 Android tooling shouldn't lock application directory

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -24,6 +24,7 @@ var shell   = require('shelljs'),
     Q       = require('q'),
     path    = require('path'),
     fs      = require('fs'),
+    os      = require('os'),
     ROOT    = path.join(__dirname, '..', '..');
 var check_reqs = require('./check_reqs');
 var exec  = require('./exec');
@@ -398,7 +399,7 @@ module.exports.run = function(options, optResolvedTarget) {
  * Returns "arm" or "x86".
  */
 module.exports.detectArchitecture = function(target) {
-    return exec('adb -s ' + target + ' shell cat /proc/cpuinfo')
+    return exec('adb -s ' + target + ' shell cat /proc/cpuinfo', os.tmpdir())
     .then(function(output) {
         if (/intel/i.exec(output)) {
             return 'x86';

--- a/bin/templates/cordova/lib/device.js
+++ b/bin/templates/cordova/lib/device.js
@@ -22,6 +22,7 @@
 var exec  = require('./exec'),
     Q     = require('q'),
     path  = require('path'),
+    os    = require('os'),
     build = require('./build'),
     appinfo = require('./appinfo'),
     ROOT = path.join(__dirname, '..', '..');
@@ -30,7 +31,7 @@ var exec  = require('./exec'),
  * Returns a promise for the list of the device ID's found
  */
 module.exports.list = function() {
-    return exec('adb devices')
+    return exec('adb devices', os.tmpdir())
     .then(function(output) {
         var response = output.split('\n');
         var device_list = [];
@@ -80,19 +81,19 @@ module.exports.install = function(target, buildResults) {
         console.log('Using apk: ' + apk_path);
         console.log('Installing app on device...');
         var cmd = 'adb -s ' + resolvedTarget.target + ' install -r "' + apk_path + '"';
-        return exec(cmd)
+        return exec(cmd, os.tmpdir())
         .then(function(output) {
             if (output.match(/Failure/)) return Q.reject('ERROR: Failed to install apk to device: ' + output);
 
             //unlock screen
             var cmd = 'adb -s ' + resolvedTarget.target + ' shell input keyevent 82';
-            return exec(cmd);
+            return exec(cmd, os.tmpdir());
         }, function(err) { return Q.reject('ERROR: Failed to install apk to device: ' + err); })
         .then(function() {
             // launch the application
             console.log('Launching application...');
             var cmd = 'adb -s ' + resolvedTarget.target + ' shell am start -W -a android.intent.action.MAIN -n ' + launchName;
-            return exec(cmd);
+            return exec(cmd, os.tmpdir());
         }).then(function() {
             console.log('LAUNCH SUCCESS');
         }, function(err) {

--- a/bin/templates/cordova/lib/log.js
+++ b/bin/templates/cordova/lib/log.js
@@ -21,6 +21,7 @@
 
 var shell = require('shelljs'),
     path  = require('path'),
+    os  = require('os'),
     Q     = require('q'),
     child_process = require('child_process'),
     ROOT  = path.join(__dirname, '..', '..');
@@ -32,7 +33,7 @@ var shell = require('shelljs'),
 module.exports.run = function() {
     var cmd = 'adb logcat | grep -v nativeGetEnabledTags';
     var d = Q.defer();
-    var adb = child_process.spawn('adb', ['logcat']);
+    var adb = child_process.spawn('adb', ['logcat'], {cwd: os.tmpdir()});
 
     adb.stdout.on('data', function(data) {
         var lines = data ? data.toString().split('\n') : [];


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7881

Use temp directory when running adb command to make sure adb server is not started in working directory and does not lock it
