### PR TITLE
Build multiple apks by default

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -54,10 +54,10 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.2.1'
 }
 
+ext.multiarch=false
+
 // PLUGIN GRADLE EXTENSIONS START
 // PLUGIN GRADLE EXTENSIONS END
-
-ext.multiarch=false
 
 android {
     sourceSets {


### PR DESCRIPTION
The xwalk webView need build multiple apks by default after install cordova-crosswalk-engine plugin, we can set ext.multiarch=true to open the flag in plugin, it don't necessary set system environment BUILD_MULTIPLE_APKS manually.
