### PR TITLE
CB-12677: (android) added option for explicitly specifying path to An…

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -99,7 +99,12 @@ module.exports.get_gradle_wrapper = function () {
     var i = 0;
     var foundStudio = false;
     var program_dir;
-    if (module.exports.isDarwin()) {
+    // CB-12677: check if Android Studio path was explicitly set via environment variable
+    if (process.env['ANDROID_STUDIO_HOME']) {
+
+        androidStudioPath = path.join(process.env['ANDROID_STUDIO_HOME'], 'gradle');
+
+    } else if (module.exports.isDarwin()) {
         program_dir = fs.readdirSync('/Applications');
         while (i < program_dir.length && !foundStudio) {
             if (program_dir[i].startsWith('Android Studio')) {
@@ -157,7 +162,8 @@ module.exports.check_gradle = function () {
     if (gradlePath.length !== 0) { d.resolve(gradlePath); } else {
         d.reject(new CordovaError('Could not find an installed version of Gradle either in Android Studio,\n' +
                                 'or on your system to install the gradle wrapper. Please include gradle \n' +
-                                'in your path, or install Android Studio'));
+                                'in your path, or install Android Studio, or set up \'ANDROID_STUDIO_HOME\'\n' +
+                                'env variable.'));
     }
     return d.promise;
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android

### What does this PR do?
Adds the option for explicitly specifying the path to Android Studio via env variable.

Automatic detection of the _Android Studio_ path currently only works, if it is installed in the default location.

The option to specify the path via an env variable offers a simple solution, in cases where automatic detection does not work.

This solution relates to [issue & discussion CB-12677](https://issues.apache.org/jira/browse/CB-12677).

### What testing has been done on this change?
manually tested

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
