### PR TITLE
CB-10112 Parse additional CLI arguments properly

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -61,13 +61,13 @@ function parseOpts(options, resolvedTarget) {
     if (options.nobuild) ret.buildMethod = 'none';
 
     if (options.argv.versionCode)
-        ret.extraArgs.push('-PcdvVersionCode=' + options.versionCode);
+        ret.extraArgs.push('-PcdvVersionCode=' + options.argv.versionCode);
 
     if (options.argv.minSdkVersion)
-        ret.extraArgs.push('-PcdvMinSdkVersion=' + options.minSdkVersion);
+        ret.extraArgs.push('-PcdvMinSdkVersion=' + options.argv.minSdkVersion);
 
     if (options.argv.gradleArg)
-        ret.extraArgs.push(options.gradleArg);
+        ret.extraArgs.push(options.argv.gradleArg);
 
     var packageArgs = {};
 


### PR DESCRIPTION
This fixes [CB-10112](https://issues.apache.org/jira/browse/CB-10112) by updating `build.js` to take an addtional platform options (passed behing `--`) from correct options object 