### PR TITLE
CB-12077: Fix paths for Android icons/splashscreens

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -66,7 +66,7 @@ function Api(platform, platformRootDir, events) {
     this.locations = {
         root: self.root,
         www: path.join(self.root, 'assets/www'),
-        res: path.relative(self.root, path.join(self.root, 'res')),
+        res: path.join(self.root, 'res'),
         platformWww: path.join(self.root, 'platform_www'),
         configXml: path.join(self.root, 'res/xml/config.xml'),
         defaultConfigXml: path.join(self.root, 'cordova/defaults.xml'),
@@ -85,7 +85,7 @@ function Api(platform, platformRootDir, events) {
       this.locations.strings = path.join(self.root, 'app/src/main/res/xml/strings.xml');
       this.locations.manifest = path.join(self.root, 'app/src/main/AndroidManifest.xml');
       this.locations.www = path.join(self.root, 'app/src/main/assets/www');
-      this.locations.res = path.relative(self.root, path.join(self.root, 'app/src/main/res'));
+      this.locations.res = path.join(self.root, 'app/src/main/res');
     }
 }
 

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -46,8 +46,8 @@ module.exports.prepare = function (cordovaProject, options) {
         return updateProjectAccordingTo(self._config, self.locations);
     })
     .then(function () {
-        updateIcons(cordovaProject, self.locations.res);
-        updateSplashes(cordovaProject, self.locations.res);
+        updateIcons(cordovaProject, path.relative(cordovaProject.root, self.locations.res));
+        updateSplashes(cordovaProject, path.relative(cordovaProject.root, self.locations.res));
     })
     .then(function () {
         events.emit('verbose', 'Prepared android project successfully');
@@ -70,8 +70,8 @@ module.exports.clean = function (options) {
     var self = this;
     return Q().then(function () {
         cleanWww(projectRoot, self.locations);
-        cleanIcons(projectRoot, projectConfig, self.locations.res);
-        cleanSplashes(projectRoot, projectConfig, self.locations.res);
+        cleanIcons(projectRoot, projectConfig, path.relative(projectRoot, self.locations.res));
+        cleanSplashes(projectRoot, projectConfig, path.relative(projectRoot, self.locations.res));
     });
 };
 


### PR DESCRIPTION
### Platforms affected

Android
### What does this PR do?

Fix icons and splashscreens defined in config.xml copying into the project to override the default Cordova ones.
### What testing has been done on this change?

Tested locally with cordova-cli
