### PR TITLE
#552: (android) check for build-extras.gradle in the app-parent directory

### DIFF
--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -93,9 +93,9 @@ ext {
 // PLUGIN GRADLE EXTENSIONS START
 // PLUGIN GRADLE EXTENSIONS END
 
-def hasBuildExtras = file('build-extras.gradle').exists()
+def hasBuildExtras = file('../build-extras.gradle').exists()
 if (hasBuildExtras) {
-    apply from: 'build-extras.gradle'
+    apply from: '../build-extras.gradle'
 }
 
 // Set property defaults after extension .gradle files.

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -93,8 +93,13 @@ ext {
 // PLUGIN GRADLE EXTENSIONS START
 // PLUGIN GRADLE EXTENSIONS END
 
-def hasBuildExtras = file('../build-extras.gradle').exists()
-if (hasBuildExtras) {
+def hasBuildExtras1 = file('build-extras.gradle').exists()
+if (hasBuildExtras1) {
+    apply from: 'build-extras.gradle'
+}
+
+def hasBuildExtras2 = file('../build-extras.gradle').exists()
+if (hasBuildExtras2) {
     apply from: '../build-extras.gradle'
 }
 


### PR DESCRIPTION
### Platforms affected
- android

### What does this PR do?
- solves issue #552. Therefor include the build-extras.gradle from `platforms/android/`
- If requested I can change this pull request to check on both places `platforms/android/` and `platforms/android/app/` 

### What testing has been done on this change?
- in a local build environment

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
