### PR TITLE
CB-10673 fixed conflicting plugin install issue with overlapped <sour…

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -34,7 +34,7 @@ var handlers = {
             if (options && options.forceCopyingSrc) {
                 copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
             } else {
-              copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+                copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
             }
         },
         uninstall:function(obj, plugin, project, options) {

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -31,7 +31,7 @@ var handlers = {
             if (!obj.src) throw new CordovaError('<source-file> element is missing "src" attribute for plugin: ' + plugin.id);
             if (!obj.targetDir) throw new CordovaError('<source-file> element is missing "target-dir" attribute for plugin: ' + plugin.id);
             var dest = path.join(obj.targetDir, path.basename(obj.src));
-            copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+            copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
         },
         uninstall:function(obj, plugin, project, options) {
             var dest = path.join(obj.targetDir, path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -31,7 +31,10 @@ var handlers = {
             if (!obj.src) throw new CordovaError('<source-file> element is missing "src" attribute for plugin: ' + plugin.id);
             if (!obj.targetDir) throw new CordovaError('<source-file> element is missing "target-dir" attribute for plugin: ' + plugin.id);
             var dest = path.join(obj.targetDir, path.basename(obj.src));
-            copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+            if (options && options.forceCopyingSrc) {
+                copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+            } else {
+                copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
         },
         uninstall:function(obj, plugin, project, options) {
             var dest = path.join(obj.targetDir, path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -34,7 +34,8 @@ var handlers = {
             if (options && options.forceCopyingSrc) {
                 copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
             } else {
-                copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+              copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
+            }
         },
         uninstall:function(obj, plugin, project, options) {
             var dest = path.join(obj.targetDir, path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -31,7 +31,7 @@ var handlers = {
             if (!obj.src) throw new CordovaError('<source-file> element is missing "src" attribute for plugin: ' + plugin.id);
             if (!obj.targetDir) throw new CordovaError('<source-file> element is missing "target-dir" attribute for plugin: ' + plugin.id);
             var dest = path.join(obj.targetDir, path.basename(obj.src));
-            if (options && options.forceCopyingSrc) {
+            if (options && options.force) {
                 copyFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);
             } else {
                 copyNewFile(plugin.dir, obj.src, project.projectDir, dest, options && options.link);


### PR DESCRIPTION
…ce-file> tag
The problem is that copyNewFile is too strict for <source-file> tag.
You will never know which two plugins will write the library to the same target-dir of the source-file.
We should let it copy the library to the same location.