### PR TITLE
CB-10660 fixed the exception when removing a non-existing directory

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -96,7 +96,7 @@ var handlers = {
                 subDir = path.resolve(project.projectDir, subRelativeDir);
                 // If it's the last framework in the plugin, remove the parent directory.
                 var parDir = path.dirname(subDir);
-                if (fs.readdirSync(parDir).length === 0) {
+                if (fs.existsSync(parDir) && fs.readdirSync(parDir).length === 0) {
                     fs.rmdirSync(parDir);
                 }
             } else {


### PR DESCRIPTION
It is ALWAYS safer to check if the directory exists before it tires to remove the directory.
The uninstallation of the plugin with a <framework> tag failed because of this issue.
