### PR TITLE
Remove GH-547 update for aidl files

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -301,8 +301,6 @@ function getInstallDestination (obj) {
         return path.join(obj.targetDir, path.basename(obj.src));
     } else if (obj.src.endsWith('.java')) {
         return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.substring(4), path.basename(obj.src));
-    } else if (obj.src.endsWith('.aidl')) {
-        return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.substring(4), path.basename(obj.src));
     } else if (obj.targetDir.includes('libs')) {
         if (obj.src.endsWith('.so')) {
             return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.substring(5), path.basename(obj.src));

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -136,11 +136,12 @@ describe('android project handler', function () {
                     path.join('app/src/main/res/values/other.extension'), false);
             });
 
-            it('Test#006f : should allow installing aidl file from sources with old target-dir scheme (GH-547)', function () {
+            it('Test#006f : should allow installing aidl file from sources with old target-dir scheme - GH-547 fix removed', function () {
+                // GH-547 fix removed to avoid breaking plugins such as cordova-plugin-purchase
                 android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/myapi.aidl', temp,
-                    path.join('app/src/main/aidl/com/mytest/myapi.aidl'), false);
+                    path.join('app/src/main/src/com/mytest/myapi.aidl'), false);
             });
 
             it('Test#006g : should allow installing aar lib file from sources with old target-dir scheme (GH-547)', function () {
@@ -349,10 +350,11 @@ describe('android project handler', function () {
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/res/values/other.extension'));
             });
 
-            it('Test#019f : should remove stuff by calling common.removeFile for Android Studio projects, of aidl with old target-dir scheme (GH-547)', function () {
+            it('Test#019f : should remove stuff by calling common.removeFile for Android Studio projects, of aidl with old target-dir scheme - GH-547 fix removed', function () {
+                // GH-547 fix removed to avoid breaking plugins such as cordova-plugin-purchase
                 android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
                 android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
-                expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/aidl/com/mytest/myapi.aidl'));
+                expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/src/com/mytest/myapi.aidl'));
             });
 
             it('Test#019g : should remove stuff by calling common.removeFile for Android Studio projects, of aar with old target-dir scheme (GH-547)', function () {


### PR DESCRIPTION
As discussed in <https://github.com/apache/cordova-android/issues/547#issuecomment-439016006> this update is needed for `https://github.com/j3k0/cordova-plugin-purchase#master` (version v7.2.4) to work on Android platform. A quick review would be really appreciated.