### PR TITLE
Clearing appPlugin when loading pages.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -500,6 +500,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
             boundKeyCodes.clear();
             pluginManager.onReset();
             pluginManager.postMessage("onPageStarted", newUrl);
+			appPlugin = null;
         }
 
         @Override


### PR DESCRIPTION
When changing a page the appPlugin becomes stale, causing the "backbutton" and other events to no longer be passable from the CordovaWebView. By setting it to null when a page is loaded it will force the updated appPlugin when it is needed next.