### PR TITLE
CB-12835: add a Context getter in CordovaInterface

### DIFF
--- a/framework/src/org/apache/cordova/CordovaInterface.java
+++ b/framework/src/org/apache/cordova/CordovaInterface.java
@@ -19,6 +19,7 @@
 package org.apache.cordova;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import org.apache.cordova.CordovaPlugin;
@@ -51,10 +52,18 @@ public interface CordovaInterface {
     /**
      * Get the Android activity.
      *
+     * If a custom engine lives outside of the Activity's lifecycle the return value may be null.
+     *
      * @return the Activity
      */
     public abstract Activity getActivity();
-    
+
+    /**
+     * Get the Android context.
+     *
+     * @return the Context
+     */
+    public Context getContext();
 
     /**
      * Called when a message is sent to plugin.

--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -20,6 +20,7 @@
 package org.apache.cordova;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -81,6 +82,11 @@ public class CordovaInterfaceImpl implements CordovaInterface {
 
     @Override
     public Activity getActivity() {
+        return activity;
+    }
+
+    @Override
+    public Context getContext() {
         return activity;
     }
 


### PR DESCRIPTION
A custom engine may live outside of the Activity's lifecycle and the
Activity instance may not always be available. This getter allows
Context accesses in all cases.
