### PR TITLE
Basic support for annotation CordovaMethod

### DIFF
--- a/framework/src/org/apache/cordova/CordovaMethod.java
+++ b/framework/src/org/apache/cordova/CordovaMethod.java
@@ -1,0 +1,30 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CordovaMethod {
+    public String action() default "";
+}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
The PR provides basic support for new annotation `@CordovaMethod` that will reduce boilerplate code for plugin authors.

At present typical Cordova plugin looks like:
```java
public class MyPlugin extends CordovaPlugin {
    private static final String METHOD_1 = "method1";
    private static final String METHOD_2 = "method2";
 
    @Override
    public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
        if (METHOD_1.equals(action)) {
            method1(args, callbackContext);
        } else if (METHOD_2.equals(action)) {
            method2(args, callbackContext);
        /// more methods...
        } else {
            return false;
        }
        return true;
    }

    protected void method1(CordovaArgs args, CallbackContext callbackContext) {
        // method1 implementation
    }

    protected void method2(CordovaArgs args, CallbackContext callbackContext) {
        // method2 implementation
    }
    ...
}
```
The proposal is to have update default implementation of method `CordovaPlugin#execute` and to mark action methods with a new annotation `@CordovaMethod`:
```java
public class MyPlugin extends CordovaPlugin {
    @CordovaMethod
    protected void method1(CordovaArgs args, CallbackContext callbackContext) {
        // method1 implementation
    }
    
    @CordovaMethod
    protected void method2(CordovaArgs args, CallbackContext callbackContext) {
        // method2 implementation
    }
    ...
}
```

This is very similar to how `CDVPlugin` from `cordova-ios` works.

### What testing has been done on this change?
I've previously created a [thread](https://lists.apache.org/thread.html/b6746c7dcd12d5685bcd7bea813651dcc349f3be31f864dd4a27080d@%3Cdev.cordova.apache.org%3E) in the mail list. There were different opinions.

The most popular concern was related to **performance**. So I created [gist](https://gist.github.com/chemerisuk/287e6cd6e1aa61a5680027967008b702) that measures performance impact of different implementations. On my machine an extra time for the `MethodCordovaPlugin` strategy was an approx 0.03ms on the first call and 0.000051ms later. It's on a desktop machine and proper testing should be done still on mobile devices, but wait, cordova plugins should not be used for performance critical apps.

A note about **backward compatibility**. Changes in this PR done in `CordovaPlugin#execute` that currently just `return false`. Plugin authors must override it in order to invoke any logic. Therefore they won't notice any change. Unlike them new plugins with target future version of `cordova-android` might use annotation `@CordovaMethod` and reduce boilerplate code.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

FYI @wtrocki