### PR TITLE
CB-13031: Fix bug with case-sensitivity of android-packageName

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -247,7 +247,7 @@ exports.create = function (project_path, config, options, events) {
         return Q.reject(new CordovaError('Project already exists! Delete and recreate'));
     }
 
-    var package_name = config.packageName() || 'my.cordova.project';
+    var package_name = config.android_packageName() || config.packageName() || 'my.cordova.project';
     var project_name = config.name() ?
         config.name().replace(/[^\w.]/g, '_') : 'CordovaExample';
 

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -24,6 +24,7 @@ var path = require('path');
 var shell = require('shelljs');
 var events = require('cordova-common').events;
 var AndroidManifest = require('./AndroidManifest');
+var checkReqs = require('./check_reqs');
 var xmlHelpers = require('cordova-common').xmlHelpers;
 var CordovaError = require('cordova-common').CordovaError;
 var ConfigParser = require('cordova-common').ConfigParser;
@@ -181,10 +182,10 @@ function updateProjectAccordingTo (platformConfig, locations) {
     events.emit('verbose', 'Wrote out android application name "' + name + '" to ' + locations.strings);
 
     // Java packages cannot support dashes
-    var pkg = (platformConfig.android_packageName() || platformConfig.packageName()).replace(/-/g, '_');
+    var androidPkgName = (platformConfig.android_packageName() || platformConfig.packageName()).replace(/-/g, '_');
 
     var manifest = new AndroidManifest(locations.manifest);
-    var orig_pkg = manifest.getPackageId();
+    var manifestId = manifest.getPackageId();
 
     manifest.getActivity()
         .setOrientation(platformConfig.getPreference('orientation'))
@@ -192,13 +193,13 @@ function updateProjectAccordingTo (platformConfig, locations) {
 
     manifest.setVersionName(platformConfig.version())
         .setVersionCode(platformConfig.android_versionCode() || default_versionCode(platformConfig.version()))
-        .setPackageId(pkg)
+        .setPackageId(androidPkgName)
         .setMinSdkVersion(platformConfig.getPreference('android-minSdkVersion', 'android'))
         .setMaxSdkVersion(platformConfig.getPreference('android-maxSdkVersion', 'android'))
         .setTargetSdkVersion(platformConfig.getPreference('android-targetSdkVersion', 'android'))
         .write();
 
-    var javaPattern = path.join(locations.root, 'src', orig_pkg.replace(/\./g, '/'), '*.java');
+    var javaPattern = path.join(locations.root, 'src', manifestId.replace(/\./g, '/'), '*.java');
     var java_files = shell.ls(javaPattern).filter(function (f) {
         return shell.grep(/extends\s+CordovaActivity/g, f);
     });
@@ -209,12 +210,16 @@ function updateProjectAccordingTo (platformConfig, locations) {
         events.emit('log', 'Multiple candidate Java files that extend CordovaActivity found. Guessing at the first one, ' + java_files[0]);
     }
 
-    var destFile = path.join(locations.root, 'src', pkg.replace(/\./g, '/'), path.basename(java_files[0]));
+    var destFile = path.join(locations.root, 'src', androidPkgName.replace(/\./g, '/'), path.basename(java_files[0]));
     shell.mkdir('-p', path.dirname(destFile));
-    shell.sed(/package [\w\.]*;/, 'package ' + pkg + ';', java_files[0]).to(destFile);
-    events.emit('verbose', 'Wrote out Android package name "' + pkg + '" to ' + destFile);
+    shell.sed(/package [\w\.]*;/, 'package ' + androidPkgName + ';', java_files[0]).to(destFile);
+    events.emit('verbose', 'Wrote out Android package name "' + androidPkgName + '" to ' + destFile);
 
-    if (orig_pkg !== pkg) {
+    var removeOrigPkg = checkReqs.isWindows() || checkReqs.isDarwin() ?
+        manifestId.toUpperCase() !== androidPkgName.toUpperCase() :
+        manifestId !== androidPkgName;
+
+    if (removeOrigPkg) {
         // If package was name changed we need to remove old java with main activity
         shell.rm('-Rf', java_files[0]);
         // remove any empty directories

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -148,7 +148,7 @@ describe('create', function () {
             spyOn(shell, 'cp');
             spyOn(shell, 'mkdir');
             spyOn(shell, 'sed');
-            config_mock = jasmine.createSpyObj('ConfigParser mock instance', ['packageName', 'name', 'android_activityName']);
+            config_mock = jasmine.createSpyObj('ConfigParser mock instance', ['packageName', 'android_packageName', 'name', 'android_activityName']);
             events_mock = jasmine.createSpyObj('EventEmitter mock instance', ['emit']);
             spyOn(check_reqs, 'get_target').and.returnValue(fake_android_target);
         });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
self

### What does this PR do?
Steps to reproduce:
1) cordova create testapp com.example.testapp testapp
2) cd testapp
3) edit config.xml, add android-packageName="com.example.Testapp" to <widget>
4) cordova platform add android

Since `windows` and `osx` file systems are case-insensitive, [this line](https://github.com/apache/cordova-android/blob/893356abcd1b005a13bb09e7467f227b52de3ae5/bin/templates/cordova/lib/prepare.js#L213) doesn't create a directory with a name from `android-packageName` attribute if it differs in casing from original package name. 

This PR makes case-sensitive check before removal of an old package.

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
