### PR TITLE
Maven needs to be above jcenter in template file

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -20,10 +20,10 @@
 
 buildscript {
     repositories {
+        jcenter()
         maven {
             url "https://maven.google.com"
         }
-        jcenter()
     }
     dependencies {
 
@@ -35,10 +35,10 @@ buildscript {
 
 allprojects {
     repositories {
+        jcenter()
         maven {
             url "https://maven.google.com"
         }
-        jcenter()
     }
     //This replaces project.properties w.r.t. build settings
     project.ext {


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

The `build.gradle` template file also needs to be changed in order to support the fix merged from #523. Resolves #521 and #524

### What testing has been done on this change?

Verified a clean Android build works without error fetching previously missing dependencies from jcenter.