### PR TITLE
CB-12101: Spot fix to go into next patch release

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -244,7 +244,8 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
             // Skip cleaning prepared files when not invoking via cordova CLI.
             opts.noPrepare = true;
 
-            return self.clean(opts);
+            if(!(AndroidStudio.isAndroidStudioProject(self.root)))
+              return self.clean(opts);
         })
        .then(function () {
             return PluginManager.get(self.platform, self.locations, project)


### PR DESCRIPTION
This fixes an Android Studio workflow so that we don't do gradle cleans when we use Android Studio.