### PR TITLE
CB-9608 cordova-android no longer builds on Node 0.10 or below

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -503,11 +503,7 @@ function parseOpts(options, resolvedTarget) {
         if (config.android && config.android[ret.buildType]) {
             var androidInfo = config.android[ret.buildType];
             if(androidInfo.keystore && !packageArgs.keystore) {
-                if(path.isAbsolute(androidInfo.keystore)) {
-                    packageArgs.keystore = androidInfo.keystore;
-                } else {
-                    packageArgs.keystore = path.relative(ROOT, path.join(path.dirname(buildConfig), androidInfo.keystore));
-                }
+                packageArgs.keystore = path.resolve(ROOT, path.relative(ROOT, path.join(path.dirname(buildConfig), androidInfo.keystore)));
             }
 
             ['alias', 'storePassword', 'password','keystoreType'].forEach(function (key){


### PR DESCRIPTION
Replaced `path.isAbsolute` usage with `path.resolve`.

[Jira issue](https://issues.apache.org/jira/browse/CB-9608)