### PR TITLE
Remove mention of ICLA from contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,6 @@ For instructions on this, start with the
 [contribution overview](http://cordova.apache.org/contribute/).
 
 The details are explained there, but the important items are:
- - Sign and submit an Apache ICLA (Contributor License Agreement).
  - Have a Jira issue open that corresponds to your contribution.
  - Run the tests so your patch doesn't break existing functionality.
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Github

### What does this PR do?
Signing the Apache ICLA is no longer required, so I've removed it from `CONTRIBUTING.md`.

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
