### PR TITLE
Move the PLUGIN GRADLE EXTENSIONS comments

### DIFF
--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -90,9 +90,6 @@ ext {
     cdvPluginPostBuildExtras = []
 }
 
-// PLUGIN GRADLE EXTENSIONS START
-// PLUGIN GRADLE EXTENSIONS END
-
 def hasBuildExtras1 = file('build-extras.gradle').exists()
 if (hasBuildExtras1) {
     apply from: 'build-extras.gradle'
@@ -124,6 +121,9 @@ ext.cdvBuildMultipleApks = cdvBuildMultipleApks == null ? false : cdvBuildMultip
 ext.cdvVersionCodeForceAbiDigit = cdvVersionCodeForceAbiDigit == null ? false : cdvVersionCodeForceAbiDigit.toBoolean();
 ext.cdvMinSdkVersion = cdvMinSdkVersion == null ? defaultMinSdkVersion : Integer.parseInt('' + cdvMinSdkVersion)
 ext.cdvVersionCode = cdvVersionCode == null ? null : Integer.parseInt('' + cdvVersionCode)
+
+// PLUGIN GRADLE EXTENSIONS START
+// PLUGIN GRADLE EXTENSIONS END
 
 def computeBuildTargetName(debugBuild) {
     def ret = 'assemble'


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Move the comment block for where gradle plugins from extensions are injected. This means they have proper access to correct version variables which are currently resolved after they are injected. I noticed this due to using https://github.com/google/cordova-plugin-browsertab which has this https://github.com/google/cordova-plugin-browsertab/blob/master/plugin/src/android/BrowserTab.gradle which always sets to 16, because the versions are resolved after plugins. This broke our code because we set our minimum SDK, however this plugin would force it lower to 16, due to the version code resolution being after.

Fix #569

### What testing has been done on this change?

Testing in our application, and run the tests in the repository. Existing test coverage _should_ cover this change, because it's just an ordering change.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.