### PR TITLE
CB-8348: (android) Add the ability to publish to Bintray jCenter Maven repository

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,6 +31,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -16,27 +16,30 @@
    under the License.
 */
 
-
-
 buildscript {
     repositories {
         mavenCentral()
-        jcenter();
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
-
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
 
 ext {
     apply from: 'cordova.gradle'
     cdvCompileSdkVersion = privateHelpers.getProjectTarget()
     cdvBuildToolsVersion = privateHelpers.findLatestInstalledBuildTools()
 }
+
+group = 'org.apache.cordova'
+version = '6.1.0'
 
 android {
     compileSdkVersion cdvCompileSdkVersion
@@ -57,6 +60,73 @@ android {
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/NOTICE'
+    }
+}
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging 'aar'
+                name 'Cordova'
+                url 'https://cordova.apache.org'
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'shazron'
+                        name 'Shazron Abdullah'
+                    }
+                }
+                scm {
+                    connection 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
+                    developerConnection 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
+                    url 'https://git-wip-us.apache.org/repos/asf?p=cordova-android'
+
+                }
+            }
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+artifacts {
+    archives sourcesJar
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    configurations = ['archives']
+    pkg {
+        name = 'cordova'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
+        websiteUrl = 'https://cordova.apache.org'
+        issueTrackerUrl = 'https://issues.apache.org/jira/browse/CB'
+        publicDownloadNumbers = true
+        licenses = ['Apache-2.0']
+        labels = ['android', 'cordova', 'phonegap']
+        version {
+            name = '6.1.0'
+            released  = new Date()
+            vcsTag = '6.1.0'
         }
     }
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -16,6 +16,12 @@
    under the License.
 */
 
+ext {
+    apply from: 'cordova.gradle'
+    cdvCompileSdkVersion = privateHelpers.getProjectTarget()
+    cdvBuildToolsVersion = privateHelpers.findLatestInstalledBuildTools()
+}
+
 buildscript {
     repositories {
         mavenCentral()
@@ -31,12 +37,6 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
-
-ext {
-    apply from: 'cordova.gradle'
-    cdvCompileSdkVersion = privateHelpers.getProjectTarget()
-    cdvBuildToolsVersion = privateHelpers.findLatestInstalledBuildTools()
-}
 
 group = 'org.apache.cordova'
 version = '6.1.0'
@@ -86,8 +86,8 @@ install {
                 }
                 developers {
                     developer {
-                        id 'shazron'
-                        name 'Shazron Abdullah'
+                        id 'stevengill'
+                        name 'Steve Gill'
                     }
                 }
                 scm {
@@ -115,7 +115,9 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
     configurations = ['archives']
     pkg {
-        name = 'cordova'
+        repo = 'maven'
+        name = 'cordova-android'
+        userOrg = 'cordova'
         licenses = ['Apache-2.0']
         vcsUrl = 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
         websiteUrl = 'https://cordova.apache.org'


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Adds support for publishing the `Cordova` platform on `jCenter`, so that applications can consume `Cordova` by specifying as a one line dependency in `build.gradle`.

### What testing has been done on this change?
Tested by publishing to my local `Maven` repo and consuming it in my application.

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-8348) in the JIRA database.
- [x] Commit message follows the format: "CB-8348: (android) Add the ability to publish to Bintray jCenter Maven repository".
- [x] Added automated test coverage as appropriate for this change.
