### PR TITLE
CB-13580: (android) fix build for multiple apks (different product flavors)

### DIFF
--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -93,15 +93,23 @@ GenericBuilder.prototype.extractRealProjectNameFromManifest = function () {
 module.exports = GenericBuilder;
 
 function apkSorter (fileA, fileB) {
+    // De-prioritize arch specific builds
+    var archSpecificRE = /-x86|-arm/;
+    if (archSpecificRE.exec(fileA)) {
+        return 1;
+    } else if (archSpecificRE.exec(fileB)) {
+        return -1;
+    }
+
     // De-prioritize unsigned builds
     var unsignedRE = /-unsigned/;
     if (unsignedRE.exec(fileA)) {
         return 1;
     } else if (unsignedRE.exec(fileB)) {
         return -1;
-    }
+    } 
 
-    var timeDiff = fs.statSync(fileA).mtime - fs.statSync(fileB).mtime;
+    var timeDiff = fs.statSync(fileB).mtime - fs.statSync(fileA).mtime;
     return timeDiff === 0 ? fileA.length - fileB.length : timeDiff;
 }
 
@@ -109,7 +117,14 @@ function findOutputApksHelper (dir, build_type, arch) {
     var shellSilent = shell.config.silent;
     shell.config.silent = true;
 
-    var ret = shell.ls(path.join(dir, build_type, '*.apk')).filter(function (candidate) {
+    // list directory recursively 
+    var ret = shell.ls('-R', dir).map(function(file) {
+        // ls does not include base directory
+        return path.join(dir, file);
+    }).filter(function (file) {
+        // find all APKs
+        return file.match(/\.apk?$/i);
+    }).filter(function (candidate) {
         var apkName = path.basename(candidate);
         // Need to choose between release and debug .apk.
         if (build_type === 'debug') {

--- a/bin/templates/cordova/lib/builders/GenericBuilder.js
+++ b/bin/templates/cordova/lib/builders/GenericBuilder.js
@@ -107,7 +107,7 @@ function apkSorter (fileA, fileB) {
         return 1;
     } else if (unsignedRE.exec(fileB)) {
         return -1;
-    } 
+    }
 
     var timeDiff = fs.statSync(fileB).mtime - fs.statSync(fileA).mtime;
     return timeDiff === 0 ? fileA.length - fileB.length : timeDiff;
@@ -117,8 +117,8 @@ function findOutputApksHelper (dir, build_type, arch) {
     var shellSilent = shell.config.silent;
     shell.config.silent = true;
 
-    // list directory recursively 
-    var ret = shell.ls('-R', dir).map(function(file) {
+    // list directory recursively
+    var ret = shell.ls('-R', dir).map(function (file) {
         // ls does not include base directory
         return path.join(dir, file);
     }).filter(function (file) {

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -184,6 +184,8 @@ android {
     buildToolsVersion cdvBuildToolsVersion
 
     if (Boolean.valueOf(cdvBuildMultipleApks)) {
+        flavorDimensions "default"
+
         productFlavors {
             armv7 {
                 versionCode defaultConfig.versionCode*10 + 2


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
cordova-android

### What does this PR do?
This PR fixes the build if cdvBuildMultipleApks is set to true by defining `flavorDimensions "default"` in `build.gradle` and by adapting the `findOutputApksHelper` method in `GenericBuilder.js` to recursively scan the `build/outputs/apk` directory for matching candidates.

A positive side-effect of this is that builds with crosswalk will work again :-)

### What testing has been done on this change?
I ran the unit tests and the connectedAndroidTest tests and did manual tests of builds with crosswalk (multiple APKs) and builds without crosswalk (single APK).

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
