### PR TITLE
CB-12453: Remove unnecessary double quotes from .bat files which are the causes of crash if project path contains spaces

### DIFF
--- a/bin/android_sdk_version.bat
+++ b/bin/android_sdk_version.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0android_sdk_version"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'android_sdk_version' script in 'bin' folder, aborting...>&2

--- a/bin/check_reqs.bat
+++ b/bin/check_reqs.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0check_reqs"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'check_reqs' script in 'bin' folder, aborting...>&2

--- a/bin/templates/cordova/lib/install-device.bat
+++ b/bin/templates/cordova/lib/install-device.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0install-device"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'install-device' script in 'cordova\lib' folder, aborting...>&2

--- a/bin/templates/cordova/lib/install-emulator.bat
+++ b/bin/templates/cordova/lib/install-emulator.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0install-emulator"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'install-emulator' script in 'cordova\lib' folder, aborting...>&2

--- a/bin/templates/cordova/lib/list-devices.bat
+++ b/bin/templates/cordova/lib/list-devices.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0list-devices"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'list-devices' script in 'cordova\lib' folder, aborting...>&2

--- a/bin/templates/cordova/lib/list-emulator-images.bat
+++ b/bin/templates/cordova/lib/list-emulator-images.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0list-emulator-images"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO. 
     ECHO ERROR: Could not find 'list-emulator-images' script in 'cordova\lib' folder, aborting...>&2

--- a/bin/templates/cordova/lib/list-started-emulators.bat
+++ b/bin/templates/cordova/lib/list-started-emulators.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0list-started-emulators"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'list-started-emulators' script in 'cordova\lib' folder, aborting...>&2

--- a/bin/templates/cordova/lib/start-emulator.bat
+++ b/bin/templates/cordova/lib/start-emulator.bat
@@ -18,7 +18,7 @@
 @ECHO OFF
 SET script_path="%~dp0start-emulator"
 IF EXIST %script_path% (
-        node "%script_path%" %*
+        node %script_path% %*
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find 'start-emulator' script in 'cordova\lib' folder, aborting...>&2

--- a/spec/e2e/helpers/projectActions.js
+++ b/spec/e2e/helpers/projectActions.js
@@ -45,7 +45,7 @@ module.exports.createProject = function (projectname, projectid, platformpath, c
     module.exports.removeProject(projectid);
 
     // create the project
-    var command = util.format('%s %s %s "%s"', createScriptPath, projectDirName, projectid, projectname);
+    var command = util.format('"%s" %s %s "%s"', createScriptPath, projectDirName, projectid, projectname);
     cp.exec(command, function (error, stdout, stderr) {
         if (error) {
             console.log(stdout);
@@ -69,8 +69,7 @@ module.exports.updateProject = function (projectid, platformpath, callback) {
     }
     var projectDirName = getDirName(projectid);
     var updateScriptPath = platformpath ? path.join(platformpath, 'bin/update') : path.join(cordova_bin, 'update');
-    var command = util.format('%s %s', updateScriptPath, projectDirName);
-
+    var command = util.format('"%s" %s', updateScriptPath, projectDirName);
     cp.exec(command, function (error, stdout, stderr) {
         if (error) {
             console.log(stdout);


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
self

### What does this PR do?
This PR fixes bug with crash if project path contains spaces

### What testing has been done on this change?
Current auto-tests don't work if project path contains spaces, this PR fixes it

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
