### PR TITLE
Remove obsolete check for JellyBean (GH-534)

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -109,17 +109,6 @@ function androidExec(success, fail, service, action, args) {
 }
 
 androidExec.init = function() {
-    //CB-11828
-    //This failsafe checks the version of Android and if it's Jellybean, it switches it to
-    //using the Online Event bridge for communicating from Native to JS
-    //
-    //It's ugly, but it's necessary.
-    var check = navigator.userAgent.toLowerCase().match(/android\s[0-9].[0-9]/);
-    var version_code = check && check[0].match(/4.[0-3].*/);
-    if (version_code != null && nativeToJsBridgeMode == nativeToJsModes.EVAL_BRIDGE) {
-      nativeToJsBridgeMode = nativeToJsModes.ONLINE_EVENT;
-    }
-
     bridgeSecret = +prompt('', 'gap_init:' + nativeToJsBridgeMode);
     channel.onNativeReady.fire();
 };


### PR DESCRIPTION
to work properly on Android Pie

was introduced in dc0bfeb0c (CB-11828)

Not needed since Android JellyBean (4.0-4.3) is no longer supported ref: <https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#requirements-and-support>

Credit goes to pradiv-kumar for raising the issue in #534 and proposing the original solution in #535.

Note that cordova.js should be regenerated by cordova-coho as described in: <https://github.com/apache/cordova-coho/blob/master/docs/platforms-release-process.md>

I would like to get this change into 7.1.x as well.

Resolves #534
Closes #535