### PR TITLE
Running Java unit tests more easily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,25 @@ language: android
 sudo: false
 jdk:
     - oraclejdk8
+env:
+    global:
+      - ANDROID_TOOLS=${ANDROID_HOME}/tools
 before_install:
     - nvm install 6
+    # ensure at least gradle 3.3 is in place.
+    - wget http://services.gradle.org/distributions/gradle-3.3-bin.zip
+    - unzip gradle-3.3-bin.zip
+    - export GRADLE_HOME=$PWD/gradle-3.3
+    - export PATH=${GRADLE_HOME}/bin:${ANDROID_HOME}:${ANDROID_HOME}/emulator:${ANDROID_TOOLS}:${ANDROID_TOOLS}/bin:${ANDROID_HOME}/platform-tools:$PATH
     - node --version
     - gradle --version
-install:
-    - npm install
-    - npm install -g codecov
     - echo y | android --silent update sdk --no-ui --all --filter platform-tools,tools,build-tools-26.0.0,android-26,android-25,extra-google-m2repository,extra-android-m2repository
 android:
     components:
       - tools
+install:
+    - npm install
+    - npm install -g codecov
 script:
     - npm test
     - npm run cover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,11 +24,10 @@ install:
   # and appveyor interpret that as errors, and blows up. so, when piping in our "Y ENTER"
   # responses, we invoke cmd so we can redirect stderr to stdout, and tell it to --update itself.
   - ps: for($i=0;$i -lt 30;$i++) { $response += "y`n"}; $response | cmd /c 'C:\android\tools\bin\sdkmanager.bat 2>&1' --update
-  - cd test
-  - gradle :wrapper -b build.gradle
-  - cd ..
   - ps: Install-Product node $env:nodejs_version
   - npm install
+  # below is a workaround on using gradle installed via choco on appveyor
+  - set path=C:\ProgramData\chocolatey\lib\gradle\tools\gradle-3.4.1\bin;%path%
 
 build: off
 

--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -69,13 +69,13 @@ GradleBuilder.prototype.getArgs = function (cmd, opts) {
  * This returns a promise
  */
 
-GradleBuilder.prototype.runGradleWrapper = function (gradle_cmd) {
+GradleBuilder.prototype.runGradleWrapper = function (gradle_cmd, gradle_file) {
     var gradlePath = path.join(this.root, 'gradlew');
-    var wrapperGradle = path.join(this.root, 'wrapper.gradle');
+    gradle_file = path.join(this.root, (gradle_file || 'wrapper.gradle'));
     if (fs.existsSync(gradlePath)) {
         // Literally do nothing, for some reason this works, while !fs.existsSync didn't on Windows
     } else {
-        return superspawn.spawn(gradle_cmd, ['-p', this.root, 'wrapper', '-b', wrapperGradle], { stdio: 'pipe' })
+        return superspawn.spawn(gradle_cmd, ['-p', this.root, 'wrapper', '-b', gradle_file], { stdio: 'pipe' })
             .progress(function (stdio) {
                 suppressJavaOptionsInfo(stdio);
             });

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "apache"
   ],
   "scripts": {
-    "test": "npm run eslint && npm run unit-tests && npm run e2e-tests",
+    "test": "npm run eslint && npm run unit-tests && npm run java-unit-tests && npm run e2e-tests",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
     "cover": "istanbul cover --root bin --print detail jasmine -- --config=spec/unit/jasmine.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",
+    "java-unit-tests": "cd test && node run_java_unit_tests.js && cd ..",
     "eslint": "eslint bin && eslint spec"
   },
   "author": "Apache Software Foundation",

--- a/test/run_java_unit_tests.js
+++ b/test/run_java_unit_tests.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var Q = require('q');
+var path = require('path');
+var superspawn = require('cordova-common').superspawn;
+
+// First we make sure the gradlew helper file is built and ready.
+var GradleBuilder = require('../bin/templates/cordova/lib/builders/GradleBuilder');
+var builder = new GradleBuilder(__dirname);
+var needs_gradlew_built = builder.runGradleWrapper('gradle', 'build.gradle');
+
+if (!needs_gradlew_built) {
+    // Due to interface of gradle builder, if the gradlew file already exists, `runGradleWrapper` returns undefined.
+    // In this case, we will fill the gap and create a resolved promise here now, this way the next bit of code
+    // will jump straight to running the tests
+    // TODO: maybe this should be done in GradleBuilder `runGradleWrapper` method instead?
+    needs_gradlew_built = Q.fcall(function () { return true; });
+}
+
+needs_gradlew_built.then(function () {
+    return superspawn.spawn(path.join(__dirname, 'gradlew'), ['test'], {stdio: 'inherit'});
+}, function (err) {
+    console.error('There was an error building the gradlew file:', err);
+}).then(function () {
+    console.log('Tests completed successfully.');
+}).fail(function (err) {
+    console.error('Tests failed!', err);
+});


### PR DESCRIPTION
### What does this PR do?

Trying to make it easy for both humans and our CI systems to run the Java unit tests. In particular, I wanted to seamlessly handle building the gradle wrapper and invoking `gradlew test` on both *nix and Windows systems.

Changes include:
- added a node script in the `test/` project directory, `run_java_unit_tests.js`, that wraps up building the gradle wrapper for the test project and invoking the unit tests (`gradlew test`)
- wrapped up running that script in the `npm run java-unit-tests` helper
- include `npm run java-unit-tests` in the top-level `npm test` script
- now runs java unit tests in travis and appveyor
- small refactor in `gradlebuilder.js` to support building the gradle wrapper more easily - kept the defaults and behaviour of gradlebuilder functions as before, just parameterized the .gradle file as part of the `runGradleWrapper` helper method.
- don't explicitly build gradlew on appveyor CI as now `npm test` will do it for you

### What testing has been done on this change?

I tested this on both Windows 10 and Mac OS 10.12, in both the fresh-clone and fully-loaded cordova-android repo cases. That is, in the fresh-clone situation, `npm run java-unit-tests` will a) download the proper gradle version, b) build the gradle wrapper and finally c) run the java unit tests. The fully-loaded case will skip right to c).

# Worth Noting

I dropped a TODO regarding the flow of promises from `GradleBuilder` - the helper method `runGradleWrapper` returns a promise in the case that it needs to build the gradle wrapper, but if the gradle wrapper is already built, it returns nothing. So, I had to handle this discrepancy in the `run_java_unit_tests.js` file. For cleanliness, it may be worth having the `runGradleWrapper` method always return a promise. I'm happy to make those changes if we deem it appropriate after a review.

Please review (or at least, FYI): @infil00p, @alsorokin, @stevengill, @dpogue, @macdonst, @purplecabbage, @jcesarmobile 
