### PR TITLE
Update SystemWebViewEngine

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -142,6 +142,7 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         webView.setVerticalScrollBarEnabled(false);
         // Enable JavaScript
         final WebSettings settings = webView.getSettings();
+        settings.setMinimumFontSize(0);
         settings.setJavaScriptEnabled(true);
         settings.setJavaScriptCanOpenWindowsAutomatically(true);
         settings.setLayoutAlgorithm(LayoutAlgorithm.NORMAL);


### PR DESCRIPTION
There is no point of having font size under 1px (which is default minimum size) BUT when we use EM and REM units (font-size: 0.1em)there might be some UI issues when the equivalent size in PX is smaller than 1