### PR TITLE
CB-9465 replace Integer.parseInt with BigInteger so that you can use longer Android version codes

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -162,7 +162,7 @@ android {
     }
 
     defaultConfig {
-        versionCode cdvVersionCode ?: Integer.parseInt("" + privateHelpers.extractIntFromManifest("versionCode"))
+        versionCode cdvVersionCode ?: new BigInteger("" + privateHelpers.extractIntFromManifest("versionCode"))
         applicationId privateHelpers.extractStringFromManifest("package")
 
         if (cdvMinSdkVersion != null) {

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -125,7 +125,7 @@ def doExtractIntFromManifest(name) {
     def pattern = Pattern.compile(name + "=\"(\\d+)\"")
     def matcher = pattern.matcher(manifestFile.getText())
     matcher.find()
-    return Integer.parseInt(matcher.group(1))
+    return new BigInteger(matcher.group(1))
 }
 
 def doExtractStringFromManifest(name) {


### PR DESCRIPTION
I used to have DNS like version codes (YYYYmmmddXX format) for my apps builds, and I can't go back in older apps because Google Play wont allow me to upload inferior version codes, so I thing we should to use BigInteger instead of Integer.parseInt