### PR TITLE
CB-13788: (android) Specify the minimum required version of google play services for plugins

### DIFF
--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -177,7 +177,7 @@ StudioBuilder.prototype.prepBuildFiles = function () {
     // For why we do this mapping: https://issues.apache.org/jira/browse/CB-8390
     var SYSTEM_LIBRARY_MAPPINGS = [
         [/^\/?extras\/android\/support\/(.*)$/, 'com.android.support:support-$1:+'],
-        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, 'com.google.android.gms:play-services:+']
+        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, 'com.google.android.gms:play-services.*?:+']
     ];
 
     propertiesObj.systemLibs.forEach(function (p) {

--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -177,7 +177,7 @@ StudioBuilder.prototype.prepBuildFiles = function () {
     // For why we do this mapping: https://issues.apache.org/jira/browse/CB-8390
     var SYSTEM_LIBRARY_MAPPINGS = [
         [/^\/?extras\/android\/support\/(.*)$/, 'com.android.support:support-$1:+'],
-        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, /com\.google\.android\.gms\:play\-services.*/]
+        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, /com\.google\.android\.gms:play-services.*/]
     ];
 
     propertiesObj.systemLibs.forEach(function (p) {

--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -177,7 +177,7 @@ StudioBuilder.prototype.prepBuildFiles = function () {
     // For why we do this mapping: https://issues.apache.org/jira/browse/CB-8390
     var SYSTEM_LIBRARY_MAPPINGS = [
         [/^\/?extras\/android\/support\/(.*)$/, 'com.android.support:support-$1:+'],
-        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, 'com.google.android.gms:play-services.*?:+']
+        [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, /com\.google\.android\.gms\:play\-services.*/]
     ];
 
     propertiesObj.systemLibs.forEach(function (p) {


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Extends the `<framework>` tag to accept particular module.

For example:
 `<framework src="com.google.android.gms:play-services-maps:+" versions=">=11.8.0" />`


### What testing has been done on this change?
Only StudioBuilder.js

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
