### PR TITLE
Unit tests for android_sdk and AndroidProject

### DIFF
--- a/bin/templates/cordova/lib/android_sdk.js
+++ b/bin/templates/cordova/lib/android_sdk.js
@@ -17,7 +17,6 @@
        under the License.
 */
 
-var Q = require('q');
 var superspawn = require('cordova-common').superspawn;
 
 var suffix_number_regex = /(\d+)$/;
@@ -95,7 +94,7 @@ module.exports.list_targets = function () {
         } else throw err;
     }).then(function (targets) {
         if (targets.length === 0) {
-            return Q.reject(new Error('No android targets (SDKs) installed!'));
+            return Promise.reject(new Error('No android targets (SDKs) installed!'));
         }
         return targets;
     });

--- a/spec/unit/AndroidProject.spec.js
+++ b/spec/unit/AndroidProject.spec.js
@@ -1,0 +1,134 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const path = require('path');
+const rewire = require('rewire');
+
+describe('AndroidProject', () => {
+    const PROJECT_DIR = 'platforms/android';
+    let AndroidProject;
+    let AndroidStudioSpy;
+
+    beforeEach(() => {
+        AndroidProject = rewire('../../bin/templates/cordova/lib/AndroidProject');
+
+        AndroidStudioSpy = jasmine.createSpyObj('AndroidStudio', ['isAndroidStudioProject']);
+        AndroidProject.__set__('AndroidStudio', AndroidStudioSpy);
+    });
+
+    describe('constructor', () => {
+        it('should set the project directory', () => {
+            const project = new AndroidProject(PROJECT_DIR);
+            expect(project.projectDir).toBe(PROJECT_DIR);
+        });
+
+        it('should set www folder correctly if not Android Studio project', () => {
+            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(false);
+
+            const project = new AndroidProject(PROJECT_DIR);
+            expect(project.www).toBe(path.join(PROJECT_DIR, 'assets/www'));
+        });
+
+        it('should set www folder correctly if it is an Android Studio project', () => {
+            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(true);
+
+            const project = new AndroidProject(PROJECT_DIR);
+            expect(project.www).toBe(path.join(PROJECT_DIR, 'app/src/main/assets/www'));
+        });
+    });
+
+    describe('getProjectFile', () => {
+        it('should create and return a new project if one does not exist', () => {
+            const newProject = AndroidProject.getProjectFile(PROJECT_DIR);
+
+            expect(newProject).toEqual(jasmine.any(AndroidProject));
+        });
+
+        it('should cache created projects', () => {
+            const newProject = AndroidProject.getProjectFile(PROJECT_DIR);
+            const secondProject = AndroidProject.getProjectFile(PROJECT_DIR);
+
+            expect(newProject).toEqual(jasmine.any(AndroidProject));
+            expect(secondProject).toBe(newProject);
+        });
+    });
+
+    describe('purgeCache', () => {
+        beforeEach(() => {
+            AndroidProject.__set__('projectFileCache', {
+                project1: 'test',
+                project2: 'anothertest',
+                project3: 'finaltest'
+            });
+        });
+
+        it('should only remove the specified project from the cache', () => {
+            const projectToRemove = 'project2';
+            AndroidProject.purgeCache(projectToRemove);
+
+            const cache = AndroidProject.__get__('projectFileCache');
+            expect(Object.keys(cache).length).toBe(2);
+            expect(cache[projectToRemove]).toBe(undefined);
+        });
+
+        it('should remove all projects from cache', () => {
+            AndroidProject.purgeCache();
+
+            const cache = AndroidProject.__get__('projectFileCache');
+            expect(Object.keys(cache).length).toBe(0);
+        });
+    });
+
+    describe('getPackageName', () => {
+        let AndroidManifestSpy;
+        let AndroidManifestFns;
+        let androidProject;
+
+        beforeEach(() => {
+            AndroidManifestFns = jasmine.createSpyObj('AndroidManifestFns', ['getPackageId']);
+            AndroidManifestSpy = jasmine.createSpy('AndroidManifest').and.returnValue(AndroidManifestFns);
+            AndroidProject.__set__('AndroidManifest', AndroidManifestSpy);
+
+            androidProject = new AndroidProject(PROJECT_DIR);
+        });
+
+        it('should get the package name from the project root manifest', () => {
+            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(false);
+
+            androidProject.getPackageName();
+
+            expect(AndroidManifestSpy).toHaveBeenCalledWith(path.join(PROJECT_DIR, 'AndroidManifest.xml'));
+        });
+
+        it('should get the package name from the Android Studio manifest', () => {
+            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(true);
+
+            androidProject.getPackageName();
+
+            expect(AndroidManifestSpy).toHaveBeenCalledWith(path.join(PROJECT_DIR, 'app/src/main/AndroidManifest.xml'));
+        });
+
+        it('should return the package name', () => {
+            const packageName = 'io.cordova.unittest';
+            AndroidManifestFns.getPackageId.and.returnValue(packageName);
+
+            expect(androidProject.getPackageName()).toBe(packageName);
+        });
+    });
+});


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This is the last unit test PR for today, I promise! The `AndroidProject` tests were originally in #458. This PR also contains increased test coverage for `android_sdk.js`. I have also refactored that to remove `Q`, as with the other PRs I submitted today.

### What testing has been done on this change?
Run unit tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
