### PR TITLE
CB-8980: Ensure copied resource-files are cleaned

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -426,7 +426,7 @@ function updateFileResources(cordovaProject, platformDir) {
 
 
 function cleanFileResources(projectRoot, projectConfig, platformDir) {
-    var files = projectConfig.getFileResources('android');
+    var files = projectConfig.getFileResources('android', true);
     if (files.length > 0) {
         events.emit('verbose', 'Cleaning resource files at ' + platformDir);
 


### PR DESCRIPTION
Requires https://github.com/apache/cordova-lib/pull/547 for the intended functionality, but is safe to merge even without it.

Addresses the point 1 of https://github.com/apache/cordova-android/pull/321#issuecomment-294985346 where `resource-file` targets were not getting cleaned.