### PR TITLE
CB-13721 (Android): fix build apps that use cdvHelpers.getConfigPreference

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -165,7 +165,7 @@ def doPromptForPassword(msg) {
 }
 
 def doGetConfigXml() {
-    def xml = file("res/xml/config.xml").getText()
+    def xml = file("src/main/res/xml/config.xml").getText()
     // Disable namespace awareness since Cordova doesn't use them properly
     return new XmlParser(false, false).parseText(xml)
 }


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Fix the location of the config.xml so cdvHelpers.getConfigPreference works

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
