### PR TITLE
older android fix (v2.3.6)

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -37,10 +37,9 @@ class SystemCookieManager implements ICordovaCookieManager {
         webView = webview;
         cookieManager = CookieManager.getInstance();
 
-        //REALLY? Nobody has seen this UNTIL NOW?
-        cookieManager.setAcceptFileSchemeCookies(true);
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            //REALLY? Nobody has seen this UNTIL NOW?
+            cookieManager.setAcceptFileSchemeCookies(true);
             cookieManager.setAcceptThirdPartyCookies(webView, true);
         }
     }


### PR DESCRIPTION
I was playing around with my old android phone (v2.3.6), which did seem to install fine.
However, the app wouldn't launch.
`adb logcat` printed a nullpointerexception, which i fixed in this commit.
I also noticed more people had the same issue on stackoverflow, so i posted the patch there as well: 

http://stackoverflow.com/questions/19350062/java-lang-nosuchmethoderror-android-webkit-cookiemanager-setacceptfileschemecoo/39671863#39671863

The `// REALLY`-comment above the`setAcceptFileSchemeCookies`-call might indicate a bugfix which wasn't tested on older devices.
