### PR TITLE
GH-485: (android) Replace deprecated "compile" with "implementation"

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -196,7 +196,7 @@ class ProjectBuilder {
                     throw new CordovaError('Unsupported system library (does not work with gradle): ' + p);
                 }
             }
-            depsList += '    compile "' + mavenRef + '"\n';
+            depsList += '    implementation "' + mavenRef + '"\n';
         });
 
         buildGradle = buildGradle.replace(/(SUB-PROJECT DEPENDENCIES START)[\s\S]*(\/\/ SUB-PROJECT DEPENDENCIES END)/, '$1\n' + depsList + '    $2');


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
generates gradle dependencies in the `build.gradle` from `<framework>` elements found in the `plugin.xml` as the new `implementation` dependencies instead of deprecated `compile` dependencies

### What testing has been done on this change?
ran `npm run test`

### Checklist
- [✘] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
Created a github Issue: https://github.com/apache/cordova-android/issues/485

- [✓] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

- [✓ ] Added automated test coverage as appropriate for this change.
None were needed

There are some more references to `compile` dependencies in other files but I left them alone bacause I am not sure what they are used for, see:

https://github.com/apache/cordova-android/blob/7.1.x/bin/templates/cordova/lib/plugin-build.gradle#L41-L43
https://github.com/apache/cordova-android/blob/7.1.x/spec/fixtures/android_studio_project/app/build.gradle#L23-L25
