### PR TITLE
solves CB-8768 issue where onActivityResult gets called before onResume after MainActivity gets killed

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -138,6 +138,7 @@ public class CordovaActivity extends Activity {
         if (!appView.isInitialized()) {
             appView.init(cordovaInterface, pluginEntries, preferences);
         }
+        cordovaInterface.onCordovaInit(appView.getPluginManager());
 
         // Wire the hardware volume controls to control media if desired.
         String volumePref = preferences.getString("DefaultVolumeStream", "");

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -138,7 +138,6 @@ public class CordovaActivity extends Activity {
         if (!appView.isInitialized()) {
             appView.init(cordovaInterface, pluginEntries, preferences);
         }
-        cordovaInterface.setPluginManager(appView.getPluginManager());
 
         // Wire the hardware volume controls to control media if desired.
         String volumePref = preferences.getString("DefaultVolumeStream", "");

--- a/framework/src/org/apache/cordova/CordovaInterface.java
+++ b/framework/src/org/apache/cordova/CordovaInterface.java
@@ -69,4 +69,11 @@ public interface CordovaInterface {
      * Returns a shared thread pool that can be used for background tasks.
      */
     public ExecutorService getThreadPool();
+
+    /**
+     * called when plugins are fully loaded (both native and javascript parts)
+     * 
+     * @param pluginManager
+     */
+    void onCordovaInit(PluginManager pluginManager);
 }

--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -13,6 +13,9 @@ import java.util.concurrent.Executors;
  */
 public class CordovaInterfaceImpl implements CordovaInterface {
     private static final String TAG = "CordovaInterfaceImpl";
+    
+    private ActivityResultHolder savedResult;
+
     protected Activity activity;
     protected ExecutorService threadPool;
     protected PluginManager pluginManager;
@@ -30,8 +33,12 @@ public class CordovaInterfaceImpl implements CordovaInterface {
         this.threadPool = threadPool;
     }
 
-    public void setPluginManager(PluginManager pluginManager) {
+    @Override
+    public void onCordovaInit(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
+        if (savedResult != null) {
+            onActivityResult(savedResult.getRequestCode(), savedResult.getResultCode(), savedResult.getIntent());
+        }
     }
 
     @Override
@@ -80,17 +87,21 @@ public class CordovaInterfaceImpl implements CordovaInterface {
         if(callback == null && initCallbackService != null) {
             // The application was restarted, but had defined an initial callback
             // before being shut down.
-            callback = pluginManager.getPlugin(initCallbackService);
+            savedResult = new ActivityResultHolder(requestCode, resultCode, intent);
+            if (pluginManager != null) {
+                callback = pluginManager.getPlugin(initCallbackService);
+            }
         }
-        initCallbackService = null;
         activityResultCallback = null;
 
         if (callback != null) {
             Log.d(TAG, "Sending activity result to plugin");
+            initCallbackService = null;
+            savedResult = null;
             callback.onActivityResult(requestCode, resultCode, intent);
             return true;
         }
-        Log.w(TAG, "Got an activity result, but no plugin was registered to receive it.");
+        Log.w(TAG, "Got an activity result, but no plugin was registered to receive it" + (savedResult != null ? " yet!": "."));
         return false;
     }
 
@@ -118,5 +129,30 @@ public class CordovaInterfaceImpl implements CordovaInterface {
      */
     public void restoreInstanceState(Bundle savedInstanceState) {
         initCallbackService = savedInstanceState.getString("callbackService");
+    }
+    
+    private class ActivityResultHolder {
+
+        private int requestCode;
+        private int resultCode;
+        private Intent intent;
+
+        public ActivityResultHolder(int requestCode, int resultCode, Intent intent) {
+            this.requestCode = requestCode;
+            this.resultCode = resultCode;
+            this.intent = intent;
+        }
+
+        public int getRequestCode() {
+            return requestCode;
+        }
+
+        public int getResultCode() {
+            return resultCode;
+        }
+
+        public Intent getIntent() {
+            return intent;
+        }
     }
 }

--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -37,7 +37,7 @@ public class CordovaInterfaceImpl implements CordovaInterface {
     public void onCordovaInit(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
         if (savedResult != null) {
-            onActivityResult(savedResult.getRequestCode(), savedResult.getResultCode(), savedResult.getIntent());
+            onActivityResult(savedResult.requestCode, savedResult.resultCode, savedResult.intent);
         }
     }
 
@@ -131,7 +131,7 @@ public class CordovaInterfaceImpl implements CordovaInterface {
         initCallbackService = savedInstanceState.getString("callbackService");
     }
     
-    private class ActivityResultHolder {
+    private static class ActivityResultHolder {
 
         private int requestCode;
         private int resultCode;
@@ -141,18 +141,6 @@ public class CordovaInterfaceImpl implements CordovaInterface {
             this.requestCode = requestCode;
             this.resultCode = resultCode;
             this.intent = intent;
-        }
-
-        public int getRequestCode() {
-            return requestCode;
-        }
-
-        public int getResultCode() {
-            return resultCode;
-        }
-
-        public Intent getIntent() {
-            return intent;
         }
     }
 }

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -500,7 +500,6 @@ public class CordovaWebViewImpl implements CordovaWebView {
 
             clearLoadTimeoutTimer();
 
-            cordova.onCordovaInit(pluginManager);
             // Broadcast message that page has loaded
             pluginManager.postMessage("onPageFinished", url);
 

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -500,6 +500,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
 
             clearLoadTimeoutTimer();
 
+            cordova.onCordovaInit(pluginManager);
             // Broadcast message that page has loaded
             pluginManager.postMessage("onPageFinished", url);
 


### PR DESCRIPTION
situation: one of the plugins launches startActivityForResult and the Android OS decides to kill our MainActivity.
once the launched activity is fulfilled it comes back to our MainActivity, which has to be recreated first.
unfortunately Android calls onActivityResult before our Activity has fully loaded our installed plugins.

this commit fixes that issue. thanks to suggestions by Andrew Grieve