### PR TITLE
CB-12099 (android) SplashScreen Screen Flicker

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -30,6 +30,10 @@ var FileUpdater = require('cordova-common').FileUpdater;
 var PlatformJson = require('cordova-common').PlatformJson;
 var PlatformMunger = require('cordova-common').ConfigChanges.PlatformMunger;
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
+var semver = require('semver');
+
+var SPLASH_SCREEN_PLUGIN_ID = 'cordova-plugin-splashscreen';
+var SPLASH_SCREEN_BG_COLOR_PLUGIN_MIN_VERSION = '4.1.0';
 
 module.exports.prepare = function (cordovaProject, options) {
     var self = this;
@@ -170,6 +174,33 @@ function updateProjectAccordingTo(platformConfig, locations) {
     var name = platformConfig.name();
     var strings = xmlHelpers.parseElementtreeSync(locations.strings);
     strings.find('string[@name="app_name"]').text = name.replace(/\'/g, '\\\'');
+
+    // Update SplashScreenBackgroundColor:
+    var splashBgColor = platformConfig.getPreference('SplashScreenBackgroundColor', 'android');
+    // Fallback to BackgroundColor, then to BLACK for backwards compatibility:
+    splashBgColor = splashBgColor || (platformConfig.getPreference('BackgroundColor', 'android') || '#ff000000');
+    splashBgColor = splashBgColor.replace('0x', '#').replace('0X', '#');
+    strings.find('color[@name="splash_background_color"]').text = splashBgColor;
+
+    // Handle project upgrade case when we have new platform and older plugin version:
+    var plugins = (new PluginInfoProvider()).getAllWithinSearchPath(path.join(locations.root, '../../plugins'));
+    var splashScreenPluginInfo = plugins.filter(function(pluginInfo) {
+        return pluginInfo.id === SPLASH_SCREEN_PLUGIN_ID;
+    })[0];
+
+    if (splashScreenPluginInfo) {
+        if (platformConfig.getPreference('SplashScreenBackgroundColor', 'android') &&
+            semver.lt(splashScreenPluginInfo.version && splashScreenPluginInfo.version.replace('-dev', ''), SPLASH_SCREEN_BG_COLOR_PLUGIN_MIN_VERSION)) {
+            events.emit('warn', 'Install cordova-plugin-splashscreen@' + SPLASH_SCREEN_BG_COLOR_PLUGIN_MIN_VERSION +
+                ' or later supporting new \'SplashScreenBackgroundColor\'\n' +
+                'preference to avoid color change on app startup.\n' +
+                'Current Splash Screen plugin version is ' + splashScreenPluginInfo.version + '\n' +
+                'Alternatively you can set \'BackgroundColor\' to the value set in \'SplashScreenBackgroundColor\'.');
+        }
+    } else {
+        events.emit('warn', 'Install cordova-plugin-splashscreen to avoid flicker issues on app startup.');
+    }
+
     fs.writeFileSync(locations.strings, strings.write({indent: 4}), 'utf-8');
     events.emit('verbose', 'Wrote out android application name "' + name + '" to ' + locations.strings);
 

--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <activity android:name="__ACTIVITY__"
                 android:label="@string/activity_name"
                 android:launchMode="singleTop"
-                android:theme="@android:style/Theme.DeviceDefault.NoActionBar"
+                android:theme="@style/SplashTheme"
                 android:windowSoftInputMode="adjustResize"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale">
             <intent-filter android:label="@string/launcher_name">

--- a/bin/templates/project/res/drawable/splash_layout.xml
+++ b/bin/templates/project/res/drawable/splash_layout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+            <solid android:color="@color/splash_background_color" />
+        </shape>
+    </item>
+    <item android:top="24dip">
+        <bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+            android:gravity="fill" android:src="@drawable/screen" />
+    </item>
+</layer-list>

--- a/bin/templates/project/res/values/strings.xml
+++ b/bin/templates/project/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="launcher_name">@string/app_name</string>
     <!-- App label shown on the task switcher. -->
     <string name="activity_name">@string/launcher_name</string>
+    <color name="splash_background_color">#ffc8c8c8</color>
+    <style name="SplashTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_layout</item>
+    </style>
 </resources>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "nopt": "^3.0.1",
     "properties-parser": "^0.2.3",
     "q": "^1.4.1",
-    "shelljs": "^0.5.3"
+    "shelljs": "^0.5.3",
+    "semver": "^5.0.1"
   },
   "bundledDependencies": [
     "cordova-common",
@@ -37,7 +38,8 @@
     "nopt",
     "properties-parser",
     "q",
-    "shelljs"
+    "shelljs",
+    "semver"
   ],
   "devDependencies": {
     "istanbul": "^0.4.2",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Introduced new SplashScreenBackgroundColor preference.
Platform will now use it or BackgroundColor or BLACK color as Activity.windowBackground to avoid black flash on start.
Added semver to dependencies (taken bundled version from common, so bundle change isn't required).

### What testing has been done on this change?
Manual and auto tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
