### PR TITLE
Resolve issue with plugin target-dir="app*" subdirs

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -295,7 +295,7 @@ function generateAttributeError (attribute, element, id) {
 function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
 
-    if (obj.targetDir.includes('app')) {
+    if (obj.targetDir.startsWith('app')) {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));

--- a/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -82,6 +82,8 @@
 	<source-file src="src/android/testaar2.aar" target-dir="libs" />
 	<source-file src="src/android/testjar2.jar" target-dir="libs" />
 	<source-file src="src/android/jniLibs/x86/libnative.so" target-dir="libs/x86" />
+        <source-file src="src/android/DummyPlugin2.java"
+                target-dir="src/com/appco" />
         <lib-file src="src/android/TestLib.jar" />
     </platform>
 </plugin>

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -164,7 +164,7 @@ describe('android project handler', function () {
                     path.join('app/src/main/jniLibs/x86/libnative.so'), false);
             });
 
-            it('Test#006j : should allow installing sources with target-dir that includes "appco"', function () {
+            it('Test#006j : should allow installing sources with target-dir that includes "app"', function () {
                 android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'), false);

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -163,6 +163,12 @@ describe('android project handler', function () {
                     'src/android/jniLibs/x86/libnative.so', temp,
                     path.join('app/src/main/jniLibs/x86/libnative.so'), false);
             });
+
+            it('Test#006j : should allow installing sources with target-dir that includes "appco"', function () {
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(copyFileSpy)
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'), false);
+            });
         });
 
         describe('of <framework> elements', function () {
@@ -371,6 +377,12 @@ describe('android project handler', function () {
                 android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, {android_studio: true});
                 android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject, {android_studio: true});
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/jniLibs/x86/libnative.so'));
+            });
+
+            it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "appco"', function () {
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'));
             });
         });
 

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -379,7 +379,7 @@ describe('android project handler', function () {
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/jniLibs/x86/libnative.so'));
             });
 
-            it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "appco"', function () {
+            it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "app"', function () {
                 android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
                 android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'));


### PR DESCRIPTION
(subdirectories) such as "appco", with unit tests to verify correct operation

Needed for @katzer plugins that use `de/appplant` subdirectory, for example:
* <https://github.com/katzer/cordova-plugin-local-notifications>, with `target-dir="src/de/appplant/cordova/plugin/notification"`
* <https://github.com/katzer/cordova-plugin-badge>, with `target-dir="src/de/appplant/cordova/plugin/badge"`
* <https://github.com/katzer/cordova-plugin-background-mode>, with `target-dir="src/de/appplant/cordova/plugin/background"`

Also needed for `cordova-plugin-inappbrowser`

Resolves #571