### PR TITLE
Rewrite install dir resolution for legacy plugins

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -295,7 +295,7 @@ function generateAttributeError (attribute, element, id) {
 function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
 
-    if (obj.targetDir.startsWith('app')) {
+    if (obj.targetDir.startsWith('app/')) {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -295,26 +295,33 @@ function generateAttributeError (attribute, element, id) {
 function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
 
-    if (obj.targetDir.startsWith('app/')) {
+    var targetDirArray = obj.targetDir.split('/');
+
+    if (targetDirArray[0] === 'app') {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));
-    } else if (obj.src.endsWith('.java')) {
-        return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.substring(4), path.basename(obj.src));
-    } else if (obj.src.endsWith('.aidl')) {
-        return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.substring(4), path.basename(obj.src));
-    } else if (obj.targetDir.includes('libs')) {
-        if (obj.src.endsWith('.so')) {
-            return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.substring(5), path.basename(obj.src));
-        } else {
+    } else {
+        // plugin ignores the new app directory structure (DEPRECATED)
+        if (obj.src.endsWith('.java')) {
+            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(/^src\/?/, ''),
+                path.basename(obj.src));
+        } else if (obj.src.endsWith('.aidl')) {
+            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(/^src\/?/, ''),
+                path.basename(obj.src));
+        } else if (targetDirArray[0] === 'libs') {
+            if (obj.src.endsWith('.so')) {
+                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(/^libs\/?/, ''),
+                    path.basename(obj.src));
+            } else {
+                return path.join('app', obj.targetDir, path.basename(obj.src));
+            }
+        } else if (obj.targetDir.startsWith('src/main/')) {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
-    } else if (obj.targetDir.includes('src/main')) {
-        return path.join('app', obj.targetDir, path.basename(obj.src));
-    } else {
+
         // For all other source files not using the new app directory structure,
         // add 'app/src/main' to the targetDir
         return path.join(APP_MAIN_PREFIX, obj.targetDir, path.basename(obj.src));
     }
-
 }

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -306,7 +306,7 @@ function getInstallDestination (obj) {
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));
     } else {
-        // plugin ignores the new app directory structure (DEPRECATED)
+        // Plugin using deprecated target directory structure (GH-580)
         if (obj.src.endsWith('.java')) {
             return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(srcReg, ''),
                 path.basename(obj.src));

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -296,10 +296,10 @@ function getInstallDestination (obj) {
     const APP_MAIN_PREFIX = 'app/src/main';
     const PATH_SEPARATOR = '/';
 
-    const appReg = new RegExp(`^app\\${PATH_SEPARATOR}?`);
-    const libsReg = new RegExp(`^libs\\${PATH_SEPARATOR}?`);
-    const srcReg = new RegExp(`^src\\${PATH_SEPARATOR}?`);
-    const srcMainReg = new RegExp(`^src\\${PATH_SEPARATOR}main\\${PATH_SEPARATOR}?`);
+    var appReg = new RegExp(`^app(\\${PATH_SEPARATOR}|$)`);
+    var libsReg = new RegExp(`^libs(\\${PATH_SEPARATOR}|$)`);
+    var srcReg = new RegExp(`^src(\\${PATH_SEPARATOR}|$)`);
+    var srcMainReg = new RegExp(`^src\\${PATH_SEPARATOR}main(\\${PATH_SEPARATOR}|$)`);
 
     if (appReg.test(obj.targetDir)) {
         // If any source file is using the new app directory structure,

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -296,10 +296,13 @@ function getInstallDestination (obj) {
     var APP_MAIN_PREFIX = 'app/src/main';
     var PATH_SEPARATOR = '/';
 
-    var appReg = new RegExp('^app(\\' + PATH_SEPARATOR + '|$)');
-    var libsReg = new RegExp('^libs(\\' + PATH_SEPARATOR + '|$)');
-    var srcReg = new RegExp('^src(\\' + PATH_SEPARATOR + '|$)');
-    var srcMainReg = new RegExp('^src\\' + PATH_SEPARATOR + 'main(\\' + PATH_SEPARATOR + '|$)');
+    var PATH_SEP_MATCH = '\\' + PATH_SEPARATOR;
+    var PATH_SEP_OR_EOL_MATCH = '(\\' + PATH_SEPARATOR + '|$)';
+
+    var appReg = new RegExp('^app' + PATH_SEP_OR_EOL_MATCH);
+    var libsReg = new RegExp('^libs' + PATH_SEP_OR_EOL_MATCH);
+    var srcReg = new RegExp('^src' + PATH_SEP_OR_EOL_MATCH);
+    var srcMainReg = new RegExp('^src' + PATH_SEP_MATCH + 'main' + PATH_SEP_OR_EOL_MATCH);
 
     if (appReg.test(obj.targetDir)) {
         // If any source file is using the new app directory structure,

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -293,30 +293,34 @@ function generateAttributeError (attribute, element, id) {
 }
 
 function getInstallDestination (obj) {
-    var APP_MAIN_PREFIX = 'app/src/main';
+    const APP_MAIN_PREFIX = 'app/src/main';
+    const PATH_SEPARATOR = '/';
 
-    var targetDirArray = obj.targetDir.split('/');
+    const appReg = new RegExp(`^app\\${PATH_SEPARATOR}?`);
+    const libsReg = new RegExp(`^libs\\${PATH_SEPARATOR}?`);
+    const srcReg = new RegExp(`^src\\${PATH_SEPARATOR}?`);
+    const srcMainReg = new RegExp(`^src\\${PATH_SEPARATOR}main\\${PATH_SEPARATOR}?`);
 
-    if (targetDirArray[0] === 'app') {
+    if (appReg.test(obj.targetDir)) {
         // If any source file is using the new app directory structure,
         // don't penalize it
         return path.join(obj.targetDir, path.basename(obj.src));
     } else {
         // plugin ignores the new app directory structure (DEPRECATED)
         if (obj.src.endsWith('.java')) {
-            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(/^src\/?/, ''),
+            return path.join(APP_MAIN_PREFIX, 'java', obj.targetDir.replace(srcReg, ''),
                 path.basename(obj.src));
         } else if (obj.src.endsWith('.aidl')) {
-            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(/^src\/?/, ''),
+            return path.join(APP_MAIN_PREFIX, 'aidl', obj.targetDir.replace(srcReg, ''),
                 path.basename(obj.src));
-        } else if (targetDirArray[0] === 'libs') {
+        } else if (libsReg.test(obj.targetDir)) {
             if (obj.src.endsWith('.so')) {
-                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(/^libs\/?/, ''),
+                return path.join(APP_MAIN_PREFIX, 'jniLibs', obj.targetDir.replace(libsReg, ''),
                     path.basename(obj.src));
             } else {
                 return path.join('app', obj.targetDir, path.basename(obj.src));
             }
-        } else if (targetDirArray[0] === 'src' && targetDirArray[1] === 'main') {
+        } else if (srcMainReg.test(obj.targetDir)) {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
 

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -293,13 +293,13 @@ function generateAttributeError (attribute, element, id) {
 }
 
 function getInstallDestination (obj) {
-    const APP_MAIN_PREFIX = 'app/src/main';
-    const PATH_SEPARATOR = '/';
+    var APP_MAIN_PREFIX = 'app/src/main';
+    var PATH_SEPARATOR = '/';
 
-    var appReg = new RegExp(`^app(\\${PATH_SEPARATOR}|$)`);
-    var libsReg = new RegExp(`^libs(\\${PATH_SEPARATOR}|$)`);
-    var srcReg = new RegExp(`^src(\\${PATH_SEPARATOR}|$)`);
-    var srcMainReg = new RegExp(`^src\\${PATH_SEPARATOR}main(\\${PATH_SEPARATOR}|$)`);
+    var appReg = new RegExp('^app(\\' + PATH_SEPARATOR + '|$)');
+    var libsReg = new RegExp('^libs(\\' + PATH_SEPARATOR + '|$)');
+    var srcReg = new RegExp('^src(\\' + PATH_SEPARATOR + '|$)');
+    var srcMainReg = new RegExp('^src\\' + PATH_SEPARATOR + 'main(\\' + PATH_SEPARATOR + '|$)');
 
     if (appReg.test(obj.targetDir)) {
         // If any source file is using the new app directory structure,

--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -316,7 +316,7 @@ function getInstallDestination (obj) {
             } else {
                 return path.join('app', obj.targetDir, path.basename(obj.src));
             }
-        } else if (obj.targetDir.startsWith('src/main/')) {
+        } else if (targetDirArray[0] === 'src' && targetDirArray[1] === 'main') {
             return path.join('app', obj.targetDir, path.basename(obj.src));
         }
 

--- a/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/spec/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -84,6 +84,8 @@
 	<source-file src="src/android/jniLibs/x86/libnative.so" target-dir="libs/x86" />
         <source-file src="src/android/DummyPlugin2.java"
                 target-dir="src/com/appco" />
+        <source-file src="src/android/DummyPlugin2.java"
+                target-dir="appco/src" />
         <lib-file src="src/android/TestLib.jar" />
     </platform>
 </plugin>

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -169,6 +169,12 @@ describe('android project handler', function () {
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'), false);
             });
+
+            it('Test#006k : should allow installing sources with target-dir that includes "app" in its first directory', function () {
+                android['source-file'].install(valid_source[11], dummyPluginInfo, dummyProject, {android_studio: true});
+                expect(copyFileSpy)
+                    .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/appco/src/DummyPlugin2.java'), false);
+            });
         });
 
         describe('of <framework> elements', function () {


### PR DESCRIPTION
Let's start fresh!

### What does this PR do?
This is the rebase of my old PR #576 coming from #575 on the master branch as encouraged.
Basically I have separated bloc that was handling new app directory structure from the old one. Plus I have rewrite tests with RegExp allowing buggy forms with or without `/` at the end.
Plus all (hope so) code reviews from @brodybits.

### What testing has been done on this change?
- new: `app`, `app/`, `app/whatever`
- old: `src`, `src/`, `src/whatever/source`, `libs`, `libs/`, `libs/whatever/bin`
- buggy: `src/myappsomething/source`, `appsomething/source`
Like my original issue with: [cordova-plugin-local-notifications](https://github.com/katzer/cordova-plugin-local-notifications/blob/6d1b27f1e9d8e2198fd1ea6e9032419295690c47/plugin.xml#L145-L147). Try it:
```
$ cordova plugin add cordova-plugin-local-notification
```

### Contextual issues and PRs raised
#577, #578, #580 