### PR TITLE
CB-14145 pin some more bundled deps in 7.1.x patch only

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,17 @@
   "license": "Apache-2.0",
   "dependencies": {
     "android-versions": "1.3.0",
+    "base64-js": "1.2.0",
     "cordova-common": "2.2.5",
     "elementtree": "0.1.6",
+    "glob": "5.0.15",
     "nopt": "3.0.1",
+    "plist": "2.1.0",
     "properties-parser": "0.2.3",
     "q": "1.4.1",
-    "shelljs": "0.5.3"
+    "sax": "0.3.5",
+    "shelljs": "0.5.3",
+    "xmlbuilder": "8.2.2"
   },
   "bundledDependencies": [
     "abbrev",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

- pin some more bundled dependencies to clear the red highlights in `npm outdated --depth=0`

### What testing has been done on this change?

- `npm audit` with npm@6.1.0 (latest version) shows 0 vulnerabilities
- `npm i && npm t` works on both deprecated Node.js 4 (npm 2.15.11) & Node.js 8 (npm 5.6.0)
- using `cordova platform add brodybits/cordova-android#cb-14145-pin-some-more-bundled-deps-in-patch-only` to add platform to new Cordova project and test on Android device using `cordova run android --device` succeeds on the following Node.js versions:
  - deprecated Node.js 4 (npm 2.15.11)
  - Node.js 8 (npm 5.6.0)

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~