### PR TITLE
CB-13975: (android) Fix to fire pause event when cdvStartInBackground=true

### DIFF
--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -43,6 +43,7 @@ public class CoreAndroid extends CordovaPlugin {
     private BroadcastReceiver telephonyReceiver;
     private CallbackContext messageChannel;
     private PluginResult pendingResume;
+    private PluginResult pendingPause;
     private final Object messageChannelLock = new Object();
 
     /**
@@ -113,6 +114,10 @@ public class CoreAndroid extends CordovaPlugin {
 			else if (action.equals("messageChannel")) {
                 synchronized(messageChannelLock) {
                     messageChannel = callbackContext;
+                    if (pendingPause != null) {
+                        sendEventMessage(pendingPause);
+                        pendingPause = null;
+                    }
                     if (pendingResume != null) {
                         sendEventMessage(pendingResume);
                         pendingResume = null;
@@ -321,7 +326,19 @@ public class CoreAndroid extends CordovaPlugin {
         } catch (JSONException e) {
             LOG.e(TAG, "Failed to create event message", e);
         }
-        sendEventMessage(new PluginResult(PluginResult.Status.OK, obj));
+        PluginResult result = new PluginResult(PluginResult.Status.OK, obj);
+
+        if (messageChannel == null) {
+            LOG.i(TAG, "Request to send event before messageChannel initialised: " + action);
+            if ("pause".equals(action)) {
+                pendingPause = result;
+            } else if ("resume".equals(action)) {
+                // When starting normally onPause then onResume is called
+                pendingPause = null;
+            }
+        } else {
+            sendEventMessage(result);
+        }
     }
 
     private void sendEventMessage(PluginResult payload) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
When the app is started with cdvStartInBackground=true then a pendingPause event is cached until the messageChannel is initialised (before the pause event never reached the webview and it wasn't possible to determine in JS code that the app was started in the background), this change results in the following JS events inside the app:

- pause
- deviceready

As a user you can then store a flag (e.g. app.inBackground) and this can be checked in 'deviceready' handler.

### What testing has been done on this change?
Only manually tested on several Android phones.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
