### PR TITLE
CB-5059 Add a CookieManager abstraction for pluggable webviews.

### DIFF
--- a/framework/src/org/apache/cordova/AndroidCookieManager.java
+++ b/framework/src/org/apache/cordova/AndroidCookieManager.java
@@ -1,0 +1,60 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova;
+
+import android.os.Build;
+import android.webkit.CookieManager;
+import android.webkit.WebView;
+
+class AndroidCookieManager implements ICordovaCookieManager {
+
+    protected WebView webView;
+
+    public AndroidCookieManager(WebView webview) {
+        webView = webview;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+        {
+            CookieManager cookieManager = CookieManager.getInstance();
+            cookieManager.setAcceptThirdPartyCookies(webView, true);
+        }
+    }
+
+    public void setCookiesEnabled(boolean accept) {
+        CookieManager.getInstance().setAcceptCookie(accept);
+    }
+
+    public void setCookie(final String url, final String value) {
+        CookieManager.getInstance().setCookie(url, value);
+    }
+
+    public String getCookie(final String url) {
+        return CookieManager.getInstance().getCookie(url);
+    }
+
+    public void clearCookies() {
+        CookieManager.getInstance().removeAllCookie();
+    }
+
+    public void flush() {
+        CookieManager.getInstance().flush();
+    }
+};
+

--- a/framework/src/org/apache/cordova/AndroidWebView.java
+++ b/framework/src/org/apache/cordova/AndroidWebView.java
@@ -66,6 +66,7 @@ public class AndroidWebView extends WebView implements CordovaWebView {
     private HashSet<Integer> boundKeyCodes = new HashSet<Integer>();
 
     PluginManager pluginManager;
+    AndroidCookieManager cookieManager;
 
     private BroadcastReceiver receiver;
 
@@ -124,6 +125,7 @@ public class AndroidWebView extends WebView implements CordovaWebView {
         this.preferences = preferences;
 
         pluginManager = new PluginManager(this, this.cordova, pluginEntries);
+        cookieManager = new AndroidCookieManager(this);
         resourceApi = new CordovaResourceApi(this.getContext(), pluginManager);
         bridge = new CordovaBridge(pluginManager, new NativeToJsMessageQueue(this, cordova), this.cordova.getActivity().getPackageName());
         initWebViewSettings();
@@ -136,11 +138,6 @@ public class AndroidWebView extends WebView implements CordovaWebView {
                 new IceCreamCordovaWebViewClient(cordova, this));
         }
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-        {
-            CookieManager cookieManager = CookieManager.getInstance();
-            cookieManager.setAcceptThirdPartyCookies(this, true);
-        }
 
         if (this.chromeClient == null) {
             setWebChromeClient(new AndroidChromeClient(cordova, this));
@@ -798,6 +795,11 @@ public class AndroidWebView extends WebView implements CordovaWebView {
     @Override
     public CordovaPreferences getPreferences() {
         return preferences;
+    }
+
+    @Override
+    public ICordovaCookieManager getCookieManager() {
+        return cookieManager;
     }
 
     @Override

--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -84,6 +84,7 @@ public interface CordovaWebView {
     Whitelist getWhitelist();
     Whitelist getExternalWhitelist();
     CordovaPreferences getPreferences();
+    ICordovaCookieManager getCookieManager();
 
     void setNetworkAvailable(boolean online);
     

--- a/framework/src/org/apache/cordova/ICordovaCookieManager.java
+++ b/framework/src/org/apache/cordova/ICordovaCookieManager.java
@@ -1,0 +1,33 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova;
+
+public interface ICordovaCookieManager {
+
+    public void setCookiesEnabled(boolean accept);
+
+    public void setCookie(final String url, final String value);
+
+    public String getCookie(final String url);
+
+    public void clearCookies();
+
+    public void flush();
+};


### PR DESCRIPTION
Crosswalk and GeckoView implementations of CordovaWebView can provide their own ICordovaCookieManager implementation for plugins to use.

/cc @infil00p & @agrieve 
If you think this is the correct way to go about this, I'll make an implementation for the Crosswalk engine and update the FileTransfer plugin.