### PR TITLE
CB-9496 removed permissions added for crosswalk

### DIFF
--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -29,8 +29,6 @@
         />
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application android:icon="@drawable/icon" android:label="@string/app_name"
         android:hardwareAccelerated="true" android:supportsRtl="true">


### PR DESCRIPTION
These would better live in the actual crosswalk plugin

https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview

I have also submitted a PR to that repo adding them to its `plugin.xml`

https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/pull/43