### PR TITLE
CB-12111: rewrite to use retro js

### DIFF
--- a/bin/templates/cordova/lib/AndroidStudio.js
+++ b/bin/templates/cordova/lib/AndroidStudio.js
@@ -4,26 +4,33 @@
  *  @param {String} root Root folder of the project
  */
 
-/*jshint esversion: 6 */
+/*jshint esnext: false */
 
 var path = require('path');
 var fs = require('fs');
 
-function isAndroidStudioProject(root) {
+module.exports.isAndroidStudioProject = function isAndroidStudioProject(root) {
     var eclipseFiles = ['AndroidManifest.xml', 'libs', 'res', 'project.properties', 'platform_www'];
     var androidStudioFiles = ['app', 'gradle', 'build', 'app/src/main/assets'];
-    var file;
-    for(file of eclipseFiles) {
-      if(fs.existsSync(path.join(root, file))) {
-        return false;
-      }
-    }
-    for(file of androidStudioFiles) {
-      if(!fs.existsSync(path.join(root, file))) {
-        return false;
-      }
-    }
-    return true;
-}
 
-module.exports.isAndroidStudioProject = isAndroidStudioProject;
+    // assume it is an AS project and not an Eclipse project
+    var isEclipse = false;
+    var isAS = true;
+
+    // if any of the following exists, then we are not an ASProj
+    eclipseFiles.forEach(function(file) {
+        if(fs.existsSync(path.join(root, file))) {
+            isEclipse = true;
+        }
+    });
+
+    // if it is NOT an eclipse project, check that all required files exist
+    if(!isEclipse) {
+        androidStudioFiles.forEach(function(file){
+            if(!fs.existsSync(path.join(root, file))) {
+                isAS = false;
+            }
+        });
+    }
+    return (!isEclipse && isAS);
+};


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
fixes JS tooling so it will still run in node v0.10 + v0.12

### What testing has been done on this change?
npm test + jshint on the affected file

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

