### PR TITLE
cdvBuildMultipleApks casting fixed

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -118,7 +118,7 @@ if (ext.cdvReleaseSigningPropertiesFile == null && file('release-signing.propert
 }
 
 // Cast to appropriate types.
-ext.cdvBuildMultipleApks = !!cdvBuildMultipleApks;
+ext.cdvBuildMultipleApks = cdvBuildMultipleApks == null ? false : cdvBuildMultipleApks.toBoolean();
 ext.cdvMinSdkVersion = cdvMinSdkVersion == null ? null : Integer.parseInt('' + cdvMinSdkVersion)
 ext.cdvVersionCode = cdvVersionCode == null ? null : Integer.parseInt('' + cdvVersionCode)
 


### PR DESCRIPTION
Casting `cdvBuildMultipleApks` via `!!` does not work when you want to modify the build process via the command line. The problem can be simply reproduced when running: `cordova build android -- --gradleArg=-PcdvBuildMultipleApks=false`. The expected output would be a build with a single apk. But the result is a build with multiple apks cause `!!"false"` is `true`. This fix solves the problem by using an more mature casting process that also can handle string that contain the value `"false"`.