### PR TITLE
Improving Android build output and verbose logging

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -246,7 +246,7 @@ exports.create = function(project_path, config, options, events) {
         events.emit('log', '\tActivity: ' + safe_activity_name);
         events.emit('log', '\tAndroid target: ' + target_api);
 
-        events.emit('verbose', 'Copying template files...');
+        events.emit('verbose', 'Copying android template project to ' + project_path);
 
         setShellFatal(true, function() {
             var project_template_dir = options.customTemplate || path.join(ROOT, 'bin', 'templates', 'project');

--- a/bin/templates/cordova/lib/Adb.js
+++ b/bin/templates/cordova/lib/Adb.js
@@ -56,7 +56,7 @@ Adb.devices = function (opts) {
 };
 
 Adb.install = function (target, packagePath, opts) {
-    events.emit('verbose', 'Installing apk ' + packagePath + ' on ' + target + '...');
+    events.emit('verbose', 'Installing apk ' + packagePath + ' on target ' + target + '...');
     var args = ['-s', target, 'install'];
     if (opts && opts.replace) args.push('-r');
     return spawn('adb', args.concat(packagePath), {cwd: os.tmpdir()})
@@ -78,12 +78,12 @@ Adb.install = function (target, packagePath, opts) {
 };
 
 Adb.uninstall = function (target, packageId) {
-    events.emit('verbose', 'Uninstalling ' + packageId + ' from ' + target + '...');
+    events.emit('verbose', 'Uninstalling package ' + packageId + ' from target ' + target + '...');
     return spawn('adb', ['-s', target, 'uninstall', packageId], {cwd: os.tmpdir()});
 };
 
 Adb.shell = function (target, shellCommand) {
-    events.emit('verbose', 'Running command "' + shellCommand + '" on ' + target + '...');
+    events.emit('verbose', 'Running adb shell command "' + shellCommand + '" on target ' + target + '...');
     var args = ['-s', target, 'shell'];
     shellCommand = shellCommand.split(/\s+/);
     return spawn('adb', args.concat(shellCommand), {cwd: os.tmpdir()})
@@ -94,7 +94,7 @@ Adb.shell = function (target, shellCommand) {
 };
 
 Adb.start = function (target, activityName) {
-    events.emit('verbose', 'Starting application "' + activityName + '" on ' + target + '...');
+    events.emit('verbose', 'Starting application "' + activityName + '" on target ' + target + '...');
     return Adb.shell(target, 'am start -W -a android.intent.action.MAIN -n' + activityName)
     .catch(function (output) {
         return Q.reject(new CordovaError('Failed to start application "' +

--- a/bin/templates/cordova/lib/AndroidManifest.js
+++ b/bin/templates/cordova/lib/AndroidManifest.js
@@ -28,7 +28,7 @@ function AndroidManifest(path) {
     this.path = path;
     this.doc = xml.parseElementtreeSync(path);
     if (this.doc.getroot().tag !== 'manifest') {
-        throw new Error(path + ' has incorrect root node name (expected "manifest")');
+        throw new Error('AndroidManifest at ' + path + ' has incorrect root node name (expected "manifest")');
     }
 }
 

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -188,18 +188,18 @@ module.exports.detectArchitecture = function(target) {
             // adb kill-server doesn't seem to do the trick.
             // Could probably find a x-platform version of killall, but I'm not actually
             // sure that this scenario even happens on non-OSX machines.
+            events.emit('verbose', 'adb timed out while detecting device/emulator architecture. Killing adb and trying again.');
             return spawn('killall', ['adb'])
             .then(function() {
-                events.emit('verbose', 'adb seems hung. retrying.');
                 return helper()
                 .then(null, function() {
                     // The double kill is sadly often necessary, at least on mac.
-                    events.emit('warn', 'Now device not found... restarting adb again.');
+                    events.emit('warn', 'adb timed out a second time while detecting device/emulator architecture. Killing adb and trying again.');
                     return spawn('killall', ['adb'])
                     .then(function() {
                         return helper()
                         .then(null, function() {
-                            return Q.reject(new CordovaError('USB is flakey. Try unplugging & replugging the device.'));
+                            return Q.reject(new CordovaError('adb timed out a third time while detecting device/emulator architecture. Try unplugging & replugging the device.'));
                         });
                     });
                 });

--- a/bin/templates/cordova/lib/builders/AntBuilder.js
+++ b/bin/templates/cordova/lib/builders/AntBuilder.js
@@ -79,7 +79,7 @@ AntBuilder.prototype.prepEnv = function(opts) {
             writeBuildXml(path.join(self.root, subProjects[i]));
         }
         if (propertiesObj.systemLibs.length > 0) {
-            throw new CordovaError('Project contains at least one plugin that requires a system library. This is not supported with ANT. Please build using gradle.');
+            throw new CordovaError('Project contains at least one plugin that requires a system library. This is not supported with ANT. Use gradle instead.');
         }
 
         var propertiesFile = opts.buildType + SIGNING_PROPERTIES;

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -286,7 +286,7 @@ module.exports.create_image = function(name, target) {
         .then(function() {
             // TODO: This seems like another error case, even though it always happens.
             console.error('ERROR : Unable to create an avd emulator, no targets found.');
-            console.error('Please ensure you have targets available by running the "android" command');
+            console.error('Ensure you have targets available by running the "android" command');
             return Q.reject();
         }, function(error) {
             console.error('ERROR : Failed to create emulator image : ');

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -187,14 +187,14 @@ module.exports.start = function(emulator_ID, boot_timeout) {
             .unref();
 
         // wait for emulator to start
-        events.emit('log', 'Waiting for emulator...');
+        events.emit('log', 'Waiting for emulator to start...');
         return self.wait_for_emulator(uuid);
     }).then(function(emulatorId) {
         if (!emulatorId)
             return Q.reject(new CordovaError('Failed to start emulator'));
 
         //wait for emulator to boot up
-        process.stdout.write('Booting up emulator (this may take a while)...');
+        process.stdout.write('Waiting for emulator to boot (this may take a while)...');
         return self.wait_for_boot(emulatorId, boot_timeout)
         .then(function(success) {
             if (success) {
@@ -272,7 +272,7 @@ module.exports.wait_for_boot = function(emulator_id, time_remaining) {
  * Returns a promise.
  */
 module.exports.create_image = function(name, target) {
-    console.log('Creating avd named ' + name);
+    console.log('Creating new avd named ' + name);
     if (target) {
         return spawn('android', ['create', 'avd', '--name', name, '--target', target])
         .then(null, function(error) {
@@ -286,7 +286,7 @@ module.exports.create_image = function(name, target) {
         .then(function() {
             // TODO: This seems like another error case, even though it always happens.
             console.error('ERROR : Unable to create an avd emulator, no targets found.');
-            console.error('Please insure you have targets available by running the "android" command');
+            console.error('Please ensure you have targets available by running the "android" command');
             return Q.reject();
         }, function(error) {
             console.error('ERROR : Failed to create emulator image : ');
@@ -299,7 +299,7 @@ module.exports.resolveTarget = function(target) {
     return this.list_started()
     .then(function(emulator_list) {
         if (emulator_list.length < 1) {
-            return Q.reject('No started emulators found, please start an emultor before deploying your project.');
+            return Q.reject('No running Android emulators found, please start an emulator before deploying your project.');
         }
 
         // default emulator
@@ -392,8 +392,8 @@ module.exports.install = function(givenTarget, buildResults) {
                     if (!/INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES/.test(error.toString()))
                         throw error;
 
-                    events.emit('warn', 'Uninstalling app from device and reinstalling it again because the ' +
-                        'installed app already signed with different key');
+                    events.emit('warn', 'Uninstalling app from device and reinstalling it because the ' +
+                        'currently installed app was signed with different key');
 
                     // This promise is always resolved, even if 'adb uninstall' fails to uninstall app
                     // or the app doesn't installed at all, so no error catching needed.

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -205,13 +205,13 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
     var real_path = fs.realpathSync(src);
     var real_plugin_path = fs.realpathSync(plugin_dir);
     if (real_path.indexOf(real_plugin_path) !== 0)
-        throw new CordovaError('"' + src + '" not located within plugin!');
+        throw new CordovaError('File "' + src + '" is located outside the plugin directory "' + plugin_dir + '"');
 
     dest = path.resolve(project_dir, dest);
 
     // check that dest path is located in project directory
     if (dest.indexOf(project_dir) !== 0)
-        throw new CordovaError('"' + dest + '" not located within project!');
+        throw new CordovaError('Destination "' + dest + '" for source file "' + src + '" is located outside the project');
 
     shell.mkdir('-p', path.dirname(dest));
 

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -28,8 +28,8 @@ var CordovaError = require('cordova-common').CordovaError;
 var handlers = {
     'source-file':{
         install:function(obj, plugin, project, options) {
-            if (!obj.src) throw new CordovaError('<source-file> element is missing "src" attribute for plugin: ' + plugin.id);
-            if (!obj.targetDir) throw new CordovaError('<source-file> element is missing "target-dir" attribute for plugin: ' + plugin.id);
+            if (!obj.src) throw new CordovaError(generateAttributeError('src', 'source-file', plugin.id));
+            if (!obj.targetDir) throw new CordovaError(generateAttributeError('target-dir', 'source-file', plugin.id));
             var dest = path.join(obj.targetDir, path.basename(obj.src));
             if (options && options.force) {
                 copyFile(plugin.dir, obj.src, project.projectDir, dest, !!(options && options.link));
@@ -63,7 +63,7 @@ var handlers = {
     'framework': {
         install:function(obj, plugin, project, options) {
             var src = obj.src;
-            if (!src) throw new CordovaError('src not specified in <framework> for plugin: ' + plugin.id);
+            if (!src) throw new CordovaError(generateAttributeError('src', 'framework', plugin.id));
 
             events.emit('verbose', 'Installing Android library: ' + src);
             var parentDir = obj.parent ? path.resolve(project.projectDir, obj.parent) : project.projectDir;
@@ -88,7 +88,7 @@ var handlers = {
         },
         uninstall:function(obj, plugin, project, options) {
             var src = obj.src;
-            if (!src) throw new CordovaError('src not specified in <framework> for plugin: ' + plugin.id);
+            if (!src) throw new CordovaError(generateAttributeError('src', 'framework', plugin.id));
 
             events.emit('verbose', 'Uninstalling Android library: ' + src);
             var parentDir = obj.parent ? path.resolve(project.projectDir, obj.parent) : project.projectDir;
@@ -120,10 +120,10 @@ var handlers = {
     asset:{
         install:function(obj, plugin, project, options) {
             if (!obj.src) {
-                throw new CordovaError('<asset> tag without required "src" attribute. plugin=' + plugin.dir);
+                throw new CordovaError(generateAttributeError('src', 'asset', plugin.id));
             }
             if (!obj.target) {
-                throw new CordovaError('<asset> tag without required "target" attribute');
+                throw new CordovaError(generateAttributeError('target', 'asset', plugin.id));
             }
 
             copyFile(plugin.dir, obj.src, project.www, obj.target);
@@ -135,7 +135,7 @@ var handlers = {
         uninstall:function(obj, plugin, project, options) {
             var target = obj.target || obj.src;
 
-            if (!target) throw new CordovaError('<asset> tag without required "target" attribute');
+            if (!target) throw new CordovaError(generateAttributeError('target', 'asset', plugin.id));
 
             removeFileF(path.resolve(project.www, target));
             removeFileF(path.resolve(project.www, 'plugins', plugin.id));
@@ -269,4 +269,8 @@ function removeFileAndParents (baseDir, destFile, stopper) {
             break;
         }
     }
+}
+
+function generateAttributeError(attribute, element, id) {
+    return 'Required attribute "' + attribute + '" not specified in <' + element + '> element from plugin: ' + id;
 }

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -66,7 +66,7 @@ function getInstallTarget(runOptions) {
                     events.emit('warn', 'No target specified, deploying to device \'' + device_list[0] + '\'.');
                     install_target = device_list[0];
                 } else {
-                    events.emit('warn', 'No target specified, deploying to emulator');
+                    events.emit('warn', 'No target specified and no devices found, deploying to emulator');
                     install_target = '--emulator';
                 }
             });

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -61,7 +61,7 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersion) {
         highestBuildToolsVersion
     } else {
         throw new RuntimeException(
-            "No installed build tools found. Please install the Android build tools version " +
+            "No installed build tools found. Install the Android build tools version " +
             minBuildToolsVersion + " or higher.")
     }
 }

--- a/spec/unit/pluginHandlers/common.spec.js
+++ b/spec/unit/pluginHandlers/common.spec.js
@@ -47,8 +47,9 @@ describe('common platform handler', function() {
         it('should throw if src not in plugin directory', function(){
             shell.mkdir('-p', project_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
-            expect(function(){copyFile(test_dir, '../non_plugin_file', project_dir, dest);}).
-                toThrow(new Error('"' + non_plugin_file + '" not located within plugin!'));
+            var outside_file = '../non_plugin_file';
+            expect(function(){copyFile(test_dir, outside_file, project_dir, dest);}).
+                toThrow(new Error('File "' + path.resolve(test_dir, outside_file) + '" is located outside the plugin directory "' + test_dir + '"'));
             shell.rm('-rf', test_dir);
         });
 
@@ -75,7 +76,7 @@ describe('common platform handler', function() {
             }
 
             expect(function(){copyFile(test_dir, symlink_file, project_dir, dest);}).
-                toThrow(new Error('"' + symlink_file + '" not located within plugin!'));
+                toThrow(new Error('File "' + path.resolve(test_dir, symlink_file) + '" is located outside the plugin directory "' + test_dir + '"'));
             shell.rm('-rf', project_dir);
         });
 
@@ -83,7 +84,7 @@ describe('common platform handler', function() {
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
             expect(function(){copyFile(test_dir, java_file, project_dir, non_plugin_file);}).
-                toThrow(new Error('"' + non_plugin_file + '" not located within project!'));
+                toThrow(new Error('Destination "' + path.resolve(project_dir, non_plugin_file) + '" for source file "' + path.resolve(test_dir, java_file) + '" is located outside the project'));
             shell.rm('-rf', project_dir);
         });
 


### PR DESCRIPTION
Improving grammar, consistency of language, detail, etc. for verbose and regular output. I'm going to use Android as an example for Windows and iOS to follow. There wasn't much that was missing log-wise, mostly just needed to be clearer about what was happening. The changes in #295 will also improve output a lot (though they might conflict with this PR a bit). Also see https://github.com/apache/cordova-lib/pull/439