### PR TITLE
CB-9334 loop on CordovaPlugins before returning remapped Uri

### DIFF
--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -374,17 +374,16 @@ public class PluginManager {
     }
 
     Uri remapUri(Uri uri) {
-        Uri remap = null;
+        Uri remap = uri;
         for (CordovaPlugin plugin : this.pluginMap.values()) {
             if (plugin != null) {
-                Uri ret = plugin.remapUri(uri);
+                Uri ret = plugin.remapUri(remap);
                 if (ret != null) {
                     remap = ret;
-                    uri = ret;
                 }
             }
         }
-        return remap;
+        return uri.equals(remap) ? null : remap;
     }
 
     /**

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -18,21 +18,14 @@
  */
 package org.apache.cordova;
 
-import java.util.HashMap;
-import java.util.List;
-
-import org.apache.cordova.CordovaWebView;
-import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaInterface;
-import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.PluginEntry;
-import org.apache.cordova.PluginResult;
-import org.json.JSONException;
-
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Debug;
 import android.util.Log;
+import org.json.JSONException;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * PluginManager is exposed to JavaScript in the Cordova WebView.
@@ -381,15 +374,17 @@ public class PluginManager {
     }
 
     Uri remapUri(Uri uri) {
+        Uri remap = null;
         for (CordovaPlugin plugin : this.pluginMap.values()) {
             if (plugin != null) {
                 Uri ret = plugin.remapUri(uri);
                 if (ret != null) {
-                    return ret;
+                    remap = ret;
+                    uri = ret;
                 }
             }
         }
-        return null;
+        return remap;
     }
 
     /**

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -396,7 +396,7 @@ public class PluginManager {
             if ((className != null) && !("".equals(className))) {
                 c = Class.forName(className);
             }
-            if (c != null & CordovaPlugin.class.isAssignableFrom(c)) {
+            if (c != null && CordovaPlugin.class.isAssignableFrom(c)) {
                 ret = (CordovaPlugin) c.newInstance();
             }
         } catch (Exception e) {


### PR DESCRIPTION
This is a fix for  https://issues.apache.org/jira/browse/CB-9334

Because sometimes you need more than one plugin to handle your Uri's.
Looping on all plugins before returning the remapped Uri.