### PR TITLE
Fix for CB-12015: initial-scale values less than 1.0 are ignored on Android

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -210,6 +210,11 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         settings.setAppCachePath(databasePath);
         settings.setAppCacheEnabled(true);
 
+        // Enable scaling
+        // Fix for CB-12015
+        settings.setUseWideViewPort(true);
+        settings.setLoadWithOverviewMode(true);
+
         // Fix for CB-1405
         // Google issue 4641
         String defaultUserAgent = settings.getUserAgentString();


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Fixed an issue where the meta tag viewport is ignored if scaling is less than 1.0.

### What testing has been done on this change?

I tested it on a couple of devices running Android 5.0 and 6.0.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
