### PR TITLE
CB-13530: Fix the utility method for finding the built APK for generic APKs

### DIFF
--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -106,10 +106,14 @@ function apkSorter (fileA, fileB) {
 }
 
 function findOutputApksHelper (dir, build_type, arch) {
+    console.log("Directory: " + dir);
+    console.log("Build Type: " + build_type);
+    console.log("Arch: " + arch);
+
     var shellSilent = shell.config.silent;
     shell.config.silent = true;
 
-    var ret = shell.ls(path.join(dir, '*.apk')).filter(function (candidate) {
+    var ret = shell.ls(path.join(dir, build_type, '*.apk')).filter(function (candidate) {
         var apkName = path.basename(candidate);
         // Need to choose between release and debug .apk.
         if (build_type === 'debug') {

--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -106,10 +106,6 @@ function apkSorter (fileA, fileB) {
 }
 
 function findOutputApksHelper (dir, build_type, arch) {
-    console.log("Directory: " + dir);
-    console.log("Build Type: " + build_type);
-    console.log("Arch: " + arch);
-
     var shellSilent = shell.config.silent;
     shell.config.silent = true;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Fixes master so that we can actually install a non-arch specific APK (Arch-specific APKs like the ones built with Crosswalk are still completely broken)

### What testing has been done on this change?
Tested to make sure it deploys to device.

### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
