### PR TITLE
CB-13923 (android) fix -1 length for compressed files

### DIFF
--- a/framework/src/org/apache/cordova/CordovaResourceApi.java
+++ b/framework/src/org/apache/cordova/CordovaResourceApi.java
@@ -263,6 +263,7 @@ public class CordovaResourceApi {
                 } catch (FileNotFoundException e) {
                     // Will occur if the file is compressed.
                     inputStream = assetManager.open(assetPath);
+                    length = inputStream.available();
                 }
                 String mimeType = getMimeTypeFromPath(assetPath);
                 return new OpenForReadResult(uri, inputStream, mimeType, length, assetFd);


### PR DESCRIPTION
*Disclaimer: Please review carefully as i'm not a java developer, I just squint a bit and pretend it's C#*

### Platforms affected

cordova 8.0.0
cordova-android 7.1.0
cordova-plugin-file 6.0.3

### What does this PR do?

Here are details to recreate the issue:

https://github.com/AnthonyWard/cordova-file-plugin-bug

In `cordova-android` the `CordovaResourceApi.java` > `OpenForReadResult` method returns a -1 length in for compressed files.

This has a knock on effect to the `cordova-plugin-file` > `Filesystem.java` > `readFileAtURL` method, causing file corruption as each chunk effectively has no end.

There is a possible fix in the plugin `cordova-plugin-file` already proposed

https://github.com/apache/cordova-plugin-file/pull/217

https://issues.apache.org/jira/browse/CB-13245?jql=text%20~%20%22CordovaResourceApi%22

Or I propose it could be fixed upstream in `cordova-android`

In the method `OpenForReadResult` there is one path (in the catch) that leaves the `length` as `-1` causing the defect.

Adding `length = inputStream.available();` in the catch fixes the issue for me.

### What testing has been done on this change?

Ran unit tests and integration tests locally, which passed.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
