### PR TITLE
Fixes build & run related bugs from builder refactor

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -141,9 +141,9 @@ function writeProjectProperties (projectPath, target_api) {
 }
 
 // This makes no sense, what if you're building with a different build system?
-function prepBuildFiles (projectPath, builder) {
+function prepBuildFiles (projectPath) {
     var buildModule = require(path.resolve(projectPath, 'cordova/lib/builders/builders'));
-    buildModule.getBuilder(builder).prepBuildFiles();
+    buildModule.getBuilder().prepBuildFiles();
 }
 
 function copyBuildRules (projectPath, isLegacy) {
@@ -329,7 +329,7 @@ exports.create = function (project_path, config, options, events) {
             });
             // Link it to local android install.
             exports.writeProjectProperties(project_path, target_api);
-            exports.prepBuildFiles(project_path, 'studio');
+            exports.prepBuildFiles(project_path);
             events.emit('log', generateDoneMessage('create', options.link));
         }).thenResolve(project_path);
 };

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -31,11 +31,10 @@ var events = require('cordova-common').events;
 var spawn = require('cordova-common').superspawn.spawn;
 var CordovaError = require('cordova-common').CordovaError;
 
+module.exports.parseBuildOptions = parseOpts;
 function parseOpts (options, resolvedTarget, projectRoot) {
     options = options || {};
     options.argv = nopt({
-        gradle: Boolean,
-        studio: Boolean,
         prepenv: Boolean,
         versionCode: String,
         minSdkVersion: String,
@@ -50,26 +49,13 @@ function parseOpts (options, resolvedTarget, projectRoot) {
     // Android Studio Build method is the default
     var ret = {
         buildType: options.release ? 'release' : 'debug',
-        buildMethod: process.env.ANDROID_BUILD || 'studio',
         prepEnv: options.argv.prepenv,
         arch: resolvedTarget && resolvedTarget.arch,
         extraArgs: []
     };
 
-    if (options.argv.gradle || options.argv.studio) {
-        ret.buildMethod = options.argv.studio ? 'studio' : 'gradle';
-    }
-
-    // This comes from cordova/run
-    if (options.studio) ret.buildMethod = 'studio';
-    if (options.gradle) ret.buildMethod = 'gradle';
-
-    if (options.nobuild) ret.buildMethod = 'none';
-
     if (options.argv.versionCode) { ret.extraArgs.push('-PcdvVersionCode=' + options.argv.versionCode); }
-
     if (options.argv.minSdkVersion) { ret.extraArgs.push('-PcdvMinSdkVersion=' + options.argv.minSdkVersion); }
-
     if (options.argv.gradleArg) {
         ret.extraArgs = ret.extraArgs.concat(options.argv.gradleArg);
     }
@@ -129,7 +115,8 @@ function parseOpts (options, resolvedTarget, projectRoot) {
  */
 module.exports.runClean = function (options) {
     var opts = parseOpts(options, null, this.root);
-    var builder = builders.getBuilder(opts.buildMethod);
+    var builder = builders.getBuilder();
+
     return builder.prepEnv(opts).then(function () {
         return builder.clean(opts);
     });
@@ -149,8 +136,8 @@ module.exports.runClean = function (options) {
  */
 module.exports.run = function (options, optResolvedTarget) {
     var opts = parseOpts(options, optResolvedTarget, this.root);
-    console.log(opts.buildMethod);
-    var builder = builders.getBuilder(opts.buildMethod);
+    var builder = builders.getBuilder();
+
     return builder.prepEnv(opts).then(function () {
         if (opts.prepEnv) {
             events.emit('verbose', 'Build file successfully prepared.');
@@ -161,8 +148,7 @@ module.exports.run = function (options, optResolvedTarget) {
             events.emit('log', 'Built the following apk(s): \n\t' + apkPaths.join('\n\t'));
             return {
                 apkPaths: apkPaths,
-                buildType: opts.buildType,
-                buildMethod: opts.buildMethod
+                buildType: opts.buildType
             };
         });
     });
@@ -276,12 +262,10 @@ module.exports.help = function () {
     console.log('Flags:');
     console.log('    \'--debug\': will build project in debug mode (default)');
     console.log('    \'--release\': will build project for release');
-    console.log('    \'--ant\': will build project with ant');
-    console.log('    \'--gradle\': will build project with gradle (default)');
     console.log('    \'--nobuild\': will skip build process (useful when using run command)');
     console.log('    \'--prepenv\': don\'t build, but copy in build scripts where necessary');
-    console.log('    \'--versionCode=#\': Override versionCode for this build. Useful for uploading multiple APKs. Requires --gradle.');
-    console.log('    \'--minSdkVersion=#\': Override minSdkVersion for this build. Useful for uploading multiple APKs. Requires --gradle.');
+    console.log('    \'--versionCode=#\': Override versionCode for this build. Useful for uploading multiple APKs.');
+    console.log('    \'--minSdkVersion=#\': Override minSdkVersion for this build. Useful for uploading multiple APKs.');
     console.log('    \'--gradleArg=<gradle command line arg>\': Extra args to pass to the gradle command. Use one flag per arg. Ex. --gradleArg=-PcdvBuildMultipleApks=true');
     console.log('');
     console.log('Signed APK flags (overwrites debug/release-signing.proprties) :');

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -35,12 +35,9 @@ const TEMPLATE =
     '# Do not modify this file -- ' + MARKER + '\n';
 
 class ProjectBuilder {
-    constructor (projectRoot) {
-        this.root = projectRoot || path.resolve(__dirname, '../../..');
-        this.binDirs = {
-            studio: path.join(this.root, 'app', 'build', 'outputs', 'apk'),
-            gradle: path.join(this.root, 'app', 'build', 'outputs', 'apk')
-        };
+    constructor (rootDirectory) {
+        this.root = rootDirectory || path.resolve(__dirname, '../../..');
+        this.binDir = path.join(this.root, 'app', 'build', 'outputs', 'apk');
     }
 
     getArgs (cmd, opts) {
@@ -295,11 +292,14 @@ class ProjectBuilder {
     }
 
     findOutputApks (build_type, arch) {
-        var self = this;
-        return Object.keys(this.binDirs).reduce(function (result, builderName) {
-            var binDir = self.binDirs[builderName];
-            return result.concat(findOutputApksHelper(binDir, build_type, builderName === 'ant' ? null : arch));
-        }, []).sort(apkSorter);
+        return findOutputApksHelper(this.binDir, build_type, arch).sort(apkSorter);
+    }
+
+    fetchBuildResults (build_type, arch) {
+        return {
+            apkPaths: this.findOutputApks(build_type, arch),
+            buildType: build_type
+        };
     }
 }
 

--- a/bin/templates/cordova/lib/builders/builders.js
+++ b/bin/templates/cordova/lib/builders/builders.js
@@ -17,29 +17,18 @@
     under the License.
 */
 
-var CordovaError = require('cordova-common').CordovaError;
-
-var knownBuilders = {
-    gradle: 'ProjectBuilder',
-    studio: 'ProjectBuilder'
-};
+const CordovaError = require('cordova-common').CordovaError;
 
 /**
- * Helper method that instantiates and returns a builder for specified build
- *   type.
+ * Helper method that instantiates and returns a builder for specified build type.
  *
- * @param   {String}  builderType   Builder name to construct and return. Must
- *   be one of gradle' or 'studio'
- *
- * @return  {Builder}               A builder instance for specified build type.
+ * @return {Builder} A builder instance for specified build type.
  */
-module.exports.getBuilder = function (builderType, projectRoot) {
-    if (!knownBuilders[builderType]) { throw new CordovaError('Builder ' + builderType + ' is not supported.'); }
-
+module.exports.getBuilder = function () {
     try {
-        var Builder = require('./' + knownBuilders[builderType]);
-        return new Builder(projectRoot);
+        const Builder = require('./ProjectBuilder');
+        return new Builder();
     } catch (err) {
-        throw new CordovaError('Failed to instantiate ' + knownBuilders[builderType] + ' builder: ' + err);
+        throw new CordovaError('Failed to instantiate ProjectBuilder builder: ' + err);
     }
 };

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -434,12 +434,9 @@ module.exports.install = function (givenTarget, buildResults) {
 
     var target;
     // We need to find the proper path to the Android Manifest
-    var manifestPath = path.join(__dirname, '..', '..', 'app', 'src', 'main', 'AndroidManifest.xml');
-    if (buildResults.buildMethod === 'gradle') {
-        manifestPath = path.join(__dirname, '../../AndroidManifest.xml');
-    }
-    var manifest = new AndroidManifest(manifestPath);
-    var pkgName = manifest.getPackageId();
+    const manifestPath = path.join(__dirname, '..', '..', 'app', 'src', 'main', 'AndroidManifest.xml');
+    const manifest = new AndroidManifest(manifestPath);
+    const pkgName = manifest.getPackageId();
 
     // resolve the target emulator
     return Promise.resolve().then(function () {

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -26,14 +26,7 @@ var handlers = {
             if (!obj.src) throw new CordovaError(generateAttributeError('src', 'source-file', plugin.id));
             if (!obj.targetDir) throw new CordovaError(generateAttributeError('target-dir', 'source-file', plugin.id));
 
-            var dest = path.join(obj.targetDir, path.basename(obj.src));
-
-            // TODO: This code needs to be replaced, since the core plugins need to be re-mapped to a different location in
-            // a later plugins release.  This is for legacy plugins to work with Cordova.
-
-            if (options && options.android_studio === true) {
-                dest = studioPathRemap(obj);
-            }
+            var dest = studioPathRemap(obj);
 
             if (options && options.force) {
                 copyFile(plugin.dir, obj.src, project.projectDir, dest, !!(options && options.link));
@@ -42,11 +35,7 @@ var handlers = {
             }
         },
         uninstall: function (obj, plugin, project, options) {
-            var dest = path.join(obj.targetDir, path.basename(obj.src));
-
-            if (options && options.android_studio === true) {
-                dest = studioPathRemap(obj);
-            }
+            var dest = studioPathRemap(obj);
 
             // TODO: Add Koltin extension to uninstall, since they are handled like Java files
             if (obj.src.endsWith('java')) {
@@ -59,33 +48,21 @@ var handlers = {
     },
     'lib-file': {
         install: function (obj, plugin, project, options) {
-            var dest = path.join('libs', path.basename(obj.src));
-            if (options && options.android_studio === true) {
-                dest = path.join('app/libs', path.basename(obj.src));
-            }
+            var dest = path.join('app/libs', path.basename(obj.src));
             copyFile(plugin.dir, obj.src, project.projectDir, dest, !!(options && options.link));
         },
         uninstall: function (obj, plugin, project, options) {
-            var dest = path.join('libs', path.basename(obj.src));
-            if (options && options.android_studio === true) {
-                dest = path.join('app/libs', path.basename(obj.src));
-            }
+            var dest = path.join('app/libs', path.basename(obj.src));
             removeFile(project.projectDir, dest);
         }
     },
     'resource-file': {
         install: function (obj, plugin, project, options) {
-            var dest = path.normalize(obj.target);
-            if (options && options.android_studio === true) {
-                dest = path.join('app/src/main', dest);
-            }
+            var dest = path.join('app', 'src', 'main', obj.target);
             copyFile(plugin.dir, obj.src, project.projectDir, dest, !!(options && options.link));
         },
         uninstall: function (obj, plugin, project, options) {
-            var dest = path.normalize(obj.target);
-            if (options && options.android_studio === true) {
-                dest = path.join('app/src/main', dest);
-            }
+            var dest = path.join('app', 'src', 'main', obj.target);
             removeFile(project.projectDir, dest);
         }
     },

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -20,7 +20,6 @@
 */
 
 var path = require('path');
-var build = require('./build');
 var emulator = require('./emulator');
 var device = require('./device');
 var Q = require('q');
@@ -50,6 +49,7 @@ function getInstallTarget (runOptions) {
  * @return  {Promise}
  */
 module.exports.run = function (runOptions) {
+    runOptions = runOptions || {};
 
     var self = this;
     var install_target = getInstallTarget(runOptions);
@@ -101,16 +101,17 @@ module.exports.run = function (runOptions) {
             });
         });
     }).then(function (resolvedTarget) {
-        // Better just call self.build, but we're doing some processing of
-        // build results (according to platformApi spec) so they are in different
-        // format than emulator.install expects.
-        // TODO: Update emulator/device.install to handle this change
-        return build.run.call(self, runOptions, resolvedTarget).then(function (buildResults) {
+        return new Promise((resolve) => {
+            const builder = require('./builders/builders').getBuilder();
+            const buildOptions = require('./build').parseBuildOptions(runOptions, null, self.root);
+            resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));
+        }).then(function (buildResults) {
             if (resolvedTarget && resolvedTarget.isEmulator) {
                 return emulator.wait_for_boot(resolvedTarget.target).then(function () {
                     return emulator.install(resolvedTarget, buildResults);
                 });
             }
+
             return device.install(resolvedTarget, buildResults);
         });
     });

--- a/spec/unit/AndroidProject.spec.js
+++ b/spec/unit/AndroidProject.spec.js
@@ -38,16 +38,7 @@ describe('AndroidProject', () => {
             expect(project.projectDir).toBe(PROJECT_DIR);
         });
 
-        it('should set www folder correctly if not Android Studio project', () => {
-            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(false);
-
-            const project = new AndroidProject(PROJECT_DIR);
-            expect(project.www).toBe(path.join(PROJECT_DIR, 'assets/www'));
-        });
-
         it('should set www folder correctly if it is an Android Studio project', () => {
-            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(true);
-
             const project = new AndroidProject(PROJECT_DIR);
             expect(project.www).toBe(path.join(PROJECT_DIR, 'app/src/main/assets/www'));
         });
@@ -108,19 +99,8 @@ describe('AndroidProject', () => {
             androidProject = new AndroidProject(PROJECT_DIR);
         });
 
-        it('should get the package name from the project root manifest', () => {
-            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(false);
-
+        it('should get the package name AndroidManifest', () => {
             androidProject.getPackageName();
-
-            expect(AndroidManifestSpy).toHaveBeenCalledWith(path.join(PROJECT_DIR, 'AndroidManifest.xml'));
-        });
-
-        it('should get the package name from the Android Studio manifest', () => {
-            AndroidStudioSpy.isAndroidStudioProject.and.returnValue(true);
-
-            androidProject.getPackageName();
-
             expect(AndroidManifestSpy).toHaveBeenCalledWith(path.join(PROJECT_DIR, 'app/src/main/AndroidManifest.xml'));
         });
 

--- a/spec/unit/builders/builders.spec.js
+++ b/spec/unit/builders/builders.spec.js
@@ -31,24 +31,15 @@ describe('builders', () => {
 
     describe('getBuilder', () => {
         it('should return an instance of ProjectBuilder when gradle is requested', () => {
-            const newBuilder = builders.getBuilder('gradle');
+            const newBuilder = builders.getBuilder();
             expect(newBuilder).toEqual(jasmine.any(ProjectBuilder));
-        });
-
-        it('should return an instance of ProjectBuilder when studio is requested', () => {
-            const newBuilder = builders.getBuilder('studio');
-            expect(newBuilder).toEqual(jasmine.any(ProjectBuilder));
-        });
-
-        it('should throw an error if the selected builder does not exist', () => {
-            expect(() => builders.getBuilder('NonExistentBuilder')).toThrow(jasmine.any(CordovaError));
         });
 
         it('should throw an error if a builder cannot be instantiated', () => {
             const requireSpy = jasmine.createSpy('require').and.throwError();
             builders.__set__('require', requireSpy);
 
-            expect(() => builders.getBuilder('gradle')).toThrow(jasmine.any(CordovaError));
+            expect(() => builders.getBuilder()).toThrow(jasmine.any(CordovaError));
         });
     });
 });

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -274,7 +274,7 @@ describe('create', function () {
             });
             it('should prepare build files', function (done) {
                 create.create(project_path, config_mock, {}, events_mock).then(function () {
-                    expect(create.prepBuildFiles).toHaveBeenCalledWith(project_path, 'studio');
+                    expect(create.prepBuildFiles).toHaveBeenCalledWith(project_path);
                 }).fail(fail).done(done);
             });
         });

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -61,14 +61,14 @@ describe('android project handler', function () {
 
         describe('of <lib-file> elements', function () {
             it('Test#001 : should copy files for Android Studio projects', function () {
-                android['lib-file'].install(valid_libs[0], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['lib-file'].install(valid_libs[0], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin, 'src/android/TestLib.jar', temp, path.join('app', 'libs', 'TestLib.jar'), false);
             });
         });
 
         describe('of <resource-file> elements', function () {
             it('Test#002 : should copy files to the correct location on an Android Studio project', function () {
-                android['resource-file'].install(valid_resources[0], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['resource-file'].install(valid_resources[0], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin, 'android-resource.xml', temp, path.join('app', 'src', 'main', 'res', 'xml', 'dummy.xml'), false);
             });
         });
@@ -81,13 +81,7 @@ describe('android project handler', function () {
             it('Test#003 : should copy stuff from one location to another by calling common.copyFile', function () {
                 android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
-                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin.java', temp, path.join('src/com/phonegap/plugins/dummyplugin/DummyPlugin.java'), false);
-            });
-
-            it('Test#004 : should install source files to the right location for Android Studio projects', function () {
-                android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject, {android_studio: true});
-                expect(copyFileSpy)
-                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin.java', temp, path.join('app/src/main/java/com/phonegap/plugins/dummyplugin/DummyPlugin.java'), false);
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin.java', temp, path.join('app', 'src', 'main', 'java', 'com', 'phonegap', 'plugins', 'dummyplugin', 'DummyPlugin.java'), false);
             });
 
             it('Test#005 : should throw if source file cannot be found', function () {
@@ -99,7 +93,7 @@ describe('android project handler', function () {
 
             it('Test#006 : should throw if target file already exists', function () {
                 // write out a file
-                var target = path.resolve(temp, 'src/com/phonegap/plugins/dummyplugin');
+                let target = path.resolve(temp, 'app', 'src', 'main', 'java', 'com', 'phonegap', 'plugins', 'dummyplugin');
                 shell.mkdir('-p', target);
                 target = path.join(target, 'DummyPlugin.java');
                 fs.writeFileSync(target, 'some bs', 'utf-8');
@@ -243,24 +237,24 @@ describe('android project handler', function () {
 
         describe('of <lib-file> elements', function () {
             it('Test#017 : should remove jar files for Android Studio projects', function () {
-                android['lib-file'].install(valid_libs[0], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['lib-file'].uninstall(valid_libs[0], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['lib-file'].install(valid_libs[0], dummyPluginInfo, dummyProject);
+                android['lib-file'].uninstall(valid_libs[0], dummyPluginInfo, dummyProject);
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/libs/TestLib.jar'));
             });
         });
 
         describe('of <resource-file> elements', function () {
             it('Test#018 : should remove files for Android Studio projects', function () {
-                android['resource-file'].install(valid_resources[0], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['resource-file'].uninstall(valid_resources[0], dummyPluginInfo, dummyProject, {android_studio: true});
-                expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/res/xml/dummy.xml'));
+                android['resource-file'].install(valid_resources[0], dummyPluginInfo, dummyProject);
+                android['resource-file'].uninstall(valid_resources[0], dummyPluginInfo, dummyProject);
+                expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app', 'src', 'main', 'res', 'xml', 'dummy.xml'));
             });
         });
 
         describe('of <source-file> elements', function () {
             it('Test#019 : should remove stuff by calling common.deleteJava for Android Studio projects', function () {
-                android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[0], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[0], dummyPluginInfo, dummyProject);
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/java/com/phonegap/plugins/dummyplugin/DummyPlugin.java'));
             });
         });

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -42,23 +42,18 @@ describe('run', () => {
     });
 
     describe('run method', () => {
-        let buildSpyObj;
         let deviceSpyObj;
         let emulatorSpyObj;
         let eventsSpyObj;
         let getInstallTargetSpy;
 
         beforeEach(() => {
-            buildSpyObj = jasmine.createSpyObj('buildSpy', ['run']);
             deviceSpyObj = jasmine.createSpyObj('deviceSpy', ['install', 'list', 'resolveTarget']);
             emulatorSpyObj = jasmine.createSpyObj('emulatorSpy', ['install', 'list_images', 'list_started', 'resolveTarget', 'start', 'wait_for_boot']);
             eventsSpyObj = jasmine.createSpyObj('eventsSpy', ['emit']);
             getInstallTargetSpy = jasmine.createSpy('getInstallTargetSpy');
 
-            buildSpyObj.run.and.returnValue(Promise.resolve());
-
             run.__set__({
-                build: buildSpyObj,
                 device: deviceSpyObj,
                 emulator: emulatorSpyObj,
                 events: eventsSpyObj,
@@ -180,22 +175,13 @@ describe('run', () => {
             );
         });
 
-        it('should build the app if a target has been found', () => {
-            getInstallTargetSpy.and.returnValue('--device');
-            deviceSpyObj.resolveTarget.and.returnValue({ target: 'device1', isEmulator: false });
-
-            return run.run().then(() => {
-                expect(buildSpyObj.run).toHaveBeenCalled();
-            });
-        });
-
         it('should install on device after build', () => {
             const deviceTarget = { target: 'device1', isEmulator: false };
             getInstallTargetSpy.and.returnValue('--device');
             deviceSpyObj.resolveTarget.and.returnValue(deviceTarget);
 
             return run.run().then(() => {
-                expect(deviceSpyObj.install).toHaveBeenCalledWith(deviceTarget, undefined);
+                expect(deviceSpyObj.install).toHaveBeenCalledWith(deviceTarget, {apkPaths: [], buildType: 'debug'});
             });
         });
 
@@ -207,7 +193,7 @@ describe('run', () => {
             emulatorSpyObj.wait_for_boot.and.returnValue(Promise.resolve());
 
             return run.run().then(() => {
-                expect(emulatorSpyObj.install).toHaveBeenCalledWith(emulatorTarget, undefined);
+                expect(emulatorSpyObj.install).toHaveBeenCalledWith(emulatorTarget, {apkPaths: [], buildType: 'debug'});
             });
         });
     });


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Fixes, refactors, and improves the build and run process that came from the builder refactor.

- General Code Refactor
- Removed builder type argument from getBuilder API
- Removed any reference of conditional statements around builder type
- Remove plugin handler install and uninstall option flag android_studio
- Remove --gradle flag references
- Fixed plugin handler install and uninstall pathing issues
- Use the nobuild flag option to control the run build.
- Updated test spec to reflect the changes.

### What testing has been done on this change?
#### General Tests
- [x] `npm test`
- [x] `npm run eslint`

#### Default Template
- [x] `cordova prepare android`
- [x] `cordova compile android`

#### Builds Tested with Device
- [x] `cordova build android`
- [x] `cordova build android --release --device`
- [x] `cordova build android --debug --device`
- [x] `cordova run android --device`

#### Builds Tested on Emulator
- [x] `cordova build android`
- [x] `cordova build android --release --emulator`
- [x] `cordova build android --debug --emulator`
- [x] `cordova run android --emulator`

### Checklist
- [x] Created GitHub Issue #488
- [x] Updated automated test coverage as appropriate for this change.