### PR TITLE
CB-14101 Fix Java version check for Java >= 9

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -39,17 +39,6 @@ function forgivingWhichSync (cmd) {
     }
 }
 
-function tryCommand (cmd, errMsg, catchStderr) {
-    var d = Q.defer();
-    child_process.exec(cmd, function (err, stdout, stderr) {
-        if (err) d.reject(new CordovaError(errMsg));
-        // Sometimes it is necessary to return an stderr instead of stdout in case of success, since
-        // some commands prints theirs output to stderr instead of stdout. 'javac' is the example
-        else d.resolve((catchStderr ? stderr : stdout).trim());
-    });
-    return d.promise;
-}
-
 module.exports.isWindows = function () {
     return (os.platform() === 'win32');
 };
@@ -205,19 +194,22 @@ module.exports.check_java = function () {
             }
         }
     }).then(function () {
-        var msg =
-            'Failed to run "javac -version", make sure that you have a JDK installed.\n' +
-            'You can get it from: http://www.oracle.com/technetwork/java/javase/downloads.\n';
-        if (process.env['JAVA_HOME']) {
-            msg += 'Your JAVA_HOME is invalid: ' + process.env['JAVA_HOME'] + '\n';
-        }
-        // We use tryCommand with catchStderr = true, because
-        // javac writes version info to stderr instead of stdout
-        return tryCommand('javac -version', msg, true).then(function (output) {
-            // Let's check for at least Java 8, and keep it future proof so we can support Java 10
-            var match = /javac ((?:1\.)(?:[8-9]\.)(?:\d+))|((?:1\.)(?:[1-9]\d+\.)(?:\d+))/i.exec(output);
-            return match && match[1];
-        });
+        return Q.denodeify(child_process.exec)('javac -version')
+            .then(outputs => {
+                // outputs contains two entries: stdout and stderr
+                // Java <= 8 writes version info to stderr, Java >= 9 to stdout
+                const output = outputs.join('').trim();
+                const match = /javac\s+([\d.]+)/i.exec(output);
+                return match && match[1];
+            }, () => {
+                var msg =
+                'Failed to run "javac -version", make sure that you have a JDK installed.\n' +
+                'You can get it from: http://www.oracle.com/technetwork/java/javase/downloads.\n';
+                if (process.env['JAVA_HOME']) {
+                    msg += 'Your JAVA_HOME is invalid: ' + process.env['JAVA_HOME'] + '\n';
+                }
+                throw new CordovaError(msg);
+            });
     });
 };
 
@@ -364,8 +356,8 @@ module.exports.run = function () {
         console.log('ANDROID_HOME=' + process.env['ANDROID_HOME']);
         console.log('JAVA_HOME=' + process.env['JAVA_HOME']);
 
-        if (!values[0]) {
-            throw new CordovaError('Requirements check failed for JDK 1.8 or greater');
+        if (String(values[0]).startsWith('1.8.')) {
+            throw new CordovaError('Requirements check failed for JDK 1.8');
         }
 
         if (!values[1]) {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -356,7 +356,7 @@ module.exports.run = function () {
         console.log('ANDROID_HOME=' + process.env['ANDROID_HOME']);
         console.log('JAVA_HOME=' + process.env['JAVA_HOME']);
 
-        if (String(values[0]).startsWith('1.8.')) {
+        if (!String(values[0]).startsWith('1.8.')) {
             throw new CordovaError('Requirements check failed for JDK 1.8');
         }
 


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
- Fix Java version check for Java >= 9
- Checks that we have exactly Java 1.8 since nothing else works with the Android SDK
- Tell the user that we need exactly Java 1.8 if we can't find it

### What testing has been done on this change?
The relevant function was not covered by unit tests to begin with, so I only tested this manually with the following code:
```js
Promise.resolve(
  require('./bin/templates/cordova/lib/check_reqs').check_java()
).then(console.log)
```
Output for Java 8 is `1.8.0`, for Java 10 is `10.0.1`.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

~~Added automated test coverage as appropriate for this change~~
