### PR TITLE
CB-9909 Shouldn't escape spaces in paths on Windows.

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -230,8 +230,12 @@ module.exports.check_android = function() {
     });
 };
 
-module.exports.getAbsoluteAndroidCmd = function() {
-    return forgivingWhichSync('android').replace(/(\s)/g, '\\$1');
+module.exports.getAbsoluteAndroidCmd = function () {
+    var cmd = forgivingWhichSync('android');
+    if (process.platform === 'win32') {
+        return '"' + cmd + '"';
+    }
+    return cmd.replace(/(\s)/g, '\\$1');
 };
 
 module.exports.check_android_target = function(valid_target) {


### PR DESCRIPTION
Instead on windows just wrap in quotes. Note that this value is only never executed directly - just displayed to the user. But this way they can copy and paste successfully on Windows.