### PR TITLE
Grant Lollipop permission requests

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -18,6 +18,7 @@
 */
 package org.apache.cordova.engine;
 
+import java.util.Arrays;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -36,6 +37,7 @@ import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
+import android.webkit.PermissionRequest;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
@@ -264,6 +266,13 @@ public class SystemWebChromeClient extends WebChromeClient {
             filePathsCallback.onReceiveValue(null);
         }
         return true;
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void onPermissionRequest(final PermissionRequest request) {
+        Log.d(LOG_TAG, "onPermissionRequest: " + Arrays.toString(request.getResources()));
+        request.grant(request.getResources());
     }
 
     public void destroyLastDialog(){


### PR DESCRIPTION
This patch overrides onPermissionRequest so that getUserMedia can be used inside the browser.

Since a hybrid app has to request permissions anyways via AndroidManifest.xml, I think it is unnecessary to have any further configuration for onPermissionRequest. Anything that the app is allowed to do should be possible from the JS side. Hence all requests are granted. This enables getUserMedia (and WebRTC) on Android Lollipop, without resorting to crosswalk.

The docs say that request.grant has to be called from the UI thread, but don't explicitly spell out whether onPermissionRequest is called from the UI thread. I think that this is so, the WebChromeClient of course makes its calls from the UI thread unless otherwise noted. So there is no need to post a runnable to the UI thread. 
