### PR TITLE
CB-8753 Maintain splash screen aspect ratio

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -34,6 +34,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.os.Bundle;
@@ -131,6 +132,11 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     protected Whitelist externalWhitelist;
     protected String launchUrl;
     protected ArrayList<PluginEntry> pluginEntries;
+    
+    /**
+     * Last orientation of device. Used to detect orientation changes.
+     */
+    private int orientation;
 
     /**
     * Sets the authentication token.
@@ -219,6 +225,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         }
 
         super.onCreate(savedInstanceState);
+        
+        // Save startup orientation. Used to determine when orientation changes in "onConfigurationChanged".
+        orientation = getResources().getConfiguration().orientation;
 
         if(savedInstanceState != null)
         {
@@ -948,4 +957,13 @@ public class CordovaActivity extends Activity implements CordovaInterface {
             outState.putString("callbackClass", cClass);
         }
     }
+    
+    @Override
+	public void onConfigurationChanged(Configuration newConfig) {
+	    super.onConfigurationChanged(newConfig);
+	    if (newConfig.orientation != orientation) {
+	    	orientation = newConfig.orientation;
+	    	postMessage("orientationChanged", orientation);
+	    }
+	}
 }


### PR DESCRIPTION
This pull request implements https://issues.apache.org/jira/browse/CB-8753. Apologies for multiple commits. I was trying to edit the commit message to include CB-8753 in the summary and ended up with three commits instead of one. I'm new to Git and Github.

There are some things about existing code that I did not completely understand. I want to list them here to help in the review process. If you know what I didn't understand it may help you find problems with my code changes.

- Is there a reason why most fields in SplashScreenInternal are static? It seems like they could just be private instance fields.

- What is the purpose of adding preferences to activity's intent extras in CordovaPreferences.copyIntoIntentExtras(Activity)? Not all preferences are copied and I did not add my new preferences either. Should I?

- Why does SplashScreenInternal keep getting preferences from CordovaPreferences object instead of just storing them in instance fields during initialization? For example, drawableId is retrieved like this throughout the class:

    int drawableId = preferences.getInteger("SplashDrawableId", 0);

Why not just have a drawableId instance variable and store the value in it once during initialization?

- Is it OK that the new preferences are only supported on Android?