### PR TITLE
Fix compile error when build multiple apks

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -50,10 +50,10 @@ task wrapper(type: Wrapper) {
     gradleVersion = '1.12'
 }
 
+ext.multiarch=false
+
 // PLUGIN GRADLE EXTENSIONS START
 // PLUGIN GRADLE EXTENSIONS END
-
-ext.multiarch=false
 
 android {
     sourceSets {
@@ -220,6 +220,9 @@ def addSigningProps(propsFilePath, signingConfig) {
     if (storeType) {
         signingConfig.storeType = storeType
     }
+}
+
+task lintVitalRelease {
 }
 
 if (file('build-extras.gradle').exists()) {


### PR DESCRIPTION
Task 'lintVitalRelease' not found in root project when build multiple apks, add a empty task for comipling.
