### PR TITLE
Update maven repo to include most recent lib versions

### DIFF
--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -20,8 +20,10 @@
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     // Switch the Android Gradle plugin version requirement depending on the

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -21,8 +21,10 @@ apply plugin: 'com.android.application'
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     // Switch the Android Gradle plugin version requirement depending on the
@@ -37,8 +39,10 @@ buildscript {
 // Allow plugins to declare Maven dependencies via build-extras.gradle.
 allprojects {
     repositories {
-        mavenCentral();
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -24,8 +24,10 @@ ext {
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {


### PR DESCRIPTION
### What does this PR do?

Fix install issues with 25.4.0+ google support libraries. As it is, they are not installable, due to move to new repo.

See note at https://developer.android.com/topic/libraries/support-library/revisions.html#25-4-0 for details:

> Important: The support libraries are now available through Google's Maven repository. You do not need to download the support repository from the SDK Manager.

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.