### PR TITLE
CB-13818: (android) Update android_sdk.js to support Android Oreo 8.0 (API 26) emulator

### DIFF
--- a/bin/templates/cordova/lib/android_sdk.js
+++ b/bin/templates/cordova/lib/android_sdk.js
@@ -62,7 +62,8 @@ module.exports.version_string_to_api_level = {
     '5.1': 22,
     '6.0': 23,
     '7.0': 24,
-    '7.1.1': 25
+    '7.1.1': 25,
+    '8.0': 26
 };
 
 function parse_targets (output) {


### PR DESCRIPTION
[CB-13818]: (android) Update `android_sdk.js` to support Android Oreo (API 26) emulator

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
cordova-android 7.0x

### What does this PR do?
Fixed the issue described in [CB-13818](https://issues.apache.org/jira/browse/CB-13818)

### What testing has been done on this change?
Tested in my own machine with cordova@7.1.0 

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
