### PR TITLE
Prevent crash when unrecognized android version encounterd

### DIFF
--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -187,7 +187,9 @@ module.exports.list_images = function () {
                 var api_level = avd.target.match(/\d+/);
                 if (api_level) {
                     var level = android_versions.get(api_level);
-                    avd.target = 'Android ' + level.semver + ' (API level ' + api_level + ')';
+                    if (level) {
+                        avd.target = 'Android ' + level.semver + ' (API level ' + api_level + ')';
+                    }
                 }
             }
             return avd;


### PR DESCRIPTION
Fixes issue where commands that list images will crash when an image with a version not present in `android-versions` is encountered, as is presently the case with API 27:

```
cordova run android --list
Available android devices:
Available android virtual devices:
LEVEL: null
ERROR: TypeError: Cannot read property 'semver' of null
An unexpected error has occured while running list-emulator-images with code 2: Error: /home/chris/Repositories/acp-guidelines/cordova/platforms/android/cordova/lib/list-emulator-images: Command failed with exit code 2
```

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
