### PR TITLE
current code requires android api level 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ you are developing directly against the framework.
 
 To create your `cordova.jar` file, run in the framework directory:
 
-    android update project -p . -t android-19
+    android update project -p . -t android-21
     ant jar
 
 


### PR DESCRIPTION
using 19 raised:

    ...
    [javac]     public boolean onShowFileChooser(WebView webView, final ValueCallback<Uri[]> filePathsCallback, final WebChromeClient.FileChooserParams fileChooserParams) {
    [javac]                                                                                                                          ^
    [javac]   symbol:   class FileChooserParams
    [javac]   location: class WebChromeClient
    [javac] /../spikes/cordova-android/framework/src/org/apache/cordova/AndroidWebViewClient.java:33: error: cannot find symbol
    [javac] import android.webkit.ClientCertRequest;
    ...