### PR TITLE
Changes for Cordova-Android 6.0.0 - Evaluate Javascript bridge as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 # under the License.
 #
 -->
+
+[![Build status](https://ci.appveyor.com/api/projects/status/github/apache/cordova-android?branch=master)](https://ci.appveyor.com/project/Humbedooh/cordova-android)
+[![Build Status](https://travis-ci.org/apache/cordova-android.svg?branch=master)](https://travis-ci.org/apache/cordova-android)
+
 # Cordova Android
 
 Cordova Android is an Android application library that allows for Cordova-based

--- a/bin/templates/project/assets/www/cordova.js
+++ b/bin/templates/project/assets/www/cordova.js
@@ -901,7 +901,7 @@ var cordova = require('cordova'),
         EVAL_BRIDGE: 3
     },
     jsToNativeBridgeMode,  // Set lazily.
-    nativeToJsBridgeMode = nativeToJsModes.ONLINE_EVENT,
+    nativeToJsBridgeMode = nativeToJsModes.EVAL_BRIDGE,
     pollEnabled = false,
     bridgeSecret = -1;
 

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -55,7 +55,7 @@ var cordova = require('cordova'),
         EVAL_BRIDGE: 3
     },
     jsToNativeBridgeMode,  // Set lazily.
-    nativeToJsBridgeMode = nativeToJsModes.ONLINE_EVENT,
+    nativeToJsBridgeMode = nativeToJsModes.EVAL_BRIDGE,
     pollEnabled = false,
     bridgeSecret = -1;
 

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -117,7 +117,8 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
                 SystemWebViewEngine.this.cordova.getActivity().runOnUiThread(r);
             }
         }));
-        bridge = new CordovaBridge(pluginManager, nativeToJsMessageQueue);
+        nativeToJsMessageQueue.addBridgeMode(new NativeToJsMessageQueue.EvalBridgeMode(this, cordova));
+	bridge = new CordovaBridge(pluginManager, nativeToJsMessageQueue);
         exposeJsInterface(webView, bridge);
     }
 


### PR DESCRIPTION
This is a change from our non-thread safe bridge to the thread-safe bridge.  This needs to be supported in Crosswalk for it to work properly.