### PR TITLE
CB-11935 Call onPause & onResume on WebView

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -315,8 +315,10 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
     @Override
     public void setPaused(boolean value) {
         if (value) {
+            webView.onPause();
             webView.pauseTimers();
         } else {
+            webView.onResume();
             webView.resumeTimers();
         }
     }


### PR DESCRIPTION
Does a best-effort attempt to pause any processing that can be paused safely, such as animations and geolocation.
Fix the potential rejection from Play Store