### PR TITLE
CB-9172 Improved emulator deploy stability

### DIFF
--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -139,7 +139,9 @@ var path  = require('path'),
     }).then(function(resolvedTarget) {
         return build.run(buildFlags, resolvedTarget).then(function(buildResults) {
             if (resolvedTarget.isEmulator) {
-                return emulator.install(resolvedTarget, buildResults);
+                return emulator.wait_for_boot(resolvedTarget.target).then(function () {
+                    return emulator.install(resolvedTarget, buildResults);
+                });
             }
             return device.install(resolvedTarget, buildResults);
         });


### PR DESCRIPTION
This is a fix for https://issues.apache.org/jira/browse/CB-9172
- Use UUID to distinguish between launched emulators
- Wait for android.process.acore instead of init.svc.bootanim on emulator boot
- Increased retry timeout when installing app to the emulator
- If there is already a started/starting emulator, wait for it's boot instead of trying to deploy to it right away