### PR TITLE
CB-9844 Remove old .java after renaming activity

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -157,8 +157,23 @@ function updateProjectAccordingTo(platformConfig, locations) {
     shell.mkdir('-p', path.dirname(destFile));
     shell.sed(/package [\w\.]*;/, 'package ' + pkg + ';', java_files[0]).to(destFile);
     events.emit('verbose', 'Wrote out Android package name to "' + pkg + '"');
-}
 
+    if (orig_pkg !== pkg) {
+        // If package was name changed we need to remove old java with main activity
+        shell.rm('-Rf',java_files[0]);
+        // remove any empty directories
+        var currentDir = path.dirname(java_files[0]);
+        var sourcesRoot = path.resolve(locations.root, 'src');
+        while(currentDir !== sourcesRoot) {
+            if(fs.existsSync(currentDir) && fs.readdirSync(currentDir).length === 0) {
+                fs.rmdirSync(currentDir);
+                currentDir = path.resolve(currentDir, '..');
+            } else {
+                break;
+            }
+        }
+    }
+}
 
 // Consturct the default value for versionCode as
 // PATCH + MINOR * 100 + MAJOR * 10000


### PR DESCRIPTION
This is a port of https://github.com/apache/cordova-lib/pull/328 to cordova-android. Need to be done in two places since the `prepare` logic was moved to platform.

More details on JIRA: [CB-9844](https://issues.apache.org/jira/browse/CB-9844) and [CB-9736](https://issues.apache.org/jira/browse/CB-9736)