### PR TITLE
CB-14059: New interface for Android plugins

### DIFF
--- a/framework/src/org/apache/cordova/ActionBasedCordovaPlugin.java
+++ b/framework/src/org/apache/cordova/ActionBasedCordovaPlugin.java
@@ -1,0 +1,43 @@
+package org.apache.cordova;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.Arrays;
+
+import java.util.List;
+
+/**
+ * Plugin implementation that accepts array of actions that implement desired functionality
+ *  and can be executed from JavaScript side.
+ *
+ * Example:
+ * class MyAction implements CordovaNativeAction { ... }
+ *
+ * class MyPlugin extends ActionBasedCordovaPlugin {
+ *     public ActionBasedCordovaPlugin(){
+ *         super(new MyAction())
+ *     }
+ * }
+ *
+ * @see CordovaNativeAction
+ */
+public class ActionBasedCordovaPlugin extends CordovaPlugin {
+
+    private final List<CordovaNativeAction> actions;
+
+    public ActionBasedCordovaPlugin(CordovaNativeAction ...actions) {
+        this.actions = Arrays.asList(actions);
+    }
+
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        for(CordovaNativeAction actionImpl: this.actions){
+            if(actionImpl.supportsAction(action)){
+                return actionImpl.execute(args, callbackContext);
+            }
+        }
+        return false;
+    }
+}
+

--- a/framework/src/org/apache/cordova/CordovaNativeAction.java
+++ b/framework/src/org/apache/cordova/CordovaNativeAction.java
@@ -1,0 +1,35 @@
+package org.apache.cordova;
+
+import org.json.JSONArray;
+
+/**
+ * Interface that needs to be implemented in order to add new action that can be executed from
+ * JavaScript
+ */
+public interface CordovaNativeAction {
+
+     /**
+      * Executes the request for specific action.
+      *
+      * This method is called from the WebView thread. To do a non-trivial amount of work, use:
+      *     cordova.getThreadPool().execute(runnable);
+      *
+      * To run on the UI thread, use:
+      *     cordova.getActivity().runOnUiThread(runnable);
+      *
+      * @param args         The exec() arguments in JSON form.
+      * @param callbackContext The callback context used when calling back into JavaScript.
+      * @return                Whether the action was valid.
+      */
+     boolean execute(JSONArray args, CallbackContext callbackContext);
+
+    /**
+     *
+     * Method used to match action to implementation
+     *
+     * @param action - action that needs to be performed
+     * @return true if action matches this implementation
+     */
+     boolean supportsAction(String action);
+}
+


### PR DESCRIPTION
h4. Motivation 

Extend existing Cordova plugin class to provide more object oriented way to set actions. This can be later extended by annotations as suggested on [mailing list post](http://mail-archives.apache.org/mod_mbox/cordova-dev/201804.mbox/%3Cpony-7bfc042908953daf1c7bd61390106e071c756368-457837495d8f36fb4e01073fadc53d7174bc0cbb%40dev.cordova.apache.org%3E)

```
class MyPlugin extends ActionBasedCordovaPlugin {
   public ActionBasedCordovaPlugin(){
      super(new MyAction())
   }
}

 class MyPlugin extends ActionBasedCordovaPlugin {
      public ActionBasedCordovaPlugin(){
          super(new MyAction())
      }
 }
```

Change do not affect any existing Cordova API.