### PR TITLE
CB-12802: (android) Fix build.gradle to sign when building with multiple APK is enable.

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -268,7 +268,7 @@ def promptForReleaseKeyPassword() {
 
 gradle.taskGraph.whenReady { taskGraph ->
     taskGraph.getAllTasks().each() { task ->
-        if (task.name == 'validateReleaseSigning' || task.name == 'validateSigningRelease') {
+        if (['validateReleaseSigning', 'validateSigningRelease', 'validateSigningArmv7Release', 'validateSigningX86Release'].contains(task.name)) {
             promptForReleaseKeyPassword()
         }
     }


### PR DESCRIPTION
When 'cdvBuildMultipleApks' is true, 'task.name' can have 'validateSigningArmv7Release' or 'validateSigningX86Release' values.

### Platforms affected
cordova 7
cordova-android 6.2.3

### What does this PR do?
Fix build.gradle to sign when building with multiple APK is enable.

### What testing has been done on this change?
Test to build with or without signature and with or without multiple APK.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database [issue on Jira](https://issues.apache.org/jira/browse/CB-12802)
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
