### PR TITLE
CB-14125:(android) Increase old plugin compatibility

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -320,8 +320,8 @@ function studioPathRemap (obj) {
     if (!obj.targetDir.includes('app/src/main')) {
         if (obj.src.endsWith('.java')) {
             return path.join('app/src/main/java', obj.targetDir.substring(4), path.basename(obj.src));
-        } else if (obj.src.endsWith('.xml')) {
-            // We are making a huge assumption here that XML files will be going to res/xml or values/xml
+        } else {
+            // For all other files, add 'app/src/main' to the targetDir if it didn't have it already
             return path.join('app/src/main', obj.targetDir, path.basename(obj.src));
         }
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Increases old plugin compatibility by adding 'app/src/main' to all plugin source-file tags that didn't include it, so the files are copied to the new Android Studio structure

### What testing has been done on this change?
Tested with `cordova plugin add https://github.com/OutSystems/cordova-plugin-audiorecorder.git` as it uses source-file for images and xml

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
