### PR TITLE
[CB-8250] fix issue with app_name containing apostrophes

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -120,7 +120,7 @@ function updateProjectAccordingTo(platformConfig, locations) {
     // Update app name by editing res/values/strings.xml
     var name = platformConfig.name();
     var strings = xmlHelpers.parseElementtreeSync(locations.strings);
-    strings.find('string[@name="app_name"]').text = name;
+    strings.find('string[@name="app_name"]').text = name.replace(/\'/g, '\\\'');
     fs.writeFileSync(locations.strings, strings.write({indent: 4}), 'utf-8');
     events.emit('verbose', 'Wrote out Android application name to "' + name + '"');
 


### PR DESCRIPTION
When the app name has an apostrophe defined in config.xml, this cause an issue on Android when building

cordova build android result :

```
:processDebugManifest UP-TO-DATE
:processDebugResources/Users/juju/Documents/projects/synchronized/test-cordova/cordova/platforms/android/build/intermediates/res/merged/debug/values/values.xml:4 : AAPT: Apostrophe not preceded by \ (in L'HelloCordova)

 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':processDebugResources'.
> com.android.ide.common.process.ProcessException: org.gradle.process.internal.ExecException: Process 'command '/Applications/android-sdk-macosx/build-tools/20.0.0/aapt'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 2.967 secs
ERROR building one of the platforms: Error code 1 for command: /Users/juju/Documents/projects/synchronized/test-cordova/cordova/platforms/android/gradlew with args: cdvBuildDebug,-b,/Users/juju/Documents/projects/synchronized/test-cordova/cordova/platforms/android/build.gradle,-Dorg.gradle.daemon=true,-Pandroid.useDeprecatedNdk=true
You may not have the required environment or OS to build this project
Error: Error code 1 for command: /Users/juju/Documents/projects/synchronized/test-cordova/cordova/platforms/android/gradlew with args: cdvBuildDebug,-b,/Users/juju/Documents/projects/synchronized/test-cordova/cordova/platforms/android/build.gradle,-Dorg.gradle.daemon=true,-Pandroid.useDeprecatedNdk=true
```

This fix just escape the apostrophe on Android so it can build
