### PR TITLE
[CB-10600] 'cordova run --release' uses wrong apk

### DIFF
--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -109,7 +109,7 @@ function findOutputApksHelper(dir, build_type, arch) {
             return /-debug/.exec(apkName) && !/-unaligned|-unsigned/.exec(apkName);
         }
         if (build_type === 'release') {
-            return /-release/.exec(apkName) && !/-unaligned/.exec(apkName);
+            return /-release/.exec(apkName) && !/-unaligned|-unsigned/.exec(apkName);
         }
         return true;
     })


### PR DESCRIPTION
When doing `cordova run android --release`, the CLI attempts to use the
android-release-unsigned.apk, which naturally fails to install on the
device because it is unsigned. The release build does also generate the
properly signed android-release.apk, and that should be used instead.

The apk-finding logic for "debug" excludes unsigned builds, so the
"release" logic should follow a similar pattern.

Fixes https://issues.apache.org/jira/browse/CB-10600