### PR TITLE
Makes CLI build play nice along with Android Studio

### DIFF
--- a/bin/templates/cordova/build
+++ b/bin/templates/cordova/build
@@ -21,7 +21,9 @@
 
 var build = require('./lib/build'),
     reqs  = require('./lib/check_reqs'),
-    args  = process.argv;
+    args  = process.argv,
+    fs = require('fs'),
+    path = require('path');
 
 // Support basic help commands
 if(args[2] == '--help' ||
@@ -32,9 +34,13 @@ if(args[2] == '--help' ||
    args[2] == '/help') {
     build.help();
 } else {
+    fs.renameSync(path.join(__dirname+"/../local.properties"),path.join(__dirname+"/../.local.properties"));
     reqs.run().done(function() {
-        return build.run(args.slice(2));
+        return build.run(args.slice(2)).then(function(){
+          fs.renameSync(path.join(__dirname+"/../.local.properties"),path.join(__dirname+"/../local.properties"));  
+        });
     }, function(err) {
+        fs.renameSync(path.join(__dirname+"/../.local.properties"),path.join(__dirname+"/../local.properties"));
         console.error(err);
         process.exit(2);
     });


### PR DESCRIPTION
Recently, I had had an issue after opening my cordova project with Android Studio whereby the cordova build android command would constantly give me this error message.

Running command: /Users/Developer/app/hooks/after_prepare/010_add_platform_class.js /Users/Developer/app
add to body class: platform-android
Running command: /Users/Developer/app/platforms/android/cordova/build 
ANDROID_HOME=/usr/local/Cellar/android-sdk/24.3.4
JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home
Running: /Users/Developer/app/platforms/android/gradlew cdvBuildDebug -b /Users/Developer/app/platforms/android/build.gradle -Dorg.gradle.daemon=true
:preBuild FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':preBuild'.
> failed to find Build Tools revision 23.0.1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 5.131 secs

/Users/Developer/app/platforms/android/cordova/node_modules/q/q.js:126
                    throw e;
                    ^
Error code 1 for command: /Users/Developer/app/platforms/android/gradlew with args: cdvBuildDebug,-b,/Users/Developer/app/platforms/android/build.gradle,-Dorg.gradle.daemon=true
ERROR building one of the platforms: Error: /Users/Developer/app/platforms/android/cordova/build: Command failed with exit code 1
You may not have the required environment or OS to build this project
Error: /Users/Developer/app/platforms/android/cordova/build: Command failed with exit code 1
    at ChildProcess.whenDone (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/cordova/superspawn.js:139:23)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:818:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)


Even though, I had all the build tools installed and everything, this issue started happening with the latest version of Android Studio. After a lot of debugging and almost giving up.

I found that the issue was happening due to local.properties file generated by Android Studio and the sdk.dir being specified in it. This change to the build script is not a permanent fix, there is something else wrong with the build process that stops it from finding the build tools.(FYI only cordova build android had this issue, a command-line based gradlew assemble task ran perfectly well).

But, this change does ensure that you can use terminal based cordova build android and you can still run and debug your app from the Android Studio as the file "local.properties" is restored afterwards.

There may be some more investigation needed to find out why the cordova build process does not work with local.properties or if this is an isolated issue that is happening on my dev environment only. This is just a temporary and quick fix to get your cordova build android working if you are also using Android Studio.