### PR TITLE
CB-14127: (android) Move google maven repo ahead of jcenter

### DIFF
--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -20,10 +20,10 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -22,10 +22,10 @@ apply plugin: 'com.android.application'
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     dependencies {

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -20,10 +20,10 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
     dependencies {
 
@@ -35,10 +35,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
     //This replaces project.properties w.r.t. build settings
     project.ext {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Move google maven repo ahead of jcenter because of some problem to get Google libs from jcenter

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
