### PR TITLE
CB-13646: End of an era.  Using the deprecated NDK by default breaks …

### DIFF
--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -58,7 +58,7 @@ StudioBuilder.prototype.getArgs = function (cmd, opts) {
     // to allow dex in process
     args.push('-Dorg.gradle.jvmargs=-Xmx2048m');
     // allow NDK to be used - required by Gradle 1.5 plugin
-    args.push('-Pandroid.useDeprecatedNdk=true');
+    // args.push('-Pandroid.useDeprecatedNdk=true');
     args.push.apply(args, opts.extraArgs);
     // Shaves another 100ms, but produces a "try at own risk" warning. Not worth it (yet):
     // args.push('-Dorg.gradle.parallel=true');


### PR DESCRIPTION
…the build.  Crosswalk users need to specify the Gradle parameters to keep it working.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Removes the deprecated NDK argument, which isn't supported anymore.

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
