### PR TITLE
Revert only copy platform node_modules with create bin

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -50,8 +50,7 @@ if (argv['activity-name']) config.setName(argv['activity-name']);
 var options = {
     link: argv.link || argv.shared,
     customTemplate: argv.argv.remain[3],
-    activityName: argv['activity-name'],
-    copyPlatformNodeModules: true
+    activityName: argv['activity-name']
 };
 
 require('./templates/cordova/loggingHelper').adjustLoggerLevel(argv);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -160,7 +160,7 @@ function copyBuildRules (projectPath, isLegacy) {
     }
 }
 
-function copyScripts (projectPath, options) {
+function copyScripts (projectPath) {
     var bin = path.join(ROOT, 'bin');
     var srcScriptsDir = path.join(bin, 'templates', 'cordova');
     var destScriptsDir = path.join(projectPath, 'cordova');
@@ -168,7 +168,7 @@ function copyScripts (projectPath, options) {
     shell.rm('-rf', destScriptsDir);
     // Copy in the new ones.
     shell.cp('-r', srcScriptsDir, projectPath);
-    if (options.copyPlatformNodeModules) shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
+    shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
     shell.cp(path.join(bin, 'check_reqs*'), destScriptsDir);
     shell.cp(path.join(bin, 'android_sdk_version*'), destScriptsDir);
     var check_reqs = path.join(destScriptsDir, 'check_reqs');
@@ -324,7 +324,7 @@ exports.create = function (project_path, config, options, events) {
                 var manifest_path = path.join(app_path, 'AndroidManifest.xml');
                 manifest.write(manifest_path);
 
-                exports.copyScripts(project_path, options);
+                exports.copyScripts(project_path);
                 exports.copyBuildRules(project_path);
             });
             // Link it to local android install.

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -259,7 +259,7 @@ describe('create', function () {
             });
             it('should copy template scripts into generated project', function (done) {
                 create.create(project_path, config_mock, {}, events_mock).then(function () {
-                    expect(create.copyScripts).toHaveBeenCalledWith(project_path, {});
+                    expect(create.copyScripts).toHaveBeenCalledWith(project_path);
                 }).fail(fail).done(done);
             });
             it('should copy build rules / gradle files into generated project', function (done) {


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
Reverts PR https://github.com/apache/cordova-android/pull/536 (Only copy platform node_modules when created by binary)

### What testing has been done on this change?
None with reverting

```
$ npm run eslint
$ npm run unit-tests
```