### PR TITLE
Gradle updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 android:
     components:
-        - build-tools-26.0.2
+        - build-tools-28.0.3
 env:
     global:
         # Keep gradle from crapping all over the log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     GRADLE_OPTS: -Dorg.gradle.daemon=false
 
     # URL for SDK Tools, Revision 26.1.1 (September 2017)
-    SDK_TOOLS_URL: https://dl.google.com/android/repository/sdk-tools-windows-3859397.zip
+    SDK_TOOLS_URL: https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip
 
     matrix:
         - nodejs_version: 6
@@ -20,7 +20,7 @@ install:
     - set PATH=%PATH%;"%ANDROID_HOME%\tools\bin"
 
     - yes 2> nul | sdkmanager --licenses > nul
-    - sdkmanager "build-tools;26.0.2"
+    - sdkmanager "build-tools;28.0.3"
 
     - choco install gradle --version 3.4.1
 

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -214,7 +214,7 @@ class ProjectBuilder {
                 // If it's not set, do nothing, assuming that we're using a future version of gradle that we don't want to mess with.
                 // For some reason, using ^ and $ don't work.  This does the job, though.
                 var distributionUrlRegex = /distributionUrl.*zip/;
-                var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.4-all.zip';
+                var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.6-all.zip';
                 var gradleWrapperPropertiesPath = path.join(self.root, 'gradle', 'wrapper', 'gradle-wrapper.properties');
                 shell.chmod('u+w', gradleWrapperPropertiesPath);
                 shell.sed('-i', distributionUrlRegex, 'distributionUrl=' + distributionUrl, gradleWrapperPropertiesPath);

--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -20,9 +20,7 @@
 
 buildscript {
     repositories {
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
 
@@ -38,7 +36,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+    implementation fileTree(dir: 'libs', include: '*.jar')
     debugCompile project(path: ":CordovaLib", configuration: "debug")
     releaseCompile project(path: ":CordovaLib", configuration: "release")
 }
@@ -46,7 +44,6 @@ dependencies {
 android {
     compileSdkVersion cdvCompileSdkVersion
     buildToolsVersion cdvBuildToolsVersion
-    publishNonDefault true
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_6

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -22,33 +22,32 @@ apply plugin: 'com.android.application'
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
 // Allow plugins to declare Maven dependencies via build-extras.gradle.
 allprojects {
     repositories {
-        mavenCentral();
+        mavenCentral()
         jcenter()
     }
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.4.0'
+    gradleVersion = '4.6.0'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.
 // Refer to: http://www.gradle.org/docs/current/userguide/tutorial_this_and_that.html
 ext {
     apply from: '../CordovaLib/cordova.gradle'
+
     // The value for android.compileSdkVersion.
     if (!project.hasProperty('cdvCompileSdkVersion')) {
         cdvCompileSdkVersion = null;
@@ -145,24 +144,25 @@ cdvBuildRelease.dependsOn {
     return computeBuildTargetName(false)
 }
 
-task cdvPrintProps << {
-    println('cdvCompileSdkVersion=' + cdvCompileSdkVersion)
-    println('cdvBuildToolsVersion=' + cdvBuildToolsVersion)
-    println('cdvVersionCode=' + cdvVersionCode)
-    println('cdvVersionCodeForceAbiDigit=' + cdvVersionCodeForceAbiDigit)
-    println('cdvMinSdkVersion=' + cdvMinSdkVersion)
-    println('cdvBuildMultipleApks=' + cdvBuildMultipleApks)
-    println('cdvReleaseSigningPropertiesFile=' + cdvReleaseSigningPropertiesFile)
-    println('cdvDebugSigningPropertiesFile=' + cdvDebugSigningPropertiesFile)
-    println('cdvBuildArch=' + cdvBuildArch)
-    println('computedVersionCode=' + android.defaultConfig.versionCode)
-    android.productFlavors.each { flavor ->
-        println('computed' + flavor.name.capitalize() + 'VersionCode=' + flavor.versionCode)
+task cdvPrintProps {
+    doLast {
+        println('cdvCompileSdkVersion=' + cdvCompileSdkVersion)
+        println('cdvBuildToolsVersion=' + cdvBuildToolsVersion)
+        println('cdvVersionCode=' + cdvVersionCode)
+        println('cdvVersionCodeForceAbiDigit=' + cdvVersionCodeForceAbiDigit)
+        println('cdvMinSdkVersion=' + cdvMinSdkVersion)
+        println('cdvBuildMultipleApks=' + cdvBuildMultipleApks)
+        println('cdvReleaseSigningPropertiesFile=' + cdvReleaseSigningPropertiesFile)
+        println('cdvDebugSigningPropertiesFile=' + cdvDebugSigningPropertiesFile)
+        println('cdvBuildArch=' + cdvBuildArch)
+        println('computedVersionCode=' + android.defaultConfig.versionCode)
+        android.productFlavors.each { flavor ->
+            println('computed' + flavor.name.capitalize() + 'VersionCode=' + flavor.versionCode)
+        }
     }
 }
 
 android {
-
     defaultConfig {
         versionCode cdvVersionCode ?: new BigInteger("" + privateHelpers.extractIntFromManifest("versionCode"))
         applicationId privateHelpers.extractStringFromManifest("package")
@@ -249,6 +249,7 @@ android {
         }
         addSigningProps(cdvReleaseSigningPropertiesFile, signingConfigs.release)
     }
+
     if (cdvDebugSigningPropertiesFile) {
         addSigningProps(cdvDebugSigningPropertiesFile, signingConfigs.debug)
     }

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -20,32 +20,30 @@
 
 buildscript {
     repositories {
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
-    dependencies {
 
+    dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.android.tools.build:gradle:3.1.0'
+
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
 allprojects {
     repositories {
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
+
     //This replaces project.properties w.r.t. build settings
     project.ext {
-      defaultBuildToolsVersion="27.0.1" //String
+      defaultBuildToolsVersion="28.0.3" //String
       defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      defaultTargetSdkVersion=27 //Integer - We ALWAYS target the latest by default
-      defaultCompileSdkVersion=27 //Integer - We ALWAYS compile with the latest by default
+      defaultTargetSdkVersion=28 //Integer - We ALWAYS target the latest by default
+      defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
     }
 }
 

--- a/bin/templates/project/legacy/build.gradle
+++ b/bin/templates/project/legacy/build.gradle
@@ -245,7 +245,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+    implementation fileTree(dir: 'libs', include: '*.jar')
     // SUB-PROJECT DEPENDENCIES START
     // SUB-PROJECT DEPENDENCIES END
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -24,17 +24,15 @@ ext {
 
 buildscript {
     repositories {
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
 
     dependencies {
         // The gradle plugin and the maven plugin have to be updated after each version of Android
         // studio comes out
-        classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
@@ -49,7 +47,6 @@ version = '8.0.0-dev'
 android {
     compileSdkVersion cdvCompileSdkVersion
     buildToolsVersion cdvBuildToolsVersion
-    publishNonDefault true
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -96,9 +93,9 @@ install {
                     }
                 }
                 scm {
-                    connection 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
-                    developerConnection 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
-                    url 'https://git-wip-us.apache.org/repos/asf?p=cordova-android'
+                    connection 'scm:git:https://github.com/apache/cordova-android.git'
+                    developerConnection 'scm:git:git@github.com:apache/cordova-android.git'
+                    url 'https://github.com/apache/cordova-android'
 
                 }
             }
@@ -124,9 +121,9 @@ bintray {
         name = 'cordova-android'
         userOrg = 'cordova'
         licenses = ['Apache-2.0']
-        vcsUrl = 'https://git-wip-us.apache.org/repos/asf?p=cordova-android.git'
+        vcsUrl = 'https://github.com/apache/cordova-android'
         websiteUrl = 'https://cordova.apache.org'
-        issueTrackerUrl = 'https://issues.apache.org/jira/browse/CB'
+        issueTrackerUrl = 'https://github.com/apache/cordova-android/issues'
         publicDownloadNumbers = true
         licenses = ['Apache-2.0']
         labels = ['android', 'cordova', 'phonegap']

--- a/framework/gradle/wrapper/gradle-wrapper.properties
+++ b/framework/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -144,7 +144,7 @@ public class CoreAndroid extends CordovaPlugin {
     public void clearCache() {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
-                webView.clearCache(true);
+                webView.clearCache();
             }
         });
     }

--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -58,7 +58,11 @@ class SystemCookieManager implements ICordovaCookieManager {
     }
 
     public void clearCookies() {
-        cookieManager.removeAllCookie();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            cookieManager.removeAllCookies(null);
+        } else {
+            cookieManager.removeAllCookie();
+        }
     }
 
     public void flush() {

--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -142,6 +142,7 @@ public class SystemWebChromeClient extends WebChromeClient {
      * Handle database quota exceeded notification.
      */
     @Override
+    @SuppressWarnings("deprecation")
     public void onExceededDatabaseQuota(String url, String databaseIdentifier, long currentQuota, long estimatedSize,
             long totalUsedQuota, WebStorage.QuotaUpdater quotaUpdater)
     {
@@ -180,11 +181,13 @@ public class SystemWebChromeClient extends WebChromeClient {
 
     // API level 7 is required for this, see if we could lower this using something else
     @Override
+    @SuppressWarnings("deprecation")
     public void onShowCustomView(View view, WebChromeClient.CustomViewCallback callback) {
         parentEngine.getCordovaWebView().showCustomView(view, callback);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onHideCustomView() {
         parentEngine.getCordovaWebView().hideCustomView();
     }

--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -74,7 +74,8 @@ public class SystemWebViewClient extends WebViewClient {
      * @param url           The url to be loaded.
      * @return              true to override, false for default behavior
      */
-	@Override
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         return parentEngine.client.onNavigationAttempt(url);
     }
@@ -186,6 +187,7 @@ public class SystemWebViewClient extends WebViewClient {
      * @param failingUrl    The url that failed to load.
      */
     @Override
+    @SuppressWarnings("deprecation")
     public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
         // Ignore error due to stopLoading().
         if (!isCurrentlyLoading) {
@@ -316,6 +318,7 @@ public class SystemWebViewClient extends WebViewClient {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
         try {
             // Check the against the whitelist and lock out access to the WebView directory

--- a/spec/fixtures/android_studio_project/app/build.gradle
+++ b/spec/fixtures/android_studio_project/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.example.anis.myapplication"
         minSdkVersion 21
-        targetSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    implementation 'com.android.support:appcompat-v7:23.4.0'
 }

--- a/test/app/build.gradle
+++ b/test/app/build.gradle
@@ -19,16 +19,18 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
+
     defaultConfig {
         applicationId "org.apache.cordova.unittests"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -23,11 +23,12 @@ buildscript {
         google()
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
 
+    dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/test/wrapper.gradle
+++ b/test/wrapper.gradle
@@ -1,3 +1,3 @@
 wrapper {
-    gradleVersion = '4.4.1'
+    gradleVersion = '4.6'
 }


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
* Updates to latest version of the [Android gradle plugin](https://developer.android.com/studio/releases/gradle-plugin#3-2-0) (3.2.0)
* Updates gradle to the minimum version required by that plugin (4.6)
* Fixes a gradle warning about LeftShift Closure being deprecated
* Fixes a gradle warning about publishNonDefault being deprecated
* Uses the `google()` repo syntax to reference the Google maven repository
* Updates the Github/project URLs for maven artifacts
* Fixes a handful of deprecation warnings happening inside the CordovaLib classes

In theory, this should fix the NDK issues reported in #504 due to outdated gradle versions.

### What testing has been done on this change?
Nothing yet :upside_down_face: 

### Checklist
- [x] Reported an issue: #504
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
