### PR TITLE
Update CordovaWebViewImpl.java

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -135,6 +135,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
         if (recreatePlugins) {
             // Don't re-initialize on first load.
             if (loadedUrl != null) {
+                //reset appPlugin
+                resetCoreAndroidPlugin();
                 pluginManager.init();
             }
             loadedUrl = url;
@@ -485,6 +487,11 @@ public class CordovaWebViewImpl implements CordovaWebView {
         // TODO: Should not destroy webview until after about:blank is done loading.
         engine.destroy();
         hideCustomView();
+    }
+
+    public void resetCoreAndroidPlugin(){
+        //In order to set the variable appPlugin null when open other url
+        appPlugin = null;
     }
 
     protected class EngineClient implements CordovaWebViewEngine.Client {


### PR DESCRIPTION
use resetCoreAndroidPlugin method to set variable null when opening other url.
when I use cordova-android framework in my project,it is troubling me that the backbutton event doesn't work if I trriger the backbutton on other url.
ps:I import the cordova.js into my html page more than once. 