### PR TITLE
Fix dest overwrite

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -34,7 +34,7 @@ var handlers = {
             // a later plugins release.  This is for legacy plugins to work with Cordova.
 
             if (options && options.android_studio === true) {
-                dest = studioPathRemap(obj);
+                dest = studioPathRemap(obj) || dest;
             }
 
             if (options && options.force) {

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -34,7 +34,7 @@ var handlers = {
             // a later plugins release.  This is for legacy plugins to work with Cordova.
 
             if (options && options.android_studio === true) {
-                dest = studioPathRemap(obj) || dest;
+                dest = getInstallDestination(obj);
             }
 
             if (options && options.force) {
@@ -47,7 +47,7 @@ var handlers = {
             var dest = path.join(obj.targetDir, path.basename(obj.src));
 
             if (options && options.android_studio === true) {
-                dest = studioPathRemap(obj);
+                dest = getInstallDestination(obj);
             }
 
             // TODO: Add Koltin extension to uninstall, since they are handled like Java files
@@ -315,6 +315,11 @@ function removeFileAndParents (baseDir, destFile, stopper) {
 
 function generateAttributeError (attribute, element, id) {
     return 'Required attribute "' + attribute + '" not specified in <' + element + '> element from plugin: ' + id;
+}
+
+function getInstallDestination (obj) {
+    return studioPathRemap(obj) ||
+        path.join(obj.targetDir, path.basename(obj.src));
 }
 
 function studioPathRemap (obj) {

--- a/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -70,6 +70,8 @@
 
         <source-file src="src/android/DummyPlugin.java"
                 target-dir="src/com/phonegap/plugins/dummyplugin" />
+        <source-file src="src/android/DummyPlugin2.java"
+                target-dir="app/src/main/src/com/phonegap/plugins/dummyplugin" />
         <lib-file src="src/android/TestLib.jar" />
     </platform>
 </plugin>

--- a/spec/fixtures/org.test.plugins.dummyplugin/src/android/DummyPlugin2.java
+++ b/spec/fixtures/org.test.plugins.dummyplugin/src/android/DummyPlugin2.java
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/android/DummyPlugin2.java

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -263,11 +263,23 @@ describe('android project handler', function () {
             });
         });
 
+        // TODO:
+        // - merge tests of <source-file> elements into single describe block
+        //   (with proper beforeEach/afterEach)
+        // - renumber the tests after Test#019
         describe('of <source-file> elements', function () {
             it('Test#019 : should remove stuff by calling common.deleteJava for Android Studio projects', function () {
                 android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject, {android_studio: true});
                 android['source-file'].uninstall(valid_source[0], dummyPluginInfo, dummyProject, {android_studio: true});
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/java/com/phonegap/plugins/dummyplugin/DummyPlugin.java'));
+            });
+        });
+
+        describe('of <source-file> element, with specific app target-dir', function () {
+            it('Test#019a : should remove stuff by calling common.deleteJava for Android Studio projects, with specific app target-dir', function () {
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].uninstall(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'));
             });
         });
 

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -108,6 +108,12 @@ describe('android project handler', function () {
                     android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject);
                 }).toThrow(new Error('"' + target + '" already exists!'));
             });
+
+            it('Test#007 : should allow installing sources using proper path', function () {
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(copyFileSpy)
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'), false);
+            });
         });
 
         describe('of <framework> elements', function () {


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Makes sure that we don't overwrite the `target-dir` of a `source-file` if the project base is android studio and the `target-dir` is the proper install path and doesn't need to be re-mapped.

### What testing has been done on this change?

I've added a new unit test, confirmed the problem exists, fixed the issue and re-ran the tests.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

### More details

Latest release (7.1.2) breaks our build. After investigation it appears that `source-file.install` handler was updated to extract the functionality of path remapping for android studio. However, if the path doesn't need to be remapped, the function returns undefined, thus updating dest to be undefined.

#### Related lines
https://github.com/apache/cordova-android/compare/7a97fd7...7.1.2#diff-4f73e5f70cec312ae82aa7d023e3c88bR320
https://github.com/apache/cordova-android/compare/7a97fd7...7.1.2#diff-4f73e5f70cec312ae82aa7d023e3c88bR50

#### Resolution

Just change line 50 to ` studioPathRemap(obj) || dest`
