### PR TITLE
CB-14008: Updating Gradle Libraries to work with Android Studio 3.1.0

### DIFF
--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -247,7 +247,7 @@ GradleBuilder.prototype.prepEnv = function (opts) {
         // For some reason, using ^ and $ don't work.  This does the job, though.
         var distributionUrlRegex = /distributionUrl.*zip/;
         /* jshint -W069 */
-        var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.1-all.zip';
+        var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.4-all.zip';
         /* jshint +W069 */
         var gradleWrapperPropertiesPath = path.join(self.root, 'gradle', 'wrapper', 'gradle-wrapper.properties');
         shell.chmod('u+w', gradleWrapperPropertiesPath);

--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -223,7 +223,7 @@ StudioBuilder.prototype.prepEnv = function (opts) {
             // If it's not set, do nothing, assuming that we're using a future version of gradle that we don't want to mess with.
             // For some reason, using ^ and $ don't work.  This does the job, though.
             var distributionUrlRegex = /distributionUrl.*zip/;
-            var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.1-all.zip';
+            var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.4-all.zip';
             var gradleWrapperPropertiesPath = path.join(self.root, 'gradle', 'wrapper', 'gradle-wrapper.properties');
             shell.chmod('u+w', gradleWrapperPropertiesPath);
             shell.sed('-i', distributionUrlRegex, 'distributionUrl=' + distributionUrl, gradleWrapperPropertiesPath);

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 
@@ -42,7 +42,7 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.1.0'
+    gradleVersion = '4.4.0'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,8 +31,10 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        // The gradle plugin and the maven plugin have to be updated after each version of Android
+        // studio comes out
+        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Bumps up the Gradle version so that we can build with the latest version of Android Studio

### What testing has been done on this change?
Tested building with Android Studio and without Android Studio

### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
