### PR TITLE
fix HtmlNotFoundTest so that it passes when file not found is handled correctly

### DIFF
--- a/test/androidTest/src/org/apache/cordova/test/HtmlNotFoundTest.java
+++ b/test/androidTest/src/org/apache/cordova/test/HtmlNotFoundTest.java
@@ -30,11 +30,17 @@ public class HtmlNotFoundTest extends BaseCordovaIntegrationTest {
   }
   public void testUrl() throws Throwable
   {
-      assertEquals(START_URL, testActivity.onPageFinishedUrl.take());
       runTestOnUiThread(new Runnable() {
           public void run() {
-              assertFalse(START_URL.equals(testActivity.getCordovaWebView().getUrl()));
+              assertTrue(START_URL.equals(testActivity.getCordovaWebView().getUrl()));
           }
       });
+
+      //loading a not-found file causes an application error and displayError is called
+      //the test activity overrides displayError to add message to onPageFinishedUrl
+      String message = testActivity.onPageFinishedUrl.take();
+      assertTrue(message.contains(START_URL));
+      assertTrue(message.contains("ERR_FILE_NOT_FOUND"));
   }
+
 }

--- a/test/src/org/apache/cordova/test/BaseTestCordovaActivity.java
+++ b/test/src/org/apache/cordova/test/BaseTestCordovaActivity.java
@@ -47,4 +47,10 @@ public class BaseTestCordovaActivity extends CordovaActivity {
         return appView;
     }
 
+    // By default, displayError shows a dialog, but for tests we just add the message to the queue
+    @Override
+    public void displayError(String title, String message, String button, boolean exit) {
+        onPageFinishedUrl.add(message);
+    }
+
 }


### PR DESCRIPTION
override displayError in testActivity to send message to queue (dialogs are not very useful in tests)
evaluate message to make sure it contains ERR_FILE_NOT_FOUND and the (invalid) START_URL