### PR TITLE
fix(build): support tilde expansion on windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -20,6 +20,7 @@
 var path = require('path');
 var fs = require('fs');
 var nopt = require('nopt');
+const untildify = require('untildify');
 
 var Adb = require('./Adb');
 
@@ -82,9 +83,7 @@ function parseOpts (options, resolvedTarget, projectRoot) {
         if (config.android && config.android[ret.buildType]) {
             var androidInfo = config.android[ret.buildType];
             if (androidInfo.keystore && !packageArgs.keystore) {
-                if (androidInfo.keystore.substr(0, 1) === '~') {
-                    androidInfo.keystore = process.env.HOME + androidInfo.keystore.substr(1);
-                }
+                androidInfo.keystore = untildify(androidInfo.keystore);
                 packageArgs.keystore = path.resolve(path.dirname(buildConfig), androidInfo.keystore);
                 events.emit('log', 'Reading the keystore from: ' + packageArgs.keystore);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3202,6 +3202,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "nopt": "^5.0.0",
     "properties-parser": "^0.3.1",
     "semver": "^7.3.5",
+    "untildify": "^4.0.0",
     "which": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Platforms affected
Android, ios, Browser

### What does this PR do?
I struggeling with home path every time changing build computer or transfer code to my teammate computer. the `build.json` config does not find home path on window with "command line" or "power shell". there is no tutorial about this. I have to go to build file to know that there is `~` equivalent with `$HOME` and `%HOMEPATH%` on window.
I think it is feature?
### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
