### PR TITLE
Include native libraries from armeabi directory when producing armv7 apk

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -176,7 +176,7 @@ android {
             armv7 {
                 versionCode defaultConfig.versionCode + 2
                 ndk {
-                    abiFilters "armeabi-v7a", ""
+                    abiFilters "armeabi-v7a", "armeabi"
                 }
             }
             x86 {


### PR DESCRIPTION
If a Cordova Android project contains `.so` files located in the `lib/armeabi` directory, they will not be included in the final apk when building for the `armv7` architecture with `cdvBuildMultipleApks` set to `true`