### PR TITLE
CB-13831: (android) Update `android-versions` to 1.3.0 to support SDK 27.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
-    "android-versions": "^1.2.1",
+    "android-versions": "^1.3.0",
     "cordova-common": "^2.2.0",
     "elementtree": "0.1.6",
     "nopt": "^3.0.1",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Updates `android-versions` to the latest version, 1.3.0, which is aware of the existence of Android API level 27, thanks to https://github.com/dvoiss/android-versions/commit/230957205eeb26e569096251a32179e88a28acfc.

As the `android-versions` npm is a "bundled dependency" this will only
take effect when a new version of `cordova-android` is published, since
bundled dependencies are packed within the npm at publish time, not
automatically fetched as dependencies at publish time (which would have
normally been covered for new installations of cordova-android@7.0.0
thanks to semver caret notation).

### What testing has been done on this change?

* `npm test`
* Confirm that the emulator (i.e. `cordova run android --emulator -d`) will actually launch.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
  - Presumably covered by the old tests.
