### PR TITLE
Emulator: Add unit tests and remove Q

### DIFF
--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -32,7 +32,6 @@ var shelljs = require('shelljs');
 var android_sdk = require('./android_sdk');
 var check_reqs = require('./check_reqs');
 
-var Q = require('q');
 var os = require('os');
 var fs = require('fs');
 var child_process = require('child_process');
@@ -168,15 +167,13 @@ module.exports.list_images_using_android = function () {
    }
  */
 module.exports.list_images = function () {
-    return Q.fcall(function () {
+    return Promise.resolve().then(function () {
         if (forgivingWhichSync('avdmanager')) {
             return module.exports.list_images_using_avdmanager();
         } else if (forgivingWhichSync('android')) {
             return module.exports.list_images_using_android();
         } else {
-            return Q().then(function () {
-                throw new CordovaError('Could not find either `android` or `avdmanager` on your $PATH! Are you sure the Android SDK is installed and available?');
-            });
+            return Promise.reject(new CordovaError('Could not find either `android` or `avdmanager` on your $PATH! Are you sure the Android SDK is installed and available?'));
         }
     }).then(function (avds) {
         // In case we're missing the Android OS version string from the target description, add it.
@@ -275,8 +272,8 @@ module.exports.get_available_port = function () {
 module.exports.start = function (emulator_ID, boot_timeout) {
     var self = this;
 
-    return Q().then(function () {
-        if (emulator_ID) return Q(emulator_ID);
+    return Promise.resolve().then(function () {
+        if (emulator_ID) return Promise.resolve(emulator_ID);
 
         return self.best_image().then(function (best) {
             if (best && best.name) {
@@ -285,7 +282,7 @@ module.exports.start = function (emulator_ID, boot_timeout) {
             }
 
             var androidCmd = check_reqs.getAbsoluteAndroidCmd();
-            return Q.reject(new CordovaError('No emulator images (avds) found.\n' +
+            return Promise.reject(new CordovaError('No emulator images (avds) found.\n' +
                 '1. Download desired System Image by running: ' + androidCmd + ' sdk\n' +
                 '2. Create an AVD by running: ' + androidCmd + ' avd\n' +
                 'HINT: For a faster emulator, use an Intel System Image and install the HAXM device driver\n'));
@@ -306,7 +303,7 @@ module.exports.start = function (emulator_ID, boot_timeout) {
             return self.wait_for_emulator(port);
         });
     }).then(function (emulatorId) {
-        if (!emulatorId) { return Q.reject(new CordovaError('Failed to start emulator')); }
+        if (!emulatorId) { return Promise.reject(new CordovaError('Failed to start emulator')); }
 
         // wait for emulator to boot up
         process.stdout.write('Waiting for emulator to boot (this may take a while)...');
@@ -332,7 +329,7 @@ module.exports.start = function (emulator_ID, boot_timeout) {
  */
 module.exports.wait_for_emulator = function (port) {
     var self = this;
-    return Q().then(function () {
+    return Promise.resolve().then(function () {
         var emulator_id = 'emulator-' + port;
         return Adb.shell(emulator_id, 'getprop dev.bootcomplete').then(function (output) {
             if (output.indexOf('1') >= 0) {
@@ -369,10 +366,13 @@ module.exports.wait_for_boot = function (emulator_id, time_remaining) {
         } else {
             process.stdout.write('.');
 
-            // Check at regular intervals
-            return Q.delay(time_remaining < CHECK_BOOTED_INTERVAL ? time_remaining : CHECK_BOOTED_INTERVAL).then(function () {
-                var updated_time = time_remaining >= 0 ? Math.max(time_remaining - CHECK_BOOTED_INTERVAL, 0) : time_remaining;
-                return self.wait_for_boot(emulator_id, updated_time);
+            return new Promise(resolve => {
+                const delay = time_remaining < CHECK_BOOTED_INTERVAL ? time_remaining : CHECK_BOOTED_INTERVAL;
+
+                setTimeout(() => {
+                    const updated_time = time_remaining >= 0 ? Math.max(time_remaining - CHECK_BOOTED_INTERVAL, 0) : time_remaining;
+                    resolve(self.wait_for_boot(emulator_id, updated_time));
+                }, delay);
             });
         }
     });
@@ -398,7 +398,7 @@ module.exports.create_image = function (name, target) {
             // TODO: This seems like another error case, even though it always happens.
             console.error('ERROR : Unable to create an avd emulator, no targets found.');
             console.error('Ensure you have targets available by running the "android" command');
-            return Q.reject();
+            return Promise.reject(new CordovaError());
         }, function (error) {
             console.error('ERROR : Failed to create emulator image : ');
             console.error(error);
@@ -409,13 +409,13 @@ module.exports.create_image = function (name, target) {
 module.exports.resolveTarget = function (target) {
     return this.list_started().then(function (emulator_list) {
         if (emulator_list.length < 1) {
-            return Q.reject('No running Android emulators found, please start an emulator before deploying your project.');
+            return Promise.reject(new CordovaError('No running Android emulators found, please start an emulator before deploying your project.'));
         }
 
         // default emulator
         target = target || emulator_list[0];
         if (emulator_list.indexOf(target) < 0) {
-            return Q.reject('Unable to find target \'' + target + '\'. Failed to deploy to emulator.');
+            return Promise.reject(new CordovaError('Unable to find target \'' + target + '\'. Failed to deploy to emulator.'));
         }
 
         return build.detectArchitecture(target).then(function (arch) {
@@ -442,7 +442,7 @@ module.exports.install = function (givenTarget, buildResults) {
     var pkgName = manifest.getPackageId();
 
     // resolve the target emulator
-    return Q().then(function () {
+    return Promise.resolve().then(function () {
         if (givenTarget && typeof givenTarget === 'object') {
             return givenTarget;
         } else {
@@ -457,7 +457,7 @@ module.exports.install = function (givenTarget, buildResults) {
     }).then(function () {
         // This promise is always resolved, even if 'adb uninstall' fails to uninstall app
         // or the app doesn't installed at all, so no error catching needed.
-        return Q.when().then(function () {
+        return Promise.resolve().then(function () {
 
             var apk_path = build.findBestApkForArchitecture(buildResults, target.arch);
             var execOptions = {
@@ -477,7 +477,7 @@ module.exports.install = function (givenTarget, buildResults) {
                 events.emit('verbose', 'Installing apk ' + apk + ' on ' + target + '...');
 
                 var command = 'adb -s ' + target + ' install -r "' + apk + '"';
-                return Q.promise(function (resolve, reject) {
+                return new Promise(function (resolve, reject) {
                     child_process.exec(command, opts, function (err, stdout, stderr) {
                         if (err) reject(new CordovaError('Error executing "' + command + '": ' + stderr));
                         // adb does not return an error code even if installation fails. Instead it puts a specific

--- a/bin/templates/cordova/lib/install-emulator
+++ b/bin/templates/cordova/lib/install-emulator
@@ -32,7 +32,7 @@ if (args.length > 2) {
     }
 }
 
-emulator.install(install_target).done(null, function (err) {
+emulator.install(install_target).catch(function (err) {
     console.error('ERROR: ' + err);
     process.exit(2);
 });

--- a/bin/templates/cordova/lib/list-emulator-images
+++ b/bin/templates/cordova/lib/list-emulator-images
@@ -23,7 +23,7 @@ var emulators = require('./emulator');
 
 // Usage support for when args are given
 require('./check_reqs').check_android().then(function () {
-    emulators.list_images().done(function (emulator_list) {
+    emulators.list_images().then(function (emulator_list) {
         emulator_list && emulator_list.forEach(function (emu) {
             console.log(emu.name);
         });

--- a/bin/templates/cordova/lib/list-started-emulators
+++ b/bin/templates/cordova/lib/list-started-emulators
@@ -23,7 +23,7 @@ var emulators = require('./emulator');
 
 // Usage support for when args are given
 require('./check_reqs').check_android().then(function () {
-    emulators.list_started().done(function (emulator_list) {
+    emulators.list_started().then(function (emulator_list) {
         emulator_list && emulator_list.forEach(function (emu) {
             console.log(emu);
         });

--- a/bin/templates/cordova/lib/start-emulator
+++ b/bin/templates/cordova/lib/start-emulator
@@ -32,7 +32,7 @@ if (args.length > 2) {
     }
 }
 
-emulator.start(install_target).done(null, function (err) {
+emulator.start(install_target).catch(function (err) {
     console.error('ERROR: ' + err);
     process.exit(2);
 });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This is pretty much the same as the devices PR (#462). I have increased the test coverage for `emulator.js` (now at 89%). As with the devices PR, this also removes Q and replaces it with native Promises. It looks like all the uses of `fin` or `finally` are all in tests, and most of them were in `emulator.spec.js`. Refactoring the tests meant they were no longer necessary. The other thing to be aware of is other parts of Cordova expecting Q-like promises. In this case, a few other files were expecting to be able to use `done`, but they could be identically replaced with `then` or `catch`.

There is probably some refactoring that could be done on `emulator.js`. The `install` function has custom functionality due to an old ticket which references Android 2.2 (!). I reckon this could be refactored to use `Adb.install`, but I have left it alone for now.

### What testing has been done on this change?
- Ran emulator-related commands
- Ran unit-tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
