### PR TITLE
CB-12423: make explicit JDK 1.8 or greater is needed in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ at the core, applications written with web technology: HTML, CSS and JavaScript.
 
 ## Requires
 
-- Java JDK 1.6 or greater
+- Java JDK 1.8 or greater
 - Android SDK [http://developer.android.com](http://developer.android.com)
 
 


### PR DESCRIPTION
Lining it up with https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#installing-the-requirements

As per https://issues.apache.org/jira/browse/CB-12423