### PR TITLE
CB-12762 : pointed package.json repo items to github mirrors instead …

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "bin/templates/cordova/Api.js",
   "repository": {
     "type": "git",
-    "url": "https://git-wip-us.apache.org/repos/asf/cordova-android.git"
+    "url": "https://github.com/apache/cordova-android"
   },
   "bugs": {
     "url": "https://issues.apache.org/jira/browse/CB"


### PR DESCRIPTION
…of apache repos site

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Pointed package.json repo items to github mirrors instead of apache repos site.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
