### PR TITLE
Only copy platform node_modules when created by binary

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -50,7 +50,8 @@ if (argv['activity-name']) config.setName(argv['activity-name']);
 var options = {
     link: argv.link || argv.shared,
     customTemplate: argv.argv.remain[3],
-    activityName: argv['activity-name']
+    activityName: argv['activity-name'],
+    copyPlatformNodeModules: true
 };
 
 require('./templates/cordova/loggingHelper').adjustLoggerLevel(argv);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -160,7 +160,7 @@ function copyBuildRules (projectPath, isLegacy) {
     }
 }
 
-function copyScripts (projectPath) {
+function copyScripts (projectPath, options) {
     var bin = path.join(ROOT, 'bin');
     var srcScriptsDir = path.join(bin, 'templates', 'cordova');
     var destScriptsDir = path.join(projectPath, 'cordova');
@@ -168,7 +168,7 @@ function copyScripts (projectPath) {
     shell.rm('-rf', destScriptsDir);
     // Copy in the new ones.
     shell.cp('-r', srcScriptsDir, projectPath);
-    shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
+    if (options.copyPlatformNodeModules) shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
     shell.cp(path.join(bin, 'check_reqs*'), destScriptsDir);
     shell.cp(path.join(bin, 'android_sdk_version*'), destScriptsDir);
     var check_reqs = path.join(destScriptsDir, 'check_reqs');
@@ -324,7 +324,7 @@ exports.create = function (project_path, config, options, events) {
                 var manifest_path = path.join(app_path, 'AndroidManifest.xml');
                 manifest.write(manifest_path);
 
-                exports.copyScripts(project_path);
+                exports.copyScripts(project_path, options);
                 exports.copyBuildRules(project_path);
             });
             // Link it to local android install.

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -259,7 +259,7 @@ describe('create', function () {
             });
             it('should copy template scripts into generated project', function (done) {
                 create.create(project_path, config_mock, {}, events_mock).then(function () {
-                    expect(create.copyScripts).toHaveBeenCalledWith(project_path);
+                    expect(create.copyScripts).toHaveBeenCalledWith(project_path, {});
                 }).fail(fail).done(done);
             });
             it('should copy build rules / gradle files into generated project', function (done) {


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
When platform is installed though CLI, `cordova platform add android`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm t