### PR TITLE
Update theme to Theme.DeviceDefault.NoActionBar

### DIFF
--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <activity android:name="__ACTIVITY__"
                 android:label="@string/activity_name"
                 android:launchMode="singleTop"
-                android:theme="@android:style/Theme.Black.NoTitleBar"
+                android:theme="@android:style/Theme.DeviceDefault.NoActionBar"
                 android:windowSoftInputMode="adjustResize"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale">
             <intent-filter android:label="@string/launcher_name">


### PR DESCRIPTION
This uses the device system theme instead of the old Gingerbread-era theme for dialogs and alerts.

Available as of API 14, which is now the minSDK version for cordova-android.