### PR TITLE
Revert Gradle distributionUrlRegex cleanup.

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -239,7 +239,8 @@ var builders = {
 
                 // If the gradle distribution URL is set, make sure it points to version 1.12.
                 // If it's not set, do nothing, assuming that we're using a future version of gradle that we don't want to mess with.
-                var distributionUrlRegex = '/^distributionUrl=.*$/';
+                // For some reason, using ^ and $ don't work.  This does the job, though.
+                var distributionUrlRegex = /distributionUrl.*zip/;
                 var distributionUrl = 'distributionUrl=http\\://services.gradle.org/distributions/gradle-1.12-all.zip';
                 var gradleWrapperPropertiesPath = path.join(projectPath, 'gradle', 'wrapper', 'gradle-wrapper.properties');
                 shell.sed('-i', distributionUrlRegex, distributionUrl, gradleWrapperPropertiesPath);


### PR DESCRIPTION
This reverts commit 75a0a6752a77e2e0f491ae4de7137f5163c7a4bd.

On my machine (Windows 8.1, Node.js 0.10.33), commit 75a0a675 breaks this regex.
