### PR TITLE
CB-12595: Fix Android Studio Detection (may need refactoring)

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -95,10 +95,31 @@ module.exports.check_ant = function() {
 
 module.exports.get_gradle_wrapper = function() {
     var androidStudioPath;
+    var i = 0;
+    var foundStudio = false;
+    var program_dir;
     if (module.exports.isDarwin()) {
-        androidStudioPath = path.join('/Applications', 'Android Studio.app', 'Contents', 'gradle');
+        program_dir = fs.readdirSync('/Applications');
+        while(i < program_dir.length && !foundStudio) {
+          if(program_dir[i].startsWith('Android Studio')) {
+            //TODO: Check for a specific Android Studio version, make sure it's not Canary
+            androidStudioPath = path.join('/Applications', program_dir[i], 'Contents', 'gradle');
+            foundStudio = true;
+          } else { ++i; }
+        }
     } else if (module.exports.isWindows()) {
-        androidStudioPath = path.join(process.env['ProgramFiles'],'Android', 'Android Studio', 'gradle');
+    var androidPath = path.join(process.env['ProgramFiles'], 'Android');
+        program_dir = fs.readdirSync(androidPath + '/');
+    console.log(path.join(process.env['ProgramFiles'], 'Android'));
+        while(i < program_dir.length && !foundStudio) {
+      console.log(program_dir[i]);
+          if(program_dir[i].startsWith('Android Studio')) {
+            foundStudio = true;
+            androidStudioPath = path.join(process.env['ProgramFiles'],'Android', program_dir[i], 'gradle');
+        console.log(androidStudioPath);
+          }
+          else { ++i; }
+        }
     }
 
     if (androidStudioPath !== null && fs.existsSync(androidStudioPath)) {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -110,13 +110,10 @@ module.exports.get_gradle_wrapper = function() {
     } else if (module.exports.isWindows()) {
     var androidPath = path.join(process.env['ProgramFiles'], 'Android');
         program_dir = fs.readdirSync(androidPath + '/');
-    console.log(path.join(process.env['ProgramFiles'], 'Android'));
         while(i < program_dir.length && !foundStudio) {
-      console.log(program_dir[i]);
           if(program_dir[i].startsWith('Android Studio')) {
             foundStudio = true;
             androidStudioPath = path.join(process.env['ProgramFiles'],'Android', program_dir[i], 'gradle');
-        console.log(androidStudioPath);
           }
           else { ++i; }
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Allows for the installation of multiple versions of Android Studio on a system without breaking the Cordova Build.

### What testing has been done on this change?
Tested it on local machine.  This is a critical fix for CB-12524 after realizing that future Android Studio versions will break that fix.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
