### PR TITLE
CB-12605 In Windows get Android studio path from the registry

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -108,15 +108,28 @@ module.exports.get_gradle_wrapper = function() {
             } else { ++i; }
         }
     } else if (module.exports.isWindows()) {
-        var androidPath = path.join(process.env['ProgramFiles'], 'Android') + '/';
-        if (fs.existsSync(androidPath)) {
-            program_dir = fs.readdirSync(androidPath);
-            while (i < program_dir.length && !foundStudio) {
-                if (program_dir[i].startsWith('Android Studio')) {
-                    foundStudio = true;
-                    androidStudioPath = path.join(process.env['ProgramFiles'], 'Android', program_dir[i], 'gradle');
-                } else { ++i; }
+    
+        var result = child_process.spawnSync(path.join(__dirname,'getASPath.bat'));
+        //console.log('result.stdout =' + result.stdout.toString());
+        //console.log('result.stderr =' + result.stderr.toString());
+
+        if(result.stderr.toString().length > 0) {
+            var androidPath = path.join(process.env['ProgramFiles'], 'Android') + '/';
+            if (fs.existsSync(androidPath)) {
+                program_dir = fs.readdirSync(androidPath);
+                while (i < program_dir.length && !foundStudio) {
+                    if (program_dir[i].startsWith('Android Studio')) {
+                        foundStudio = true;
+                        androidStudioPath = path.join(process.env['ProgramFiles'], 'Android', program_dir[i], 'gradle');
+                    } else { ++i; }
+                }
             }
+        }
+        else {
+            // console.log('got android studio path from registry');
+            // remove the (os independent) new line char at the end of stdout
+            // add gradle to match the above.
+            androidStudioPath = path.join(result.stdout.toString().split('\r\n')[0],'gradle');
         }
     }
 

--- a/bin/templates/cordova/lib/getASPath.bat
+++ b/bin/templates/cordova/lib/getASPath.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+for /f "tokens=2*" %%a in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Android Studio" /v Path') do set "ASPath=%%~b"
+ECHO %ASPath%


### PR DESCRIPTION
### Platforms affected
Android on windows

### What does this PR do?
Allows installs of Android Studio in places other than C://

### What testing has been done on this change?
Tested with and without registry value present

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
