### PR TITLE
fix package name validation

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -150,7 +150,7 @@ function validatePackageName(package_name) {
     //Make the package conform to Java package types
     //http://developer.android.com/guide/topics/manifest/manifest-element.html#package
     //Enforce underscore limitation
-    if (!/^[a-zA-Z][a-zA-Z0-9_]+(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(package_name)) {
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_]+(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(package_name)) {
         return Q.reject('Package name must look like: com.company.Name');
     }
 


### PR DESCRIPTION
you can see accepted applications in google play that contain number in the first part of package name, those apps cant be build with  because of this validation bug\inconsistent with google play. for example this package: http://bit.ly/1aVO6Re