### PR TITLE
Part of fix for CT-7992

### DIFF
--- a/framework/assets/www/cordova.js
+++ b/framework/assets/www/cordova.js
@@ -19,6 +19,9 @@
  under the License.
 */
 ;(function() {
+if (window.cordova) {
+    return; // protect against accidental multiple inclusion
+}
 var PLATFORM_VERSION_BUILD_LABEL = '4.0.0-dev';
 // file: src/scripts/require.js
 


### PR DESCRIPTION
New Cordova users, especially those building applications from building
blocks, sometimes end up with more than one <script> tag for cordova.js.
This currently results in bizarre behavior.  This change makes such
mistakes harmless, thus resulting in a more user-friendly experience.