### PR TITLE
Lint JS w/out extension too

### DIFF
--- a/bin/android_sdk_version
+++ b/bin/android_sdk_version
@@ -21,9 +21,7 @@
 
 var android_sdk = require('./templates/cordova/lib/android_sdk');
 
-android_sdk.print_newest_available_sdk_target().done(null, function(err) {
+android_sdk.print_newest_available_sdk_target().done(null, function (err) {
     console.error(err);
     process.exit(2);
 });
-
-

--- a/bin/check_reqs
+++ b/bin/check_reqs
@@ -22,9 +22,10 @@
 var check_reqs = require('./templates/cordova/lib/check_reqs');
 
 check_reqs.run().done(
-    function success() {
+    function success () {
         console.log('Looks like your environment fully supports cordova-android development!');
-    }, function fail(err) {
+    },
+    function fail (err) {
         console.log(err);
         process.exit(2);
     }

--- a/bin/create
+++ b/bin/create
@@ -23,12 +23,12 @@ var ConfigParser = require('cordova-common').ConfigParser;
 var Api = require('./templates/cordova/Api');
 
 var argv = require('nopt')({
-    'help' : Boolean,
-    'cli' : Boolean,
-    'shared' : Boolean,
-    'link' : Boolean,
-    'activity-name' : [String, undefined]
-}, { 'd' : '--verbose' });
+    'help': Boolean,
+    'cli': Boolean,
+    'shared': Boolean,
+    'link': Boolean,
+    'activity-name': [String, undefined]
+}, { 'd': '--verbose' });
 
 if (argv.help || argv.argv.remain.length === 0) {
     console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'create')) + ' <path_to_new_project> <package_name> <project_name> [<template_path>] [--activity-name <activity_name>] [--link]');

--- a/bin/templates/cordova/build
+++ b/bin/templates/cordova/build
@@ -19,24 +19,25 @@
        under the License.
 */
 
-var args  = process.argv;
+var args = process.argv;
 var Api = require('./Api');
 var nopt = require('nopt');
 var path = require('path');
 
 // Support basic help commands
-if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0)
+if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(args[2]) >= 0) {
     require('./lib/build').help();
+}
 
 // Do some basic argument parsing
 var buildOpts = nopt({
-    'verbose' : Boolean,
-    'silent' : Boolean,
-    'debug' : Boolean,
-    'release' : Boolean,
+    'verbose': Boolean,
+    'silent': Boolean,
+    'debug': Boolean,
+    'release': Boolean,
     'nobuild': Boolean,
-    'buildConfig' : path
-}, { 'd' : '--verbose' });
+    'buildConfig': path
+}, { 'd': '--verbose' });
 
 // Make buildOptions compatible with PlatformApi build method spec
 buildOpts.argv = buildOpts.argv.original;
@@ -44,7 +45,7 @@ buildOpts.argv = buildOpts.argv.original;
 require('./loggingHelper').adjustLoggerLevel(buildOpts);
 
 new Api().build(buildOpts)
-.catch(function(err) {
+.catch(function (err) {
     console.error(err.stack);
     process.exit(2);
 });

--- a/bin/templates/cordova/clean
+++ b/bin/templates/cordova/clean
@@ -20,11 +20,11 @@
 */
 
 var Api = require('./Api');
-var path  = require('path');
+var path = require('path');
 var nopt = require('nopt');
 
 // Support basic help commands
-if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0) {
+if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0) {
     console.log('Usage: ' + path.relative(process.cwd(), process.argv[1]));
     console.log('Cleans the project directory.');
     process.exit(0);
@@ -32,9 +32,9 @@ if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 
 
 // Do some basic argument parsing
 var opts = nopt({
-    'verbose' : Boolean,
-    'silent' : Boolean
-}, { 'd' : '--verbose' });
+    'verbose': Boolean,
+    'silent': Boolean
+}, { 'd': '--verbose' });
 
 // Make buildOptions compatible with PlatformApi clean method spec
 opts.argv = opts.argv.original;
@@ -45,7 +45,7 @@ opts.noPrepare = true;
 require('./loggingHelper').adjustLoggerLevel(opts);
 
 new Api().clean(opts)
-.catch(function(err) {
+.catch(function (err) {
     console.error(err.stack);
     process.exit(2);
 });

--- a/bin/templates/cordova/lib/install-device
+++ b/bin/templates/cordova/lib/install-device
@@ -19,23 +19,23 @@
        under the License.
 */
 
-var device = require('./device'),
-    args   = process.argv;
+var device = require('./device');
+var args = process.argv;
 
-if(args.length > 2) {
+if (args.length > 2) {
     var install_target;
-    if (args[2].substring(0, 9) == '--target=') {
+    if (args[2].substring(0, 9) === '--target=') {
         install_target = args[2].substring(9, args[2].length);
-        device.install(install_target).done(null, function(err) {
+        device.install(install_target).done(null, function (err) {
             console.error('ERROR: ' + err);
             process.exit(2);
         });
-     } else {
+    } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
         process.exit(2);
-     }
+    }
 } else {
-    device.install().done(null, function(err) {
+    device.install().done(null, function (err) {
         console.error('ERROR: ' + err);
         process.exit(2);
     });

--- a/bin/templates/cordova/lib/install-emulator
+++ b/bin/templates/cordova/lib/install-emulator
@@ -19,20 +19,20 @@
        under the License.
 */
 
-var emulator = require('./emulator'),
-    args     = process.argv;
+var emulator = require('./emulator');
+var args = process.argv;
 
 var install_target;
-if(args.length > 2) {
-    if (args[2].substring(0, 9) == '--target=') {
+if (args.length > 2) {
+    if (args[2].substring(0, 9) === '--target=') {
         install_target = args[2].substring(9, args[2].length);
-     } else {
+    } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
         process.exit(2);
-     }
+    }
 }
 
-emulator.install(install_target).done(null, function(err) {
+emulator.install(install_target).done(null, function (err) {
     console.error('ERROR: ' + err);
     process.exit(2);
 });

--- a/bin/templates/cordova/lib/list-devices
+++ b/bin/templates/cordova/lib/list-devices
@@ -22,12 +22,12 @@
 var devices = require('./device');
 
 // Usage support for when args are given
-require('./check_reqs').check_android().then(function() {
-    devices.list().done(function(device_list) {
-        device_list && device_list.forEach(function(dev) {
+require('./check_reqs').check_android().then(function () {
+    devices.list().done(function (device_list) {
+        device_list && device_list.forEach(function (dev) {
             console.log(dev);
         });
-    }, function(err) {
+    }, function (err) {
         console.error('ERROR: ' + err);
         process.exit(2);
     });

--- a/bin/templates/cordova/lib/list-emulator-images
+++ b/bin/templates/cordova/lib/list-emulator-images
@@ -22,12 +22,12 @@
 var emulators = require('./emulator');
 
 // Usage support for when args are given
-require('./check_reqs').check_android().then(function() {
-    emulators.list_images().done(function(emulator_list) {
-        emulator_list && emulator_list.forEach(function(emu) {
+require('./check_reqs').check_android().then(function () {
+    emulators.list_images().done(function (emulator_list) {
+        emulator_list && emulator_list.forEach(function (emu) {
             console.log(emu.name);
         });
-    }, function(err) {
+    }, function (err) {
         console.error('ERROR: ' + err);
         process.exit(2);
     });

--- a/bin/templates/cordova/lib/list-started-emulators
+++ b/bin/templates/cordova/lib/list-started-emulators
@@ -22,12 +22,12 @@
 var emulators = require('./emulator');
 
 // Usage support for when args are given
-require('./check_reqs').check_android().then(function() {
-    emulators.list_started().done(function(emulator_list) {
-        emulator_list && emulator_list.forEach(function(emu) {
+require('./check_reqs').check_android().then(function () {
+    emulators.list_started().done(function (emulator_list) {
+        emulator_list && emulator_list.forEach(function (emu) {
             console.log(emu);
         });
-    }, function(err) {
+    }, function (err) {
         console.error('ERROR: ' + err);
         process.exit(2);
     });

--- a/bin/templates/cordova/lib/start-emulator
+++ b/bin/templates/cordova/lib/start-emulator
@@ -19,21 +19,20 @@
        under the License.
 */
 
-var emulator = require('./emulator'),
-      args   = process.argv;
+var emulator = require('./emulator');
+var args = process.argv;
 
 var install_target;
-if(args.length > 2) {
-    if (args[2].substring(0, 9) == '--target=') {
+if (args.length > 2) {
+    if (args[2].substring(0, 9) === '--target=') {
         install_target = args[2].substring(9, args[2].length);
-     } else {
+    } else {
         console.error('ERROR : argument \'' + args[2] + '\' not recognized.');
         process.exit(2);
-     }
+    }
 }
 
-emulator.start(install_target).done(null, function(err) {
+emulator.start(install_target).done(null, function (err) {
     console.error('ERROR: ' + err);
     process.exit(2);
 });
-

--- a/bin/templates/cordova/log
+++ b/bin/templates/cordova/log
@@ -19,17 +19,17 @@
        under the License.
 */
 
-var log  = require('./lib/log'),
-    reqs = require('./lib/check_reqs'),
-    args = process.argv;
+var log = require('./lib/log');
+var reqs = require('./lib/check_reqs');
+var args = process.argv;
 
 // Usage support for when args are given
-if(args.length > 2) {
+if (args.length > 2) {
     log.help();
 } else {
-    reqs.run().done(function() {
+    reqs.run().done(function () {
         return log.run();
-    }, function(err) {
+    }, function (err) {
         console.error('ERROR: ' + err);
         process.exit(2);
     });

--- a/bin/templates/cordova/run
+++ b/bin/templates/cordova/run
@@ -24,22 +24,23 @@ var nopt = require('nopt');
 var path = require('path');
 
 // Support basic help commands
-if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0)
+if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0) {
     require('./lib/run').help();
+}
 
 // Do some basic argument parsing
 var runOpts = nopt({
-    'verbose' : Boolean,
-    'silent' : Boolean,
-    'debug' : Boolean,
-    'release' : Boolean,
+    'verbose': Boolean,
+    'silent': Boolean,
+    'debug': Boolean,
+    'release': Boolean,
     'nobuild': Boolean,
-    'buildConfig' : path,
-    'archs' : String,
-    'device' : Boolean,
+    'buildConfig': path,
+    'archs': String,
+    'device': Boolean,
     'emulator': Boolean,
-    'target' : String
-}, { 'd' : '--verbose' });
+    'target': String
+}, { 'd': '--verbose' });
 
 // Make runOptions compatible with PlatformApi run method spec
 runOpts.argv = runOpts.argv.remain;
@@ -47,7 +48,7 @@ runOpts.argv = runOpts.argv.remain;
 require('./loggingHelper').adjustLoggerLevel(runOpts);
 
 new Api().run(runOpts)
-.catch(function(err) {
+.catch(function (err) {
     console.error(err, err.stack);
     process.exit(2);
 });

--- a/bin/templates/cordova/version
+++ b/bin/templates/cordova/version
@@ -20,7 +20,7 @@
 */
 
 // Coho updates this line:
-var VERSION = "7.2.0-dev";
+var VERSION = '7.2.0-dev';
 
 module.exports.version = VERSION;
 

--- a/bin/update
+++ b/bin/update
@@ -18,13 +18,13 @@
        specific language governing permissions and limitations
        under the License.
 */
-var path   = require('path');
+var path = require('path');
 var Api = require('./templates/cordova/Api');
-var args  = require('nopt')({
+var args = require('nopt')({
     'link': Boolean,
     'shared': Boolean,
     'help': Boolean
-}, { 'd' : '--verbose' });
+}, { 'd': '--verbose' });
 
 if (args.help || args.argv.remain.length === 0) {
     console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'update')) + ' <path_to_project> [--link]');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "cover": "istanbul cover --root bin --print detail jasmine -- --config=spec/unit/jasmine.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",
     "java-unit-tests": "node test/run_java_unit_tests.js",
-    "eslint": "eslint bin spec test"
+    "eslint": "run-s -c eslint:*",
+    "eslint:scripts": "eslint bin spec test",
+    "eslint:bins": "eslint 'bin/**/*' --ignore-pattern '**/*.*' --ignore-pattern '**/gitignore'"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
@@ -56,6 +58,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "istanbul": "^0.4.2",
     "jasmine": "~2.6.0",
+    "npm-run-all": "^4.1.3",
     "promise-matchers": "~0",
     "rewire": "^2.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "apache"
   ],
   "scripts": {
-    "test": "npm run eslint && npm run unit-tests && npm run java-unit-tests && npm run e2e-tests",
+    "test": "run-s eslint unit-tests java-unit-tests e2e-tests",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
     "cover": "istanbul cover --root bin --print detail jasmine -- --config=spec/unit/jasmine.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",


### PR DESCRIPTION
This uses `npm-run-all` to run the two ESLint invocations unconditionally in sequence while still preserving the error code.