### PR TITLE
[WIP] Reproduce GH-540 on 7.1.2

### DIFF
--- a/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -70,6 +70,8 @@
 
         <source-file src="src/android/DummyPlugin.java"
                 target-dir="src/com/phonegap/plugins/dummyplugin" />
+        <source-file src="src/android/DummyPlugin2.java"
+                target-dir="app/src/main/src/com/phonegap/plugins/dummyplugin" />
         <lib-file src="src/android/TestLib.jar" />
     </platform>
 </plugin>

--- a/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -72,6 +72,8 @@
                 target-dir="src/com/phonegap/plugins/dummyplugin" />
         <source-file src="src/android/DummyPlugin2.java"
                 target-dir="app/src/main/src/com/phonegap/plugins/dummyplugin" />
+        <source-file src="src/android/TestLib.jar"
+                target-dir="app/libs" />
         <lib-file src="src/android/TestLib.jar" />
     </platform>
 </plugin>

--- a/spec/fixtures/org.test.plugins.dummyplugin/src/android/DummyPlugin2.java
+++ b/spec/fixtures/org.test.plugins.dummyplugin/src/android/DummyPlugin2.java
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/android/DummyPlugin2.java

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -114,6 +114,12 @@ describe('android project handler', function () {
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'), false);
             });
+
+            it('Test#008 : should allow installing lib file from sources using proper path', function () {
+                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(copyFileSpy)
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/TestLib.jar', temp, path.join('app/libs/TestLib.jar'), false);
+            });
         });
 
         describe('of <framework> elements', function () {

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -108,6 +108,12 @@ describe('android project handler', function () {
                     android['source-file'].install(valid_source[0], dummyPluginInfo, dummyProject);
                 }).toThrow(new Error('"' + target + '" already exists!'));
             });
+
+            it('Test#007 : should allow installing sources using proper path', function () {
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(copyFileSpy)
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'), false);
+            });
         });
 
         describe('of <framework> elements', function () {


### PR DESCRIPTION
- unit test from GH-39 (PR #39)
- similar unit test that reproduces GH-40 (issue #40) on 7.1.2

These tests pass on 7.1.1, fail on 7.1.2 and on master.

Reverting ea6477f4d3e63ebb1f1717cc02e3117aa356ce84 on 7.1.x would cause these tests to pass again.