### PR TITLE
CB-8917: Added pending plugin callbacks to resume event payload

### DIFF
--- a/cordova-js-src/platform.js
+++ b/cordova-js-src/platform.js
@@ -79,11 +79,25 @@ function onMessageFromNative(msg) {
         case 'searchbutton':
         // App life cycle events
         case 'pause':
-        case 'resume':
         // Volume events
         case 'volumedownbutton':
         case 'volumeupbutton':
             cordova.fireDocumentEvent(action);
+            break;
+        case 'resume':
+            if(arguments.length > 1 && msg.pendingResult) {
+                if(arguments.length === 2) {
+                    msg.pendingResult.result = arguments[1];
+                } else {
+                    // The plugin returned a multipart message
+                    var res = [];
+                    for(var i = 1; i < arguments.length; i++) {
+                        res.push(arguments[i]);
+                    }
+                    msg.pendingResult.result = res;
+                }
+            }
+            cordova.fireDocumentEvent(action, msg);
             break;
         default:
             throw new Error('Unknown event action ' + action);

--- a/framework/src/org/apache/cordova/CallbackContext.java
+++ b/framework/src/org/apache/cordova/CallbackContext.java
@@ -31,7 +31,7 @@ public class CallbackContext {
 
     private String callbackId;
     private CordovaWebView webView;
-    private boolean finished;
+    protected boolean finished;
     private int changingThreads;
 
     public CallbackContext(String callbackId, CordovaWebView webView) {

--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -30,6 +30,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -77,7 +78,7 @@ public class CordovaPlugin {
     public String getServiceName() {
         return serviceName;
     }
-    
+
     /**
      * Executes the request.
      *
@@ -173,6 +174,29 @@ public class CordovaPlugin {
      */
     public void onDestroy() {
     }
+
+    /**
+     * Called when the Activity is being destroyed (e.g. if a plugin calls out to an external
+     * Activity and the OS kills the CordovaActivity in the background). The plugin should save its
+     * state in this method only if it is awaiting the result of an external Activity and needs
+     * to preserve some information so as to handle that result; onRestoreStateForActivityResult()
+     * will only be called if the plugin is the recipient of an Activity result
+     *
+     * @return  Bundle containing the state of the plugin or null if state does not need to be saved
+     */
+    public Bundle onSaveInstanceState() {
+        return null;
+    }
+
+    /**
+     * Called when a plugin is the recipient of an Activity result after the CordovaActivity has
+     * been destroyed. The Bundle will be the same as the one the plugin returned in
+     * onSaveInstanceState()
+     *
+     * @param state             Bundle containing the state of the plugin
+     * @param callbackContext   Replacement Context to return the plugin result to
+     */
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {}
 
     /**
      * Called when a message is sent to plugin.
@@ -323,7 +347,7 @@ public class CordovaPlugin {
      */
     public void onReset() {
     }
-    
+
     /**
      * Called when the system received an HTTP authentication request. Plugin can use
      * the supplied HttpAuthHandler to process this auth challenge.
@@ -332,14 +356,14 @@ public class CordovaPlugin {
      * @param handler           The HttpAuthHandler used to set the WebView's response
      * @param host              The host requiring authentication
      * @param realm             The realm for which authentication is required
-     * 
+     *
      * @return                  Returns True if plugin will resolve this auth challenge, otherwise False
-     * 
+     *
      */
     public boolean onReceivedHttpAuthRequest(CordovaWebView view, ICordovaHttpAuthHandler handler, String host, String realm) {
         return false;
     }
-    
+
     /**
      * Called when he system received an SSL client certificate request.  Plugin can use
      * the supplied ClientCertRequest to process this certificate challenge.

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -445,7 +445,10 @@ public class CordovaWebViewImpl implements CordovaWebView {
         // Resume JavaScript timers. This affects all webviews within the app!
         engine.setPaused(false);
         this.pluginManager.onResume(keepRunning);
-        // To be the same as other platforms, fire this event only when resumed after a "pause".
+
+        // In order to match the behavior of the other platforms, we only send onResume after an
+        // onPause has occurred. The resume event might still be sent if the Activity was killed
+        // while waiting for the result of an external Activity once the result is obtained
         if (hasPausedEver) {
             sendJavascriptEvent("resume");
         }

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -19,10 +19,6 @@
 
 package org.apache.cordova;
 
-import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.LOG;
-import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,6 +41,8 @@ class CoreAndroid extends CordovaPlugin {
     protected static final String TAG = "CordovaApp";
     private BroadcastReceiver telephonyReceiver;
     private CallbackContext messageChannel;
+    private PluginResult pendingResume;
+    private final Object messageChannelLock = new Object();
 
     /**
      * Send an event to be fired on the Javascript side.
@@ -112,7 +110,13 @@ class CoreAndroid extends CordovaPlugin {
                 this.exitApp();
             }
 			else if (action.equals("messageChannel")) {
-                messageChannel = callbackContext;
+                synchronized(messageChannelLock) {
+                    messageChannel = callbackContext;
+                    if (pendingResume != null) {
+                        sendEventMessage(pendingResume);
+                        pendingResume = null;
+                    }
+                }
                 return true;
             }
 
@@ -313,10 +317,13 @@ class CoreAndroid extends CordovaPlugin {
         } catch (JSONException e) {
             LOG.e(TAG, "Failed to create event message", e);
         }
-        PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, obj);
-        pluginResult.setKeepCallback(true);
+        sendEventMessage(new PluginResult(PluginResult.Status.OK, obj));
+    }
+
+    private void sendEventMessage(PluginResult payload) {
+        payload.setKeepCallback(true);
         if (messageChannel != null) {
-            messageChannel.sendPluginResult(pluginResult);
+            messageChannel.sendPluginResult(payload);
         }
     }
 
@@ -327,5 +334,24 @@ class CoreAndroid extends CordovaPlugin {
     public void onDestroy()
     {
         webView.getContext().unregisterReceiver(this.telephonyReceiver);
+    }
+
+    /**
+     * Used to send the resume event in the case that the Activity is destroyed by the OS
+     *
+     * @param resumeEvent PluginResult containing the payload for the resume event to be fired
+     */
+    public void sendResumeEvent(PluginResult resumeEvent) {
+        // This operation must be synchronized because plugin results that trigger resume
+        // events can be processed asynchronously
+        synchronized(messageChannelLock) {
+            if (messageChannel != null) {
+                sendEventMessage(resumeEvent);
+            } else {
+                // Might get called before the page loads, so we need to store it until the
+                // messageChannel gets created
+                this.pendingResume = resumeEvent;
+            }
+        }
     }
 }

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -26,6 +26,7 @@ import org.json.JSONException;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.Debug;
 import android.util.Log;
 
@@ -511,4 +512,16 @@ public class PluginManager {
         }
     }
 
+    public Bundle onSaveInstanceState() {
+        Bundle state = new Bundle();
+        for (CordovaPlugin plugin : this.pluginMap.values()) {
+            if (plugin != null) {
+                Bundle pluginState = plugin.onSaveInstanceState();
+                if(pluginState != null) {
+                    state.putBundle(plugin.getServiceName(), pluginState);
+                }
+            }
+        }
+        return state;
+    }
 }

--- a/framework/src/org/apache/cordova/ResumeCallback.java
+++ b/framework/src/org/apache/cordova/ResumeCallback.java
@@ -1,0 +1,76 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova;
+
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResumeCallback extends CallbackContext {
+    private final String TAG = "CordovaResumeCallback";
+    private String serviceName;
+    private PluginManager pluginManager;
+
+    public ResumeCallback(String serviceName, PluginManager pluginManager) {
+        super("resumecallback", null);
+        this.serviceName = serviceName;
+        this.pluginManager = pluginManager;
+    }
+
+    @Override
+    public void sendPluginResult(PluginResult pluginResult) {
+        synchronized (this) {
+            if (finished) {
+                LOG.w(TAG, serviceName + " attempted to send a second callback to ResumeCallback\nResult was: " + pluginResult.getMessage());
+                return;
+            } else {
+                finished = true;
+            }
+        }
+
+        JSONObject event = new JSONObject();
+        JSONObject pluginResultObject = new JSONObject();
+
+        try {
+            pluginResultObject.put("pluginServiceName", this.serviceName);
+            pluginResultObject.put("pluginStatus", PluginResult.StatusMessages[pluginResult.getStatus()]);
+
+            event.put("action", "resume");
+            event.put("pendingResult", pluginResultObject);
+        } catch (JSONException e) {
+            LOG.e(TAG, "Unable to create resume object for Activity Result");
+        }
+
+        PluginResult eventResult = new PluginResult(PluginResult.Status.OK, event);
+
+        // We send a list of results to the js so that we don't have to decode
+        // the PluginResult passed to this CallbackContext into JSON twice.
+        // The results are combined into an event payload before the event is
+        // fired on the js side of things (see platform.js)
+        List<PluginResult> result = new ArrayList<PluginResult>();
+        result.add(eventResult);
+        result.add(pluginResult);
+
+        CoreAndroid appPlugin = (CoreAndroid) pluginManager.getPlugin(CoreAndroid.PLUGIN_NAME);
+        appPlugin.sendResumeEvent(new PluginResult(PluginResult.Status.OK, result));
+    }
+}


### PR DESCRIPTION
This is a redo of #236 after receiving some feedback. This relates to CB-8917 and CB-9189.

### Background
The issue at hand is that plugins can make calls to an external Activity and, if the device is low on memory, there is a chance that the CordovaActivity will get killed in the background causing the plugin to lose its state as well as its context for the callback. Activities in Android typically handle this situation by using `onSaveInstanceState()` and `onCreate()` methods to save and restore state respectively as the Activity is created and destroyed. This solution exposes that lifecycle to plugins, allowing them to save state and have it restored if necessary.

### Saving/Restoring plugin state
Two new methods are exposed to plugins that they can override to save/restore state.
```java
/**
 * Called when the Activity is being destroyed (e.g. if a plugin calls out to an external
 * Activity and the OS kills the CordovaActivity in the background). The plugin should save its
 * state in this method only if it is awaiting the result of an external Activity and needs
 * to preserve some information so as to handle that result; onRestoreStateForActivityResult()
 * will only be called if the plugin is the recipient of an Activity result
 *
 * @return  Bundle containing the state of the plugin or null if state does not need to be saved
 */
public Bundle onSaveInstanceState() {}

/**
 * Called when a plugin is the recipient of an Activity result after the CordovaActivity has
 * been destroyed. The Bundle will be the same as the one the plugin returned in
 * onSaveInstanceState()
 *
 * @param state             Bundle containing the state of the plugin
 * @param callbackContext   Replacement Context to return the plugin result to
 */
public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {}
```
The plugin is given a replacement CallbackContext as part of `onRestoreStateForActivityResult` that can accept the result the plugin would normally return and add it to the resume event payload for use in the js (see JSON below). Thus, it requires minimal modifications to existing plugins

_NOTE:_ When I mention that plugins are given the opportunity to restore state, I want to clarify that this only happens for plugins that are waiting for an external Activity result. This makes the API a little less intuitive, but otherwise we would be conflicting with the accepted behavior that plugins currently get destroyed (i.e. lose all of their state) and are selectively rebuilt whenever a new URL is loaded into the webview. If we restore state on resume, then we can end up with some awkward cases where part of the resuming involves loading a new page so the state gets lost again and so on and so forth. My thinking is that restoring the other state is better left to app developers

### Saving/Restoring js state
We already send out pause and resume events. This solution enhances these events in the case of Activity destruction by adding to them the result of any pending Plugin calls. The resume event is of the form
```
{
    action: "resume",
    pendingResult: {
        pluginServiceName: <plugin service name e.g. "Camera">,
        pluginStatus: <description of result' status (see PluginResult.java)>,
        result: <argument(s) that would have been given to the callback>
    }
}
```
It is the responsibility of the application developer to properly use these events and save their state as well as keep information about what plugin results they have pending. We should provide guidance for this in the Android documentation and plugin documentation should clearly communicate when it is necessary.

### Discussion
#### Benefits:

* It requires minimal updates to existing plugins (and no updates at all if the plugin doesn't use an external Activity)
* It is a general solution/pattern that plugins can follow rather than forcing them to include platform specific methods in their APIs

#### Downsides:

* The resume callback will only ever get received after the initial page loads (potential page flickering)
* The pending result part of the event object doesn't provide much context (so it puts more responsibility on the app developer to keep state so they know what they're getting)

In the core plugins, this is mostly relevant to the Camera plugin which previously would crash upon receiving the Activity result if the CordovaActivity had been killed by the OS while a picture was being taken/chosen (CB-9189). The updated Camera Plugin can be found in [this branch](https://github.com/MSOpenTech/cordova-plugin-camera/tree/save-state-plugin-only) and a (trivial) example application that uses this API + instructions for testing can be found [here](https://gist.github.com/riknoll/d0ab25583b1dc8ab22af).
