### PR TITLE
Revert CB-12015: initial-scale values less than 1.0 are ignored on Android

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -210,11 +210,6 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         settings.setAppCachePath(databasePath);
         settings.setAppCacheEnabled(true);
 
-        // Enable scaling
-        // Fix for CB-12015
-        settings.setUseWideViewPort(true);
-        settings.setLoadWithOverviewMode(true);
-
         // Fix for CB-1405
         // Google issue 4641
         String defaultUserAgent = settings.getUserAgentString();


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Reverts the fix for CB-12015 which is causing more problems than it is fixing.

### What testing has been done on this change?

Create a new project with change. Behaviour reverts to pre CB-12015 changes.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
