### PR TITLE
Mark some 7.1.3 bundled dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,17 @@
   "dependencies": {
     "android-versions": "1.3.0",
     "base64-js": "1.2.0",
+    "big-integer": "1.6.32",
     "cordova-common": "2.2.5",
     "elementtree": "0.1.6",
     "glob": "5.0.15",
     "nopt": "3.0.1",
+    "path-is-absolute": "1.0.1",
     "plist": "2.1.0",
     "properties-parser": "0.2.3",
     "q": "1.4.1",
     "sax": "0.3.5",
+    "semver": "5.5.0",
     "shelljs": "0.5.3",
     "xmlbuilder": "8.2.2"
   },


### PR DESCRIPTION
to resolve red entries from npm outdated, in 7.1.x only (**not wanted** in `master` branch):

```
Package            Current  Wanted  Latest  Location
_______            _______  ______  ______  ________
big-integer         1.6.32  1.6.36  1.6.36  cordova-android
path-is-absolute     1.0.1   2.0.0   2.0.0  cordova-android
semver               5.5.0   5.6.0   5.6.0  cordova-android
```

Will be merged (as a self-approved change) into 7.1.x release once build is green to unblock the patch release.