### PR TITLE
fullscreen no immersive

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -118,7 +118,9 @@ public class CordovaActivity extends Activity {
             preferences.set("Fullscreen", true);
         }
         if (preferences.getBoolean("Fullscreen", false)) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            // NOTE: use the FullscreenNotImmersive configuration key to set the activity in a REAL full screen
+            // (as was the case in previous cordova versions)
+            if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) && !preferences.getBoolean("FullscreenNotImmersive", false)) {
                 immersiveMode = true;
             } else {
                 getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,


### PR DESCRIPTION
hi,
we are using Cordova and would like to have the ability to set the Cordova activity in full screen mode, and not in an immersive mode regardless of the Android version (as was the case in previous Cordova versions).
therefore, we added a new configuration key to the Cordova config: "FullscreenNotImmersive".
when set to true the Cordova activity will be started using the full-screen-not-immersive flags.
otherwise, it will be started using the relevant flags according to the Android version (the original v5.1.x implementation). by default, this configuration key is set to false (= original implementation).
we would appreciate if you could merge this pull request so that other developers would be able to enjoy this logic ;)

@infil00p @daserge - i closed the previous pull request, and created a new one under master as you requested ;)