### PR TITLE
CB-12981: handle slightly different AVD list output in Android SDK 26.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
+    "android-versions": "^1.2.0",
     "cordova-common": "^2.1.0",
     "elementtree": "0.1.6",
     "nopt": "^3.0.1",


### PR DESCRIPTION
Would cause "cannot read property replace of undefined" errors when trying to deploy an Android 8 emulator.

This supersedes #393.

