### PR TITLE
CB-9519 Fix the engine destruction bug

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -479,8 +479,6 @@ public class CordovaWebViewImpl implements CordovaWebView {
         // We should use a blank data: url instead so it's more obvious
         this.loadUrl("about:blank");
 
-        // TODO: Should not destroy webview until after about:blank is done loading.
-        engine.destroy();
         hideCustomView();
     }
 
@@ -541,6 +539,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
 
             // Shutdown if blank loaded
             if (url.equals("about:blank")) {
+                engine.destroy();
                 pluginManager.postMessage("exit", null);
             }
         }


### PR DESCRIPTION
By moving a line of code, engine can be destroyed after `about:blank` is completely loaded.