### PR TITLE
Update create.js

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -226,7 +226,7 @@ exports.create = function(project_path, config, options, events) {
         return Q.reject(new CordovaError('Project already exists! Delete and recreate'));
     }
 
-    var package_name = config.packageName() || 'my.cordova.project';
+    var package_name = config.android_packageName() || config.packageName() || 'my.cordova.project';
     var project_name = config.name() ?
         config.name().replace(/[^\w.]/g,'_') : 'CordovaExample';
 


### PR DESCRIPTION
Use android packageName to create project when it's different from the packageName ("id" in config.xml)

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
