### PR TITLE
CB-14139 android: Add jvmargs flag for custom values

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -53,6 +53,7 @@ function parseOpts (options, resolvedTarget, projectRoot) {
         buildMethod: process.env.ANDROID_BUILD || 'studio',
         prepEnv: options.argv.prepenv,
         arch: resolvedTarget && resolvedTarget.arch,
+        jvmargs: (options.argv.jvmargs || '-Xmx2048m'),
         extraArgs: []
     };
 

--- a/bin/templates/cordova/lib/builders/GradleBuilder.js
+++ b/bin/templates/cordova/lib/builders/GradleBuilder.js
@@ -57,7 +57,7 @@ GradleBuilder.prototype.getArgs = function (cmd, opts) {
     // 10 seconds -> 6 seconds
     args.push('-Dorg.gradle.daemon=true');
     // to allow dex in process
-    args.push('-Dorg.gradle.jvmargs=-Xmx2048m');
+    args.push('-Dorg.gradle.jvmargs=' + opts.jvmargs);
     // allow NDK to be used - required by Gradle 1.5 plugin
     args.push('-Pandroid.useDeprecatedNdk=true');
     args.push.apply(args, opts.extraArgs);

--- a/bin/templates/cordova/lib/builders/StudioBuilder.js
+++ b/bin/templates/cordova/lib/builders/StudioBuilder.js
@@ -57,7 +57,7 @@ StudioBuilder.prototype.getArgs = function (cmd, opts) {
     // 10 seconds -> 6 seconds
     args.push('-Dorg.gradle.daemon=true');
     // to allow dex in process
-    args.push('-Dorg.gradle.jvmargs=-Xmx2048m');
+    args.push('-Dorg.gradle.jvmargs=' + opts.jvmargs);
     // allow NDK to be used - required by Gradle 1.5 plugin
     // args.push('-Pandroid.useDeprecatedNdk=true');
     args.push.apply(args, opts.extraArgs);


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Added an additional flag `--jvmargs` to allow users to customize the Gradle's JVM memory heap size settings.

Document updates have been submitted in [cordova-docs PR 839](https://github.com/apache/cordova-docs/pull/839).

JIRA Ticket: [CB-14139](https://issues.apache.org/jira/browse/CB-14139)

### What testing has been done on this change?
- cordova build and run with and without flag settings.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
