### PR TITLE
Changes for Cordova-Android 6.0.0 - Android Modules as Plugins

### DIFF
--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -71,10 +71,16 @@ GradleBuilder.prototype.prepBuildFiles = function() {
     var subProjects = propertiesObj.libs;
     for (var i = 0; i < subProjects.length; ++i) {
         if (subProjects[i] !== 'CordovaLib') {
-            shell.cp('-f', pluginBuildGradle, path.join(this.root, subProjects[i], 'build.gradle'));
+            var subProjectGradle = path.join(this.root, subProjects[i], 'build.gradle');
+            // Only copy the gradle if it doesn't exist for the library
+            fs.exists(subProjectGradle, function(exists) {
+              if (!exists)
+                {
+                  shell.cp('-f', pluginBuildGradle, path.join(this.root, subProjects[i], 'build.gradle'));
+                }
+            });
         }
     }
-
     var name = this.extractRealProjectNameFromManifest();
     //Remove the proj.id/name- prefix from projects: https://issues.apache.org/jira/browse/CB-9149
     var settingsGradlePaths =  subProjects.map(function(p){

--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -99,10 +99,20 @@ GradleBuilder.prototype.prepBuildFiles = function() {
     // Update dependencies within build.gradle.
     var buildGradle = fs.readFileSync(path.join(this.root, 'build.gradle'), 'utf8');
     var depsList = '';
+    var insertExclude = function(libName) {
+        if(libName.indexOf("cordova-plugin") != -1) {
+          depsList += '{\n        exclude module:("CordovaLib")\n    }\n';
+        }
+        else {
+          depsList += "\n";
+        }
+    }
     subProjects.forEach(function(p) {
         var libName=p.replace(/[/\\]/g, ':').replace(name+'-','');
-        depsList += '    debugCompile project(path: "' + libName + '", configuration: "debug")\n';
-        depsList += '    releaseCompile project(path: "' + libName + '", configuration: "release")\n';
+        depsList += '    debugCompile(project(path: "' + libName + '", configuration: "debug"))';
+        insertExclude(libName);
+        depsList += '    releaseCompile(project(path: "' + libName + '", configuration: "release"))';
+        insertExclude(libName);
     });
     // For why we do this mapping: https://issues.apache.org/jira/browse/CB-8390
     var SYSTEM_LIBRARY_MAPPINGS = [

--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -71,11 +71,13 @@ GradleBuilder.prototype.prepBuildFiles = function() {
     var subProjects = propertiesObj.libs;
     var checkAndCopy = function(subProject, root) {
       var subProjectGradle = path.join(root, subProject, 'build.gradle');
-      fs.exists(subProject, function(exists) {
-        if (!exists) {
+      // This is the future-proof way of checking if a file exists
+      // This must be synchronous to satisfy a Travis test
+      try {
+          fs.accessSync(subProjectGradle, fs.F_OK);
+      } catch (e) {
           shell.cp('-f', pluginBuildGradle, subProjectGradle);
-        }
-      });
+      }
     };
     for (var i = 0; i < subProjects.length; ++i) {
         if (subProjects[i] !== 'CordovaLib') {

--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -21,24 +21,15 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the
     // installed version of Gradle. This dependency is documented at
     // http://tools.android.com/tech-docs/new-build-system/version-compatibility
     // and https://issues.apache.org/jira/browse/CB-8143
-    if (gradle.gradleVersion >= "2.2") {
-        dependencies {
-            classpath 'com.android.tools.build:gradle:1.0.0+'
-        }
-    } else if (gradle.gradleVersion >= "2.1") {
-        dependencies {
-            classpath 'com.android.tools.build:gradle:0.14.0+'
-        }
-    } else {
-        dependencies {
-            classpath 'com.android.tools.build:gradle:0.12.0+'
-        }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.0.0+'
     }
 }
 


### PR DESCRIPTION
Redoing this branch as gradle_respect, where we don't nuke the gradle files of AARs, Library Projects and other things that have gradle files.  This should resolve a lot of irritating errors, but slows down plugin installation with file checks. :/

We do need a better solution to this, but it would require a refactor of how we do builds.