### PR TITLE
CB-6936: fix crash when calling methods on a destroyed webview

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -109,7 +109,11 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         nativeToJsMessageQueue.addBridgeMode(new NativeToJsMessageQueue.OnlineEventsBridgeMode(new NativeToJsMessageQueue.OnlineEventsBridgeMode.OnlineEventsBridgeModeDelegate() {
             @Override
             public void setNetworkAvailable(boolean value) {
-                webView.setNetworkAvailable(value);
+                //sometimes this can be called after calling webview.destroy() on destroy()
+                //thus resulting in a NullPointerException
+                if(webView!=null) {
+                   webView.setNetworkAvailable(value); 
+                }
             }
             @Override
             public void runOnUiThread(Runnable r) {


### PR DESCRIPTION
Hi guys. This has happened in some of my apps, not often, but a few times. I also have see some reports on the web.
Take a look at this stack overflow thread for instance:
http://stackoverflow.com/questions/36239052/nullpointerexception-in-cordova-app-reported-by-fabric-sdk
I think that better than just doing a try/catch is just check if the webView is valid/null or not
