### PR TITLE
CB-10600 'cordova run android --release' does not use signed and zip-…

### DIFF
--- a/bin/templates/cordova/lib/Adb.js
+++ b/bin/templates/cordova/lib/Adb.js
@@ -63,8 +63,14 @@ Adb.install = function (target, packagePath, opts) {
     .then(function(output) {
         // 'adb install' seems to always returns no error, even if installation fails
         // so we catching output to detect installation failure
-        if (output.match(/Failure/))
+        if (output.match(/Failure/)) {
+            if (output.match(/INSTALL_PARSE_FAILED_NO_CERTIFICATES/)) {
+                output += '\n\n' + 'Sign the build using \'-- --keystore\' or \'--buildConfig\'' +
+                    ' or sign and deploy the unsigned apk manually using Android tools.';
+            }
+
             return Q.reject(new CordovaError('Failed to install apk to device: ' + output));
+        }
     });
 };
 

--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -93,6 +93,14 @@ GenericBuilder.prototype.extractRealProjectNameFromManifest = function () {
 module.exports = GenericBuilder;
 
 function apkSorter(fileA, fileB) {
+    // De-prioritize unsigned builds
+    var unsignedRE = /-unsigned/;
+    if (unsignedRE.exec(fileA)) {
+        return 1;
+    } else if (unsignedRE.exec(fileB)) {
+        return -1;
+    }
+
     var timeDiff = fs.statSync(fileA).mtime - fs.statSync(fileB).mtime;
     return timeDiff === 0 ? fileA.length - fileB.length : timeDiff;
 }
@@ -128,7 +136,8 @@ function findOutputApksHelper(dir, build_type, arch) {
         return !!/-x86|-arm/.exec(path.basename(p)) == archSpecific;
         /*jshint +W018 */
     });
-    if (archSpecific && ret.length > 1) {
+
+    if (archSpecific && ret.length > 1 && arch) {
         ret = ret.filter(function(p) {
             return path.basename(p).indexOf('-' + arch) != -1;
         });

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -368,8 +368,14 @@ module.exports.install = function(givenTarget, buildResults) {
                         if (err) reject(new CordovaError('Error executing "' + command + '": ' + stderr));
                         // adb does not return an error code even if installation fails. Instead it puts a specific
                         // message to stdout, so we have to use RegExp matching to detect installation failure.
-                        else if (/Failure/.test(stdout)) reject(new CordovaError('Failed to install apk to emulator: ' + stdout));
-                        else resolve(stdout);
+                        else if (/Failure/.test(stdout)) {
+                            if (stdout.match(/INSTALL_PARSE_FAILED_NO_CERTIFICATES/)) {
+                                stdout += 'Sign the build using \'-- --keystore\' or \'--buildConfig\'' +
+                                    ' or sign and deploy the unsigned apk manually using Android tools.';
+                            }
+                            
+                            reject(new CordovaError('Failed to install apk to emulator: ' + stdout));
+                        } else resolve(stdout);
                     });
                 });
             }


### PR DESCRIPTION
…aligned version of APK

De-prioritize unsigned builds
Adds an actionable hint for INSTALL_PARSE_FAILED_NO_CERTIFICATES error
Removes filtering by architecture when not specified

[Jira issue](https://issues.apache.org/jira/browse/CB-10600)