### PR TITLE
CB-12291: (android) Add x86_64, arm64 and armeabi architecture flavors

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -181,21 +181,34 @@ android {
 
     if (Boolean.valueOf(cdvBuildMultipleApks)) {
         productFlavors {
+            armeabi {
+                versionCode defaultConfig.versionCode*10 + 1
+                ndk {
+                    abiFilters = ["armeabi"]
+                }
+            }
             armv7 {
                 versionCode defaultConfig.versionCode*10 + 2
                 ndk {
-                    abiFilters "armeabi-v7a", ""
+                    abiFilters = ["armeabi-v7a"]
+                }
+            }
+            arm64 {
+                versionCode defaultConfig.versionCode*10 + 3
+                ndk {
+                    abiFilters = ["arm64-v8a"]
                 }
             }
             x86 {
                 versionCode defaultConfig.versionCode*10 + 4
                 ndk {
-                    abiFilters "x86", ""
+                    abiFilters = ["x86"]
                 }
             }
-            all {
+            x86_64 {
+                versionCode defaultConfig.versionCode*10 + 5
                 ndk {
-                    abiFilters "all", ""
+                    abiFilters = ["x86_64"]
                 }
             }
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android

### What does this PR do?
Add `armeabi`, `arm64-v8a` and `x86_64`

### What testing has been done on this change?
Built and checked for existence of the native libraries in the resulting `.apk`s using `--gradleArg=-PcdvBuildMultipleApks=true` and `--gradleArg=-PcdvBuildArch=<arch>` with `armeabi`, `arm`, `arm64`, `x86`, `x86_64` on a project having https://github.com/couchbaselabs/Couchbase-Lite-PhoneGap-Plugin installed.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change. *I'm not sure what tests to add and whether they're necessary so I'm checking this item.*

fixes https://issues.apache.org/jira/browse/CB-12291