### PR TITLE
Improve target-dir restriction for detecting new android project…

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -341,7 +341,7 @@ function getInstallDestination (obj) {
             } else {
                 return path.join('app', obj.targetDir, path.basename(obj.src));
             }
-        } else if (obj.targetDir.startsWith('src/main/')) {
+        } else if (targetDirArray[0] === 'src' && targetDirArray[1] === 'main') {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
 

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -320,7 +320,7 @@ function generateAttributeError (attribute, element, id) {
 function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
 
-    if (obj.targetDir.startsWith('app')) {
+    if (obj.targetDir.startsWith('app/')) {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -320,26 +320,33 @@ function generateAttributeError (attribute, element, id) {
 function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
 
-    if (obj.targetDir.startsWith('app/')) {
+    var targetDirArray = obj.targetDir.split('/');
+
+    if (targetDirArray[0] === 'app') {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));
-    } else if (obj.src.endsWith('.java')) {
-        return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.substring(4), path.basename(obj.src));
-    } else if (obj.src.endsWith('.aidl')) {
-        return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.substring(4), path.basename(obj.src));
-    } else if (obj.targetDir.includes('libs')) {
-        if (obj.src.endsWith('.so')) {
-            return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.substring(5), path.basename(obj.src));
-        } else {
+    } else {
+        // plugin ignores the new app directory structure (DEPRECATED)
+        if (obj.src.endsWith('.java')) {
+            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(/^src\/?/, ''),
+                path.basename(obj.src));
+        } else if (obj.src.endsWith('.aidl')) {
+            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(/^src\/?/, ''),
+                path.basename(obj.src));
+        } else if (targetDirArray[0] === 'libs') {
+            if (obj.src.endsWith('.so')) {
+                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(/^libs\/?/, ''),
+                    path.basename(obj.src));
+            } else {
+                return path.join('app', obj.targetDir, path.basename(obj.src));
+            }
+        } else if (obj.targetDir.startsWith('src/main/')) {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
-    } else if (obj.targetDir.includes('src/main')) {
-        return path.join('app', obj.targetDir, path.basename(obj.src));
-    } else {
+
         // For all other source files not using the new app directory structure,
         // add 'app/src/main' to the targetDir
         return path.join(APP_MAIN_PREFIX, obj.targetDir, path.basename(obj.src));
     }
-
 }

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -318,30 +318,34 @@ function generateAttributeError (attribute, element, id) {
 }
 
 function getInstallDestination (obj) {
-    var APP_MAIN_PREFIX = 'app/src/main';
+    const APP_MAIN_PREFIX = 'app/src/main';
+    const PATH_SEPARATOR = '/';
 
-    var targetDirArray = obj.targetDir.split('/');
+    const appReg = new RegExp(`^app\\${PATH_SEPARATOR}?`);
+    const libsReg = new RegExp(`^libs\\${PATH_SEPARATOR}?`);
+    const srcReg = new RegExp(`^src\\${PATH_SEPARATOR}?`);
+    const srcMainReg = new RegExp(`^src\\${PATH_SEPARATOR}main\\${PATH_SEPARATOR}?`);
 
-    if (targetDirArray[0] === 'app') {
+    if (appReg.test(obj.targetDir)) {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));
     } else {
         // plugin ignores the new app directory structure (DEPRECATED)
         if (obj.src.endsWith('.java')) {
-            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(/^src\/?/, ''),
+            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(srcReg, ''),
                 path.basename(obj.src));
         } else if (obj.src.endsWith('.aidl')) {
-            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(/^src\/?/, ''),
+            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(srcReg, ''),
                 path.basename(obj.src));
-        } else if (targetDirArray[0] === 'libs') {
+        } else if (libsReg.test(obj.targetDir)) {
             if (obj.src.endsWith('.so')) {
-                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(/^libs\/?/, ''),
+                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(libsReg, ''),
                     path.basename(obj.src));
             } else {
                 return path.join('app', obj.targetDir, path.basename(obj.src));
             }
-        } else if (targetDirArray[0] === 'src' && targetDirArray[1] === 'main') {
+        } else if (srcMainReg.test(obj.targetDir)) {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
 


### PR DESCRIPTION
…structure used in plugin.xml. (#575)

### What does this PR do?
It just checks that `source-file` `target-dir` starts with `app/` more than `app` in order to detect the new android project structure usage in `plugin.xml`.
All explanations in #575.