### PR TITLE
CB-10897 Refactor URI Parsing for Whitelist

### DIFF
--- a/test/assets/www/whitelist/index.html
+++ b/test/assets/www/whitelist/index.html
@@ -36,10 +36,14 @@
      Loading Page 2 should be successful.<br>
      Loading Page 3 should be in web browser.<br>
      Loading Page 2 with target=_blank should be in web browser? <br>
-     (THIS DOESN'T HAPPEN.) https://issues.apache.org/jira/browse/CB-362 
+     (THIS DOESN'T HAPPEN.) https://issues.apache.org/jira/browse/CB-362 <br>
+     Loading Google Maps App should open in Play Store <br>
+     Loading Gmail App should fail <br>
      </div>
     <a href="index2.html" class="btn large">Page 2</a>
     <a href="http://www.google.com" class="btn large">Page 3</a>
     <a href="index2.html" class="btn large" target="_blank">Page 2 with target=_blank</a>
+    <a href="market://details?id=com.google.android.apps.maps" class="btn large">Google Maps App</a>
+    <a href="market://details?id=com.google.android.gm" class="btn large">Gmail App</a>
   </body>
 </html>

--- a/test/res/xml/config.xml
+++ b/test/res/xml/config.xml
@@ -30,6 +30,7 @@
     <access origin="https://*.google.com/*" />
     <access origin="https://*.googleapis.com/*" />
     <access origin="https://*.gstatic.com/*" />
+    <access origin="market://details?id=com.google.android.apps.maps" launch-external="yes"/>
     <content src="index.html" />
     <preference name="loglevel" value="DEBUG" />
     <preference name="useBrowserHistory" value="true" />


### PR DESCRIPTION
Fix for CB-10897. 

I moved out the code that parses the 'origin' from the whitelist to a separate function so that it can also be used to parse the URLs that request access instead of using Android's Uri class parse function. Android's Uri parse function does not parse 'host' the same way that Cordova parses the host in origin for whitelist, so host ends up being null and the comparison fails. Using the same parsing methods is the way to go to give accurate comparisons of URLs to those in the whitelist. 

Also, I can have specific non http/https URLs in my whitelist now. 
Something like this works now without the wildcard:
`<allow-intent href="market://details?id=com.google.android.apps.maps" />`
