### PR TITLE
CB-8902: use immersive mode when available and "fullscreen" is set to 'true'

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -31,6 +31,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -115,8 +116,24 @@ public class CordovaActivity extends Activity {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
         } else if (preferences.getBoolean("Fullscreen", false)) {
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+            {
+                setSystemUiVisibilityMode(getWindow());
+                getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+                    @Override
+                    public void onSystemUiVisibilityChange(int visibility) {
+                        if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+                            setSystemUiVisibilityMode(getWindow());
+                        }
+                    }
+                });
+            }
+            else
+            {
+                getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            }
         } else {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
@@ -129,6 +146,18 @@ public class CordovaActivity extends Activity {
         {
             cordovaInterface.restoreInstanceState(savedInstanceState);
         }
+    }
+
+    private void setSystemUiVisibilityMode(Window window) {
+        final int uiOptions =
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_FULLSCREEN
+                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+
+        window.getDecorView().setSystemUiVisibility(uiOptions);
     }
     
     protected void init() {

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -89,6 +89,9 @@ public class CordovaActivity extends Activity {
     // when another application (activity) is started.
     protected boolean keepRunning = true;
 
+    // Flag to keep immersive mode if set to fullscreen
+    protected boolean immersiveMode = false;
+
     // Read from config.xml:
     protected CordovaPreferences preferences;
     protected String launchUrl;
@@ -113,21 +116,13 @@ public class CordovaActivity extends Activity {
         if(preferences.getBoolean("SetFullscreen", false))
         {
             Log.d(TAG, "The SetFullscreen configuration is deprecated in favor of Fullscreen, and will be removed in a future version.");
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        } else if (preferences.getBoolean("Fullscreen", false)) {
-
+            preferences.set("Fullscreen", true);
+        }
+        if(preferences.getBoolean("Fullscreen", false))
+        {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
             {
-                setSystemUiVisibilityMode(getWindow());
-                getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
-                    @Override
-                    public void onSystemUiVisibilityChange(int visibility) {
-                        if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
-                            setSystemUiVisibilityMode(getWindow());
-                        }
-                    }
-                });
+                immersiveMode = true;
             }
             else
             {
@@ -146,18 +141,6 @@ public class CordovaActivity extends Activity {
         {
             cordovaInterface.restoreInstanceState(savedInstanceState);
         }
-    }
-
-    private void setSystemUiVisibilityMode(Window window) {
-        final int uiOptions =
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
-
-        window.getDecorView().setSystemUiVisibility(uiOptions);
     }
     
     protected void init() {
@@ -324,6 +307,24 @@ public class CordovaActivity extends Activity {
 
         if (this.appView != null) {
             appView.handleDestroy();
+        }
+    }
+
+    /**
+     * Called when view focus is changed
+     */
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus && immersiveMode) {
+            final int uiOptions = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+
+            getWindow().getDecorView().setSystemUiVisibility(uiOptions);
         }
     }
 


### PR DESCRIPTION
"Fullscreen" preference set to 'true' in the config.xml should hide the navigation bar on android devices that support immersive mode.
