### PR TITLE
CB-11022 Duplicate www files to both destinations on plugin add/rm

### DIFF
--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -50,6 +50,7 @@ describe('android project handler', function() {
         beforeEach(function() {
             shell.mkdir('-p', temp);
             dummyProject = AndroidProject.getProjectFile(temp);
+            copyFileSpy.reset();
             common.__set__('copyFile', copyFileSpy);
         });
 
@@ -161,6 +162,51 @@ describe('android project handler', function() {
                 expect(dummyProject.addGradleReference).toHaveBeenCalledWith(dummyProject.projectDir, someString);
             });
         });
+
+        describe('of <js-module> elements', function() {
+            var jsModule = {src: 'www/dummyPlugin.js'};
+            var wwwDest, platformWwwDest;
+
+            beforeEach(function () {
+                spyOn(fs, 'writeFileSync');
+                wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
+                platformWwwDest = path.resolve(dummyProject.platformWww, 'plugins', dummyPluginInfo.id, jsModule.src);
+            });
+
+            it('should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+                android['js-module'].install(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
+                expect(fs.writeFileSync).toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
+            });
+
+            it('should put module to www only when options.usePlatformWww flag is not specified', function () {
+                android['js-module'].install(jsModule, dummyPluginInfo, dummyProject);
+                expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
+                expect(fs.writeFileSync).not.toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
+            });
+        });
+
+        describe('of <asset> elements', function() {
+            var asset = {src: 'www/dummyPlugin.js', target: 'foo/dummy.js'};
+            var wwwDest, platformWwwDest;
+
+            beforeEach(function () {
+                wwwDest = path.resolve(dummyProject.www, asset.target);
+                platformWwwDest = path.resolve(dummyProject.platformWww, asset.target);
+            });
+
+            it('should put asset to both www and platform_www when options.usePlatformWww flag is specified', function () {
+                android.asset.install(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.www, asset.target);
+                expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.platformWww, asset.target);
+            });
+
+            it('should put asset to www only when options.usePlatformWww flag is not specified', function () {
+                android.asset.install(asset, dummyPluginInfo, dummyProject);
+                expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.www, asset.target);
+                expect(copyFileSpy).not.toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.platformWww, asset.target);
+            });
+        });
     });
 
     describe('uninstallation', function() {
@@ -252,6 +298,67 @@ describe('android project handler', function() {
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
                 expect(removeFileSpy).toHaveBeenCalledWith(dummyProject.projectDir, someString);
                 expect(dummyProject.removeGradleReference).toHaveBeenCalledWith(dummyProject.projectDir, someString);
+            });
+        });
+
+
+        describe('of <js-module> elements', function() {
+            var jsModule = {src: 'www/dummyPlugin.js'};
+            var wwwDest, platformWwwDest;
+
+            beforeEach(function () {
+                wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
+                platformWwwDest = path.resolve(dummyProject.platformWww, 'plugins', dummyPluginInfo.id, jsModule.src);
+
+                spyOn(shell, 'rm');
+
+                var existsSyncOrig = fs.existsSync;
+                spyOn(fs, 'existsSync').andCallFake(function (file) {
+                    if ([wwwDest, platformWwwDest].indexOf(file) >= 0 ) return true;
+                    return existsSyncOrig.call(fs, file);
+                });
+            });
+
+            it('should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+                android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                expect(shell.rm).toHaveBeenCalledWith('-Rf', wwwDest);
+                expect(shell.rm).toHaveBeenCalledWith('-Rf', platformWwwDest);
+            });
+
+            it('should put module to www only when options.usePlatformWww flag is not specified', function () {
+                android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject);
+                expect(shell.rm).toHaveBeenCalledWith('-Rf', wwwDest);
+                expect(shell.rm).not.toHaveBeenCalledWith('-Rf', platformWwwDest);
+            });
+        });
+
+        describe('of <asset> elements', function() {
+            var asset = {src: 'www/dummyPlugin.js', target: 'foo/dummy.js'};
+            var wwwDest, platformWwwDest;
+
+            beforeEach(function () {
+                wwwDest = path.resolve(dummyProject.www, asset.target);
+                platformWwwDest = path.resolve(dummyProject.platformWww, asset.target);
+
+                spyOn(shell, 'rm');
+
+                var existsSyncOrig = fs.existsSync;
+                spyOn(fs, 'existsSync').andCallFake(function (file) {
+                    if ([wwwDest, platformWwwDest].indexOf(file) >= 0 ) return true;
+                    return existsSyncOrig.call(fs, file);
+                });
+            });
+
+            it('should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+                android.asset.uninstall(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
+                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
+            });
+
+            it('should put module to www only when options.usePlatformWww flag is not specified', function () {
+                android.asset.uninstall(asset, dummyPluginInfo, dummyProject);
+                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
+                expect(shell.rm).not.toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });
         });
     });


### PR DESCRIPTION
This is a supplementary PR for https://github.com/apache/cordova-lib/pull/423 which removes requirement for running prepare to copy plugin's files to `www` dir.