### PR TITLE
Add a warning about the using of `android.bat`

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -216,7 +216,7 @@ module.exports.check_java = function () {
 // Returns a promise.
 module.exports.check_android = function () {
     return Q().then(function () {
-        var androidCmdPath = forgivingWhichSync('sdkmanager');
+        var androidCmdPath = forgivingWhichSync('android');
         var adbInPath = forgivingWhichSync('adb');
         var avdmanagerInPath = forgivingWhichSync('avdmanager');
         var hasAndroidHome = !!process.env['ANDROID_HOME'] && fs.existsSync(process.env['ANDROID_HOME']);
@@ -315,8 +315,11 @@ module.exports.check_android = function () {
 
 // TODO: is this actually needed?
 module.exports.getAbsoluteAndroidCmd = function () {
-    var cmd = forgivingWhichSync('sdkmanager');
+    var cmd = forgivingWhichSync('android');
+    if (cmd.length === 0) {
     
+        cmd = forgivingWhichSync('sdkmanager');
+    }
     if (module.exports.isWindows()) {
         return '"' + cmd + '"';
     }
@@ -337,6 +340,7 @@ module.exports.check_android_target = function (originalError) {
         var androidCmd = module.exports.getAbsoluteAndroidCmd();
         var msg = 'Please install Android target / API level: "' + desired_api_level + '".\n\n' +
             'Hint: Open the SDK manager by running: ' + androidCmd + '\n' +
+            'Note that Android\Sdk\tools\bin\sdkmanager should be used instead of android.bat.\n' +
             'You will require:\n' +
             '1. "SDK Platform" for API level ' + desired_api_level + '\n' +
             '2. "Android SDK Platform-tools (latest)\n' +

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -216,7 +216,7 @@ module.exports.check_java = function () {
 // Returns a promise.
 module.exports.check_android = function () {
     return Q().then(function () {
-        var androidCmdPath = forgivingWhichSync('android');
+        var androidCmdPath = forgivingWhichSync('sdkmanager');
         var adbInPath = forgivingWhichSync('adb');
         var avdmanagerInPath = forgivingWhichSync('avdmanager');
         var hasAndroidHome = !!process.env['ANDROID_HOME'] && fs.existsSync(process.env['ANDROID_HOME']);
@@ -315,10 +315,8 @@ module.exports.check_android = function () {
 
 // TODO: is this actually needed?
 module.exports.getAbsoluteAndroidCmd = function () {
-    var cmd = forgivingWhichSync('android');
-    if (cmd.length === 0) {
-        cmd = forgivingWhichSync('sdkmanager');
-    }
+    var cmd = forgivingWhichSync('sdkmanager');
+    
     if (module.exports.isWindows()) {
         return '"' + cmd + '"';
     }

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -317,7 +317,6 @@ module.exports.check_android = function () {
 module.exports.getAbsoluteAndroidCmd = function () {
     var cmd = forgivingWhichSync('android');
     if (cmd.length === 0) {
-    
         cmd = forgivingWhichSync('sdkmanager');
     }
     if (module.exports.isWindows()) {
@@ -340,7 +339,7 @@ module.exports.check_android_target = function (originalError) {
         var androidCmd = module.exports.getAbsoluteAndroidCmd();
         var msg = 'Please install Android target / API level: "' + desired_api_level + '".\n\n' +
             'Hint: Open the SDK manager by running: ' + androidCmd + '\n' +
-            'Note that Android\Sdk\tools\bin\sdkmanager should be used instead of android.bat.\n' +
+            'Note that Android\\Sdk\\tools\\bin\\sdkmanager should be used instead of android.bat.\n' +
             'You will require:\n' +
             '1. "SDK Platform" for API level ' + desired_api_level + '\n' +
             '2. "Android SDK Platform-tools (latest)\n' +


### PR DESCRIPTION
Hi,

### Platforms affected

Android.

Like it said:

```
**************************************************************************
The "android" command is deprecated.
For manual SDK, AVD, and project management, please use Android Studio.
For command-line tools, use tools\bin\sdkmanager.bat
and tools\bin\avdmanager.bat
**************************************************************************
```

### What does this PR do?

The conditionnal structure has been removed to use systematically `sdkmanager` instead of `android.bat`.

See [this issue](https://github.com/apache/cordova/issues/61) for more.

### What testing has been done on this change?

None. The method behaviour hasn't been significantly altered, actually.

Feel free to add/remove what you want. :)


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
