### PR TITLE
CB-8383 Handle pause event when keeprunning=false

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -433,8 +433,17 @@ public class CordovaWebViewImpl implements CordovaWebView {
 
         // If app doesn't want to run in background
         if (!keepRunning) {
-            // Pause JavaScript timers. This affects all webviews within the app!
-            engine.setPaused(true);
+            // Delay setPaused while javascript processes pause event 
+            Thread t = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        Thread.sleep(250);
+                        // Pause JavaScript timers. This affects all webviews within the app!
+                        engine.setPaused(true);
+                    } catch (InterruptedException e) {
+                    }
+                }
+            });
         }
     }
     @Override


### PR DESCRIPTION
I added this pull request to hopefully get some attention to this bug https://issues.apache.org/jira/browse/CB-8383. When keeprunning = false in config.xml, any pause event processing is halted until the app returns. Not only is the pause event missed on app backgrounding, but on return it processes the pause and resume events.