### PR TITLE
CB-10014: Set gradle applicationId to package name.

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -163,6 +163,8 @@ android {
 
     defaultConfig {
         versionCode cdvVersionCode ?: Integer.parseInt("" + privateHelpers.extractIntFromManifest("versionCode") + "0")
+        applicationId privateHelpers.extractStringFromManifest("package")
+
         if (cdvMinSdkVersion != null) {
             minSdkVersion cdvMinSdkVersion
         }

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -128,6 +128,14 @@ def doExtractIntFromManifest(name) {
     return Integer.parseInt(matcher.group(1))
 }
 
+def doExtractStringFromManifest(name) {
+    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
+    def pattern = Pattern.compile(name + "=\"(\\S+)\"")
+    def matcher = pattern.matcher(manifestFile.getText())
+    matcher.find()
+    return matcher.group(1)
+}
+
 def doPromptForPassword(msg) {
     if (System.console() == null) {
         def ret = null
@@ -179,6 +187,7 @@ ext {
     privateHelpers.getProjectTarget = { doGetProjectTarget() }
     privateHelpers.findLatestInstalledBuildTools = { doFindLatestInstalledBuildTools('19.1.0') }
     privateHelpers.extractIntFromManifest = { name -> doExtractIntFromManifest(name) }
+    privateHelpers.extractStringFromManifest = { name -> doExtractStringFromManifest(name) }
     privateHelpers.promptForPassword = { msg -> doPromptForPassword(msg) }
     privateHelpers.ensureValueExists = { filePath, props, key -> doEnsureValueExists(filePath, props, key) }
 


### PR DESCRIPTION
This fixes an issue that's affecting several Cordova Android apps where Google Play services causes conflicts that prevent multiple apps from being installed.

JIRA issue: https://issues.apache.org/jira/browse/CB-10014
See also: https://code.google.com/p/android/issues/detail?id=193567
http://tools.android.com/tech-docs/new-build-system/applicationid-vs-packagename