### PR TITLE
Output current package name if package name can't be validated

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -194,7 +194,7 @@ function validatePackageName (package_name) {
     var msg = 'Error validating package name. ';
 
     if (!/^[a-zA-Z][a-zA-Z0-9_]+(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(package_name)) {
-        return Q.reject(new CordovaError(msg + 'Must look like: `com.company.Name`. Currently is: `' + package_name + '`' ));
+        return Q.reject(new CordovaError(msg + 'Must look like: `com.company.Name`. Currently is: `' + package_name + '`'));
     }
 
     // Class is a reserved word

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -194,7 +194,7 @@ function validatePackageName (package_name) {
     var msg = 'Error validating package name. ';
 
     if (!/^[a-zA-Z][a-zA-Z0-9_]+(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(package_name)) {
-        return Q.reject(new CordovaError(msg + 'Package name must look like: com.company.Name'));
+        return Q.reject(new CordovaError(msg + 'Must look like: `com.company.Name`. Currently is: `' + package_name + '`' ));
     }
 
     // Class is a reserved word


### PR DESCRIPTION
We have this of the package name. It only outputs that the current one is bad, not what the current one actually is. Added an output of the current one to the error.