### PR TITLE
CB-9831 Fixed test-build script not to remove symlinked 'cordova-comm…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "scripts": {
         "test": "npm run jshint && jasmine-node --color spec",
-        "test-build": "rm -rf \"test create\" && node ./bin/create \"test create\" com.test.app 応用 && \"./test create/cordova/build\" && rm -rf \"test create\"",
+        "test-build": "node ./bin/create \"test create\" com.test.app 応用 && \"./test create/cordova/build\" && cd \"test create/cordova\" && npm r cordova-common && cd ../.. && rm -rf \"test create\"",
         "jshint": "node node_modules/jshint/bin/jshint bin && node node_modules/jshint/bin/jshint spec"
     },
     "author": "Apache Software Foundation",


### PR DESCRIPTION
…on' contents

This is a fix for https://issues.apache.org/jira/browse/CB-9831