### PR TITLE
Add a section for plugin extensions

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -40,6 +40,9 @@ task wrapper(type: Wrapper) {
     gradleVersion = '1.12'
 }
 
+// PLUGIN GRADLE EXTENSIONS START
+// PLUGIN GRADLE EXTENSIONS END
+
 ext.multiarch=false
 
 android {


### PR DESCRIPTION
The https://github.com/apache/cordova-lib/pull/119 add gradle reference from plugin to project. The cordova-lib will add the reference between the lines. It looks like:
// PLUGIN GRADLE EXTENSIONS START
apply from: 'libs/xwalk_core_library/xwalk.gradle'
// PLUGIN GRADLE EXTENSIONS END

The xwalk.gradle can set ext.multiarch=true to support multiple APKs by default, so add this section in here.
