### PR TITLE
Dependency bump cordova-common@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "android-versions": "^1.3.0",
-    "cordova-common": "^2.2.0",
+    "cordova-common": "^3.0.0",
     "elementtree": "0.1.6",
     "nopt": "^3.0.1",
     "properties-parser": "^0.2.3",


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
Updates the cordova-common dependency to ^3.0.0.

### What testing has been done on this change?
- Travis CI Testing: https://travis-ci.org/erisu/cordova-android/builds/452163874
- Appveyor Testing: https://ci.appveyor.com/project/erisu/cordova-android/builds/20134186