### PR TITLE
CB-9696: Add possibility to use non-immersive fullscreen in all Andro…

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -117,8 +117,8 @@ public class CordovaActivity extends Activity {
             Log.d(TAG, "The SetFullscreen configuration is deprecated in favor of Fullscreen, and will be removed in a future version.");
             preferences.set("Fullscreen", true);
         }
-        if (preferences.getBoolean("Fullscreen", false)) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (preferences.getBoolean("Fullscreen", false))  {
+            if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) && preferences.getBoolean("Fullscreen-Immersive", true)) {
                 immersiveMode = true;
             } else {
                 getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,


### PR DESCRIPTION
…id versions

When setting the new preference "fullscreen-immersive" to false like this:

<preference name="fullscreen" value="true" />
<preference name="fullscreen-immersive" value="false" />

Cordova reverts to old fullscreen behaviour also on newer Android versions. This fixes issue
CB-9696.