### PR TITLE
CB-9343 Split the Content-Type to obtain a clean mimetype

### DIFF
--- a/framework/src/org/apache/cordova/CordovaResourceApi.java
+++ b/framework/src/org/apache/cordova/CordovaResourceApi.java
@@ -191,7 +191,11 @@ public class CordovaResourceApi {
                     HttpURLConnection conn = httpClient.open(new URL(uri.toString()));
                     conn.setDoInput(false);
                     conn.setRequestMethod("HEAD");
-                    return conn.getHeaderField("Content-Type");
+                    String mimeType = conn.getHeaderField("Content-Type");
+                    if (mimeType != null) {
+                        mimeType = mimeType.split(";")[0];
+                    }
+                    return mimeType;
                 } catch (IOException e) {
                 }
             }
@@ -286,6 +290,9 @@ public class CordovaResourceApi {
                 HttpURLConnection conn = httpClient.open(new URL(uri.toString()));
                 conn.setDoInput(true);
                 String mimeType = conn.getHeaderField("Content-Type");
+                if (mimeType != null) {
+                    mimeType = mimeType.split(";")[0];
+                }
                 int length = conn.getContentLength();
                 InputStream inputStream = conn.getInputStream();
                 return new OpenForReadResult(uri, inputStream, mimeType, length, null);


### PR DESCRIPTION
This is a fix for https://issues.apache.org/jira/browse/CB-9343

If Content-Type contains a charset, only take the mimetype part