### PR TITLE
The CoreAndroid's loadUrl method should load web pages in the UI thread

### DIFF
--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -201,7 +201,17 @@ public class CoreAndroid extends CordovaPlugin {
                 e.printStackTrace();
             }
         }
-        this.webView.showWebPage(url, openExternal, clearHistory, params);
+
+        // The showWebPage should run in UI thread so it can access the webView for operations like clearHistory and loadUrl
+        final String destUrl = url;
+        final boolean external = openExternal;
+        final boolean clearHis = clearHistory;
+        final HashMap<String, Object> destParams = params;
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                webView.showWebPage(destUrl, external, clearHis, destParams);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Upate CoreAndroid's loadUrl method to load web pages in the UI thread

### What testing has been done on this change?
Built and run the generated application, calling {color:red}navigator.app.loadUrl('http://domain.com', { "clearHistory": true}){color} , verify that there is not more errors and navigation can be made successfully.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-12421: The CoreAndroid's loadUrl method should load web pages in the UI thread"
- [x] Added automated test coverage as appropriate for this change. (don't know how?)
