### PR TITLE
CB-13404, CB-13406: `best_image` function fixes when choosing emulator images to deploy to

### DIFF
--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -207,11 +207,11 @@ module.exports.best_image = function () {
 
         var closest = 9999;
         var best = images[0];
-        var project_target = check_reqs.get_target().replace('android-', '');
+        var project_target = parseInt(check_reqs.get_target().replace('android-', ''));
         for (var i in images) {
             var target = images[i].target;
-            if (target) {
-                var num = target.split('(API level ')[1].replace(')', '');
+            if (target && target.indexOf('API level') > -1) {
+                var num = parseInt(target.split('(API level ')[1].replace(')', ''));
                 if (num === project_target) {
                     return images[i];
                 } else if (project_target - num < closest && project_target > num) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
-    "android-versions": "^1.2.0",
+    "android-versions": "^1.2.1",
     "cordova-common": "^2.1.0",
     "elementtree": "0.1.6",
     "nopt": "^3.0.1",
@@ -38,6 +38,7 @@
     "shelljs": "^0.5.3"
   },
   "bundledDependencies": [
+    "android-versions",
     "cordova-common",
     "elementtree",
     "nopt",


### PR DESCRIPTION
This PR addresses both [CB-13404](https://issues.apache.org/jira/browse/CB-13404) and [CB-13406](https://issues.apache.org/jira/browse/CB-13406).

Summary of changes:
 - added tests to the `best_image` method of the emulator command line scripts.
 - when comparing project and AVD API levels, sub-optimal matches of the API level would lead to incoherent results for `best_image` since we were applying integer comparisons on strings.
 - added required module `android-versions` to `bundledDependencies`
 - bumped `android-versions` to 1.2.1 to fix issues when converting API levels and Android semver strings for Android 8.

### What testing has been done on this change?

Ran automated tests.