### PR TITLE
CB-12218: (android) Fix consistency of null result message

### DIFF
--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -511,6 +511,9 @@ public class NativeToJsMessageQueue {
                             .append(pluginResult.getMessage())
                             .append("')");
                     break;
+                case PluginResult.MESSAGE_TYPE_NULL:
+                    sb.append("null");
+                    break;
                 default:
                     sb.append(pluginResult.getMessage());
             }

--- a/test/app/src/test/java/org/apache/cordova/unittests/NativeToJsMessageQueueTest.java
+++ b/test/app/src/test/java/org/apache/cordova/unittests/NativeToJsMessageQueueTest.java
@@ -161,4 +161,17 @@ public class NativeToJsMessageQueueTest {
         assertEquals(result, "cordova.callbackFromNative('37',true,1,[0,1,2,3,4],false);");
     }
 
+    @Test
+    public void testNullPopAndEncodeAsJs()
+    {
+        NativeToJsMessageQueue queue = new NativeToJsMessageQueue();
+        queue.addBridgeMode(new NativeToJsMessageQueue.NoOpBridgeMode());
+        queue.setBridgeMode(0);
+
+        PluginResult result = new PluginResult(PluginResult.Status.OK, (String)null);
+        queue.addPluginResult(result, TEST_CALLBACK_ID);
+        assertFalse(queue.isEmpty());
+        String resultString = queue.popAndEncodeAsJs();
+        assertEquals(resultString, "cordova.callbackFromNative('" + TEST_CALLBACK_ID + "',true,1,[null],false);");
+    }
 }


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Fix problem that JavaScript receives ""(empty string) instead of null
if plugin sends null result from new thread.

### What testing has been done on this change?

npm test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
