### PR TITLE
CB-9286 Fixes build failure when ANDROID_HOME is not set.

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -260,7 +260,7 @@ module.exports.check_android_target = function(valid_target) {
 
 // Returns a promise.
 module.exports.run = function() {
-    return Q.all([this.check_java(), this.check_android(), this.check_android_target()])
+    return Q.all([this.check_java(), this.check_android().then(this.check_android_target)])
     .then(function() {
         console.log('ANDROID_HOME=' + process.env['ANDROID_HOME']);
         console.log('JAVA_HOME=' + process.env['JAVA_HOME']);


### PR DESCRIPTION
This fixes [CB-9286](https://issues.apache.org/jira/browse/CB-9286) which is a regression from 4bf705a.