### PR TITLE
Cherry-pick gradle related fixes to 6.4.x

### DIFF
--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -20,10 +20,10 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -21,10 +21,10 @@ apply plugin: 'com.android.application'
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the
@@ -39,10 +39,10 @@ buildscript {
 // Allow plugins to declare Maven dependencies via build-extras.gradle.
 allprojects {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -24,10 +24,10 @@ ext {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     dependencies {

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -20,8 +20,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -33,8 +33,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Cherry-pick gradle error fixes from `master` to `6.4.x`:

- https://github.com/apache/cordova-android/pull/450
- https://github.com/apache/cordova-android/pull/523

### What testing has been done on this change?

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
