### PR TITLE
Strip starting dot from ActivityName

### DIFF
--- a/bin/templates/cordova/lib/AndroidManifest.js
+++ b/bin/templates/cordova/lib/AndroidManifest.js
@@ -65,9 +65,12 @@ AndroidManifest.prototype.setPackageId = function (pkgId) {
 
 AndroidManifest.prototype.getActivity = function () {
     var activity = this.doc.getroot().find('./application/activity');
+    var originalActivityName = activity.attrib['android:name'];
+    var activityName = originalActivityName.charAt(0) === '.' ? originalActivityName.slice(1) : originalActivityName;
+
     return {
         getName: function () {
-            return activity.attrib['android:name'];
+            return activityName;
         },
         setName: function (name) {
             if (!name) {
@@ -102,30 +105,31 @@ AndroidManifest.prototype.getActivity = function () {
     };
 };
 
-['minSdkVersion', 'maxSdkVersion', 'targetSdkVersion'].forEach(function (sdkPrefName) {
-    // Copy variable reference to avoid closure issues
-    var prefName = sdkPrefName;
+['minSdkVersion', 'maxSdkVersion', 'targetSdkVersion']
+    .forEach(function (sdkPrefName) {
+        // Copy variable reference to avoid closure issues
+        var prefName = sdkPrefName;
 
-    AndroidManifest.prototype['get' + capitalize(prefName)] = function () {
-        var usesSdk = this.doc.getroot().find('./uses-sdk');
-        return usesSdk && usesSdk.attrib['android:' + prefName];
-    };
+        AndroidManifest.prototype['get' + capitalize(prefName)] = function () {
+            var usesSdk = this.doc.getroot().find('./uses-sdk');
+            return usesSdk && usesSdk.attrib['android:' + prefName];
+        };
 
-    AndroidManifest.prototype['set' + capitalize(prefName)] = function (prefValue) {
-        var usesSdk = this.doc.getroot().find('./uses-sdk');
+        AndroidManifest.prototype['set' + capitalize(prefName)] = function (prefValue) {
+            var usesSdk = this.doc.getroot().find('./uses-sdk');
 
-        if (!usesSdk && prefValue) { // if there is no required uses-sdk element, we should create it first
-            usesSdk = new et.Element('uses-sdk');
-            this.doc.getroot().append(usesSdk);
-        }
+            if (!usesSdk && prefValue) { // if there is no required uses-sdk element, we should create it first
+                usesSdk = new et.Element('uses-sdk');
+                this.doc.getroot().append(usesSdk);
+            }
 
-        if (prefValue) {
-            usesSdk.attrib['android:' + prefName] = prefValue;
-        }
+            if (prefValue) {
+                usesSdk.attrib['android:' + prefName] = prefValue;
+            }
 
-        return this;
-    };
-});
+            return this;
+        };
+    });
 
 AndroidManifest.prototype.getDebuggable = function () {
     return this.doc.getroot().find('./application').attrib['android:debuggable'] === 'true';
@@ -150,7 +154,7 @@ AndroidManifest.prototype.setDebuggable = function (value) {
  *   manifest will be written to file it has been read from.
  */
 AndroidManifest.prototype.write = function (destPath) {
-    fs.writeFileSync(destPath || this.path, this.doc.write({indent: 4}), 'utf-8');
+    fs.writeFileSync(destPath || this.path, this.doc.write({ indent: 4 }), 'utf-8');
 };
 
 module.exports = AndroidManifest;


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Strip starting dot from ActivityName. Activity's name may already contain a leading dot symbol in the AndroidManifest.xml. If this is the case it has to be stripped.

### What testing has been done on this change?
1. `cordova create myApp`
1. `cd myApp`
1. `cordova platform add <this branch>`
1. `sed -i s/MainActivity/.MainActivity/ platforms/android/AndroidManifest.xml`
1. `cordova run android`
With the `master` branch `cordova` fails to launch the application and with this branch it succeeds. 

### Checklist
- [x] [Reported the issue](https://issues.apache.org/jira/browse/CB-13720) in the JIRA database

