### PR TITLE
Parse options correctly

### DIFF
--- a/bin/templates/cordova/build
+++ b/bin/templates/cordova/build
@@ -39,7 +39,7 @@ var buildOpts = nopt({
 }, { 'd' : '--verbose' });
 
 // Make buildOptions compatible with PlatformApi build method spec
-buildOpts.argv = buildOpts.argv.remain;
+buildOpts.argv = buildOpts.argv.original;
 
 new Api().build(buildOpts)
 .catch(function(err) {

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -31,7 +31,7 @@ var events = require('cordova-common').events;
 var spawn = require('cordova-common').superspawn.spawn;
 var CordovaError = require('cordova-common').CordovaError;
 
-function parseOpts(options, resolvedTarget) {
+function parseOpts(options, resolvedTarget, projectRoot) {
     options = options || {};
     options.argv = nopt({
         gradle: Boolean,
@@ -72,7 +72,7 @@ function parseOpts(options, resolvedTarget) {
     var packageArgs = {};
 
     if (options.argv.keystore)
-        packageArgs.keystore = path.relative(this.root, path.resolve(options.argv.keystore));
+        packageArgs.keystore = path.relative(projectRoot, path.resolve(options.argv.keystore));
 
     ['alias','storePassword','password','keystoreType'].forEach(function (flagName) {
         if (options.argv[flagName])
@@ -120,7 +120,7 @@ function parseOpts(options, resolvedTarget) {
  * Returns a promise.
  */
 module.exports.runClean = function(options) {
-    var opts = parseOpts(options);
+    var opts = parseOpts(options, null, this.root);
     var builder = builders.getBuilder(opts.buildMethod);
     return builder.prepEnv(opts)
     .then(function() {
@@ -141,7 +141,7 @@ module.exports.runClean = function(options) {
  *   information.
  */
 module.exports.run = function(options, optResolvedTarget) {
-    var opts = parseOpts(options, optResolvedTarget);
+    var opts = parseOpts(options, optResolvedTarget, this.root);
     var builder = builders.getBuilder(opts.buildMethod);
     var self = this;
     return builder.prepEnv(opts)


### PR DESCRIPTION
Fix 1
Options have already passed through `nopt` module in the build file. Nopt successfully parses all options which results in `argv.remain` being an empty array.
This ultimately leads to a bug in the `parseOpts` function where the options undergo a second parsing from nopt.
The end result is - this options are not respected at all.

Fix 2
parseOpts function referenced `this.root` but the `this` object is not the `new Api` as expected. This leads to an exception upon calling `path.relative(this.root, ...)`.