### PR TITLE
Ignore version file in eslint to resolve build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "java-unit-tests": "node test/run_java_unit_tests.js",
     "eslint": "run-s -c eslint:*",
     "eslint:scripts": "eslint bin spec test",
-    "eslint:bins": "eslint 'bin/**/*' --ignore-pattern '**/*.*' --ignore-pattern '**/gitignore'"
+    "eslint:bins": "eslint 'bin/**/*' --ignore-pattern '**/*.*' --ignore-pattern '**/gitignore' --ignore-pattern 'bin/templates/cordova/version'"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",


### PR DESCRIPTION
This change should to give us a green build again.

Rationale is that the eslint update introduced in 393dad6349d8df55d8fca7d3e5014f36dfa4610c checks most of the files under `bin` and will not accept JavaScript that uses double-quotes for strings. The workaround in 393dad6349d8df55d8fca7d3e5014f36dfa4610c was to change the generated `bin/templates/cordova/version` file to use single-quotes in the version string.

But since cordova-coho will regenerate `bin/templates/cordova/version` with double-quotes when updating the version number, we need a different solution.

This is a quick workaround solution. I won't have a problem if anyone wants to propose an improved solution. Alternative may be to update cordova-coho to generate version file with single-quotes.