### PR TITLE
CB-8976: Added the `cdvVersionCodeForceAbiDigit` property

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -70,6 +70,10 @@ ext {
     if (!project.hasProperty('cdvBuildMultipleApks')) {
         cdvBuildMultipleApks = null
     }
+    // Whether to append a 0 "abi digit" to versionCode when only a single APK is build 
+    if (!project.hasProperty('cdvVersionCodeForceAbiDigit')) {
+        cdvVersionCodeForceAbiDigit = null
+    }
     // .properties files to use for release signing.
     if (!project.hasProperty('cdvReleaseSigningPropertiesFile')) {
         cdvReleaseSigningPropertiesFile = null
@@ -111,6 +115,7 @@ if (ext.cdvReleaseSigningPropertiesFile == null && file('release-signing.propert
 
 // Cast to appropriate types.
 ext.cdvBuildMultipleApks = cdvBuildMultipleApks == null ? false : cdvBuildMultipleApks.toBoolean();
+ext.cdvVersionCodeForceAbiDigit = cdvVersionCodeForceAbiDigit == null ? false : cdvVersionCodeForceAbiDigit.toBoolean();
 ext.cdvMinSdkVersion = cdvMinSdkVersion == null ? null : Integer.parseInt('' + cdvMinSdkVersion)
 ext.cdvVersionCode = cdvVersionCode == null ? null : Integer.parseInt('' + cdvVersionCode)
 
@@ -138,6 +143,7 @@ task cdvPrintProps << {
     println('cdvCompileSdkVersion=' + cdvCompileSdkVersion)
     println('cdvBuildToolsVersion=' + cdvBuildToolsVersion)
     println('cdvVersionCode=' + cdvVersionCode)
+    println('cdvVersionCodeForceAbiDigit=' + cdvVersionCodeForceAbiDigit)
     println('cdvMinSdkVersion=' + cdvMinSdkVersion)
     println('cdvBuildMultipleApks=' + cdvBuildMultipleApks)
     println('cdvReleaseSigningPropertiesFile=' + cdvReleaseSigningPropertiesFile)
@@ -198,6 +204,11 @@ android {
                     abiFilters "all", ""
                 }
             }
+        }
+    } else if (Boolean.valueOf(cdvVersionCodeForceAbiDigit)) {
+        // This provides compatibility to the default logic for versionCode before cordova-android 5.2.0
+        defaultConfig {
+            versionCode defaultConfig.versionCode*10
         }
     }
     /*


### PR DESCRIPTION
 to the template build.gradle that appends 0 to the versionCode when `cdvBuildMultipleApks` is not set

### Platforms affected
Android

### What does this PR do?
Adds a Gradle property that, when set to true, establishes a fallback for the 10x bigger versionCodes that were auto-generated even for non-multi-APK builds in cordova-android version before 5.2.0. 

### What testing has been done on this change?
Only local testing. Planned to add some automated testing and documentation but didn't get around to it. Hope someone else will pick it up.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
