### PR TITLE
CB-12646: Fix the parsing `android` command ouput message

### DIFF
--- a/bin/templates/cordova/lib/android_sdk.js
+++ b/bin/templates/cordova/lib/android_sdk.js
@@ -122,7 +122,7 @@ module.exports.list_targets = function() {
     .catch(function(err) {
         // there's a chance `android` no longer works.
         // lets see if `sdkmanager` is available and we can figure it out
-        var avail_regex = /"?android"? command is no longer available/;
+        var avail_regex = /"?android"? command is ((no longer available)|(deprecated))?/;
         if (err.code && ((err.stdout && err.stdout.match(avail_regex)) || (err.stderr && err.stderr.match(avail_regex)))) {
             return module.exports.list_targets_with_sdkmanager();
         } else throw err;

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -177,7 +177,8 @@ module.exports.list_images = function() {
             // try to use `avdmanager` in case `android` reports it is no longer available.
             // this likely means the target machine is using a newer version of
             // the android sdk, and possibly `avdmanager` is available.
-            if (err.code == 1 && err.stdout.indexOf('android command is no longer available')) {
+            var avail_regex = /"?android"? command is ((no longer available)|(deprecated))?/;
+            if (err.code == 1 && err.stdout.match(avail_regex)) {
                 return module.exports.list_images_using_avdmanager();
             } else {
                 throw err;

--- a/spec/unit/android_sdk.spec.js
+++ b/spec/unit/android_sdk.spec.js
@@ -105,6 +105,23 @@ describe("android_sdk", function () {
                 done();
             });
         });
+        it("should parse Android SDK installed target information with `avdmanager` command if list_targets_with_android fails due to `android` command being deprecated", function(done) {
+            var deferred = Q.defer();
+            spyOn(android_sdk, "list_targets_with_android").and.returnValue(deferred.promise);
+            deferred.reject({
+                code: 1,
+                stdout: "The \"android\" command is deprecated."
+            });
+            var twoferred = Q.defer();
+            twoferred.resolve(["target1"]);
+            var sdkmanager_spy = spyOn(android_sdk, "list_targets_with_sdkmanager").and.returnValue(twoferred.promise);
+            return android_sdk.list_targets()
+            .then(function(targets) {
+                expect(sdkmanager_spy).toHaveBeenCalled();
+                expect(targets[0]).toEqual("target1");
+                done();
+            });
+        });
         it("should throw an error if no Android targets were found.", function(done) {
             var deferred = Q.defer();
             spyOn(android_sdk, "list_targets_with_android").and.returnValue(deferred.promise);


### PR DESCRIPTION
### Platforms affected

Cordova Android 6.2.0 above

### What does this PR do?

Add a regular express for parsing the output message from `android` command since [Android SDK tool 26.0.0](https://developer.android.com/studio/releases/sdk-tools.html)

### What testing has been done on this change?

Add the testing case with output message from `android` command since Android SDK tool 26.0.0

### Checklist
- [X] Issue: CB-12646
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
