### PR TITLE
The extra digit need to be added to the end of the version code

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -184,13 +184,13 @@ android {
     if (Boolean.valueOf(cdvBuildMultipleApks)) {
         productFlavors {
             armv7 {
-                versionCode cdvVersionCode ?: defaultConfig.versionCode + 2
+                versionCode defaultConfig.versionCode + 2
                 ndk {
                     abiFilters "armeabi-v7a", ""
                 }
             }
             x86 {
-                versionCode cdvVersionCode ?: defaultConfig.versionCode + 4
+                versionCode defaultConfig.versionCode + 4
                 ndk {
                     abiFilters "x86", ""
                 }


### PR DESCRIPTION
The version code of default config is generated by the environment variable
and the value from AndroidManifest.xml.
The test case is using the command line "cordova build -- --versionCode=100".