### PR TITLE
Android Platform Release Preparation (Cordova 9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ tmp/**/*
 *.iml
 npm-debug.log
 node_modules/
+coverage/
+.nyc_output/

--- a/bin/templates/cordova/build
+++ b/bin/templates/cordova/build
@@ -45,7 +45,7 @@ buildOpts.argv = buildOpts.argv.original;
 require('./loggingHelper').adjustLoggerLevel(buildOpts);
 
 new Api().build(buildOpts)
-.catch(function (err) {
-    console.error(err.stack);
-    process.exit(2);
-});
+    .catch(function (err) {
+        console.error(err.stack);
+        process.exit(2);
+    });

--- a/bin/templates/cordova/clean
+++ b/bin/templates/cordova/clean
@@ -45,7 +45,7 @@ opts.noPrepare = true;
 require('./loggingHelper').adjustLoggerLevel(opts);
 
 new Api().clean(opts)
-.catch(function (err) {
-    console.error(err.stack);
-    process.exit(2);
-});
+    .catch(function (err) {
+        console.error(err.stack);
+        process.exit(2);
+    });

--- a/bin/templates/cordova/lib/Adb.js
+++ b/bin/templates/cordova/lib/Adb.js
@@ -44,7 +44,7 @@ function isEmulator (line) {
  *   devices/emulators
  */
 Adb.devices = function (opts) {
-    return spawn('adb', ['devices'], {cwd: os.tmpdir()}).then(function (output) {
+    return spawn('adb', ['devices'], { cwd: os.tmpdir() }).then(function (output) {
         return output.split('\n').filter(function (line) {
             // Filter out either real devices or emulators, depending on options
             return (line && opts && opts.emulators) ? isEmulator(line) : isDevice(line);
@@ -58,7 +58,7 @@ Adb.install = function (target, packagePath, opts) {
     events.emit('verbose', 'Installing apk ' + packagePath + ' on target ' + target + '...');
     var args = ['-s', target, 'install'];
     if (opts && opts.replace) args.push('-r');
-    return spawn('adb', args.concat(packagePath), {cwd: os.tmpdir()}).then(function (output) {
+    return spawn('adb', args.concat(packagePath), { cwd: os.tmpdir() }).then(function (output) {
         // 'adb install' seems to always returns no error, even if installation fails
         // so we catching output to detect installation failure
         if (output.match(/Failure/)) {
@@ -77,14 +77,14 @@ Adb.install = function (target, packagePath, opts) {
 
 Adb.uninstall = function (target, packageId) {
     events.emit('verbose', 'Uninstalling package ' + packageId + ' from target ' + target + '...');
-    return spawn('adb', ['-s', target, 'uninstall', packageId], {cwd: os.tmpdir()});
+    return spawn('adb', ['-s', target, 'uninstall', packageId], { cwd: os.tmpdir() });
 };
 
 Adb.shell = function (target, shellCommand) {
     events.emit('verbose', 'Running adb shell command "' + shellCommand + '" on target ' + target + '...');
     var args = ['-s', target, 'shell'];
     shellCommand = shellCommand.split(/\s+/);
-    return spawn('adb', args.concat(shellCommand), {cwd: os.tmpdir()}).catch(function (output) {
+    return spawn('adb', args.concat(shellCommand), { cwd: os.tmpdir() }).catch(function (output) {
         return Q.reject(new CordovaError('Failed to execute shell command "' +
             shellCommand + '"" on device: ' + output));
     });

--- a/bin/templates/cordova/lib/AndroidManifest.js
+++ b/bin/templates/cordova/lib/AndroidManifest.js
@@ -146,7 +146,7 @@ AndroidManifest.prototype.setDebuggable = function (value) {
  *   manifest will be written to file it has been read from.
  */
 AndroidManifest.prototype.write = function (destPath) {
-    fs.writeFileSync(destPath || this.path, this.doc.write({indent: 4}), 'utf-8');
+    fs.writeFileSync(destPath || this.path, this.doc.write({ indent: 4 }), 'utf-8');
 };
 
 module.exports = AndroidManifest;

--- a/bin/templates/cordova/lib/device.js
+++ b/bin/templates/cordova/lib/device.js
@@ -86,7 +86,7 @@ module.exports.install = function (target, buildResults) {
         events.emit('log', 'Using apk: ' + apk_path);
         events.emit('log', 'Package name: ' + pkgName);
 
-        return Adb.install(resolvedTarget.target, apk_path, {replace: true}).catch(function (error) {
+        return Adb.install(resolvedTarget.target, apk_path, { replace: true }).catch(function (error) {
             // CB-9557 CB-10157 only uninstall and reinstall app if the one that
             // is already installed on device was signed w/different certificate
             if (!/INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES/.test(error.toString())) { throw error; }
@@ -97,7 +97,7 @@ module.exports.install = function (target, buildResults) {
             // This promise is always resolved, even if 'adb uninstall' fails to uninstall app
             // or the app doesn't installed at all, so no error catching needed.
             return Adb.uninstall(resolvedTarget.target, pkgName).then(function () {
-                return Adb.install(resolvedTarget.target, apk_path, {replace: true});
+                return Adb.install(resolvedTarget.target, apk_path, { replace: true });
             });
         }).then(function () {
             // unlock screen

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -223,13 +223,13 @@ module.exports.best_image = function () {
 
 // Returns a promise.
 module.exports.list_started = function () {
-    return Adb.devices({emulators: true});
+    return Adb.devices({ emulators: true });
 };
 
 // Returns a promise.
 // TODO: we should remove this, there's a more robust method under android_sdk.js
 module.exports.list_targets = function () {
-    return superspawn.spawn('android', ['list', 'targets'], {cwd: os.tmpdir()}).then(function (output) {
+    return superspawn.spawn('android', ['list', 'targets'], { cwd: os.tmpdir() }).then(function (output) {
         var target_out = output.split('\n');
         var targets = [];
         for (var i = target_out.length; i >= 0; i--) {
@@ -419,7 +419,7 @@ module.exports.resolveTarget = function (target) {
         }
 
         return build.detectArchitecture(target).then(function (arch) {
-            return {target: target, arch: arch, isEmulator: true};
+            return { target: target, arch: arch, isEmulator: true };
         });
     });
 };

--- a/bin/templates/cordova/lib/log.js
+++ b/bin/templates/cordova/lib/log.js
@@ -31,7 +31,7 @@ var ROOT = path.join(__dirname, '..', '..');
  */
 module.exports.run = function () {
     var d = Q.defer();
-    var adb = child_process.spawn('adb', ['logcat'], {cwd: os.tmpdir()});
+    var adb = child_process.spawn('adb', ['logcat'], { cwd: os.tmpdir() });
 
     adb.stdout.on('data', function (data) {
         var lines = data ? data.toString().split('\n') : [];

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -183,7 +183,7 @@ function updateProjectAccordingTo (platformConfig, locations) {
         strings.find('string[@name="launcher_name"]').text = shortName.replace(/\'/g, '\\\'');
     }
 
-    fs.writeFileSync(locations.strings, strings.write({indent: 4}), 'utf-8');
+    fs.writeFileSync(locations.strings, strings.write({ indent: 4 }), 'utf-8');
     events.emit('verbose', 'Wrote out android application name "' + name + '" to ' + locations.strings);
 
     // Java packages cannot support dashes
@@ -661,7 +661,7 @@ function cleanFileResources (projectRoot, projectConfig, platformDir) {
 
         FileUpdater.updatePaths(
             resourceMap, {
-                rootDir: projectRoot, all: true}, logFileOp);
+                rootDir: projectRoot, all: true }, logFileOp);
     }
 }
 

--- a/bin/templates/cordova/run
+++ b/bin/templates/cordova/run
@@ -48,7 +48,7 @@ runOpts.argv = runOpts.argv.remain;
 require('./loggingHelper').adjustLoggerLevel(runOpts);
 
 new Api().run(runOpts)
-.catch(function (err) {
-    console.error(err, err.stack);
-    process.exit(2);
-});
+    .catch(function (err) {
+        console.error(err, err.stack);
+        process.exit(2);
+    });

--- a/bin/update
+++ b/bin/update
@@ -34,4 +34,4 @@ if (args.help || args.argv.remain.length === 0) {
 
 require('./templates/cordova/loggingHelper').adjustLoggerLevel(args);
 
-Api.updatePlatform(args.argv.remain[0], {link: (args.link || args.shared)}).done();
+Api.updatePlatform(args.argv.remain[0], { link: (args.link || args.shared) }).done();

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "dependencies": {
     "android-versions": "^1.3.0",
     "cordova-common": "^3.1.0",
-    "elementtree": "0.1.6",
-    "nopt": "^3.0.1",
-    "properties-parser": "^0.2.3",
+    "elementtree": "^0.1.7",
+    "nopt": "^4.0.1",
+    "properties-parser": "^0.3.1",
     "q": "^1.4.1",
     "shelljs": "^0.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "android-versions": "^1.3.0",
-    "cordova-common": "^3.0.0",
+    "cordova-common": "^3.1.0",
     "elementtree": "0.1.6",
     "nopt": "^3.0.1",
     "properties-parser": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
     "shelljs": "^0.5.3"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-node": "^5.0.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint": "^5.12.0",
+    "eslint-config-semistandard": "^13.0.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.2",
-    "jasmine": "^3.1.0",
-    "npm-run-all": "^4.1.3",
+    "jasmine": "^3.3.1",
+    "npm-run-all": "^4.1.5",
     "promise-matchers": "~0",
-    "rewire": "^2.1.3"
+    "rewire": "^4.0.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/apache/cordova-android"
   },
   "bugs": {
-    "url": "https://issues.apache.org/jira/browse/CB"
+    "url": "https://github.com/apache/cordova-android/issues"
   },
   "keywords": [
     "android",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "test": "run-s eslint unit-tests java-unit-tests e2e-tests",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
-    "cover": "istanbul cover --root bin --print detail jasmine -- --config=spec/unit/jasmine.json",
+    "cover": "nyc jasmine --config=spec/unit/jasmine.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",
     "java-unit-tests": "node test/run_java_unit_tests.js",
     "eslint": "run-s -c eslint:*",
@@ -47,14 +47,24 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "istanbul": "^0.4.2",
     "jasmine": "^3.3.1",
     "npm-run-all": "^4.1.5",
+    "nyc": "^13.1.0",
     "promise-matchers": "~0",
     "rewire": "^4.0.1"
   },
   "engines": {
     "node": ">=6.0.0"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "nyc": {
+    "include": [
+      "bin/lib/**",
+      "bin/templates/cordova/**"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
     "nyc": "^13.1.0",
-    "promise-matchers": "~0",
     "rewire": "^4.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,14 +19,12 @@
     "apache"
   ],
   "scripts": {
-    "test": "run-s eslint unit-tests java-unit-tests e2e-tests",
+    "test": "npm run eslint && npm run cover && npm run java-unit-tests",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
-    "cover": "nyc jasmine --config=spec/unit/jasmine.json",
+    "cover": "nyc jasmine --config=spec/coverage.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",
     "java-unit-tests": "node test/run_java_unit_tests.js",
-    "eslint": "run-s -c eslint:*",
-    "eslint:scripts": "eslint bin spec test",
-    "eslint:bins": "eslint 'bin/**/*' --ignore-pattern '**/*.*' --ignore-pattern '**/gitignore' --ignore-pattern 'bin/templates/cordova/version'"
+    "eslint": "eslint bin spec test"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
@@ -48,7 +46,6 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
-    "npm-run-all": "^4.1.5",
     "nyc": "^13.1.0",
     "promise-matchers": "~0",
     "rewire": "^4.0.1"

--- a/spec/coverage.json
+++ b/spec/coverage.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+      "unit/**/*[sS]pec.js",
+      "e2e/**/*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/unit/Adb.spec.js
+++ b/spec/unit/Adb.spec.js
@@ -72,7 +72,7 @@ emulator-5554\tdevice
         });
 
         it('should return only emulators if opts.emulators is true', () => {
-            return Adb.devices({emulators: true}).then(devices => {
+            return Adb.devices({ emulators: true }).then(devices => {
                 expect(devices.length).toBe(1);
                 expect(devices[0]).toBe(emulatorId);
             });

--- a/spec/unit/config/GradlePropertiesParser.spec.js
+++ b/spec/unit/config/GradlePropertiesParser.spec.js
@@ -87,7 +87,7 @@ describe('Gradle Builder', () => {
 
             parser = new GradlePropertiesParser('/root');
 
-            parser._defaults = {'org.gradle.jvmargs': '-Xmx2048m'};
+            parser._defaults = { 'org.gradle.jvmargs': '-Xmx2048m' };
         });
 
         it('should detect missing default property and sets the property.', () => {

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -195,7 +195,7 @@ describe('create', function () {
             });
             it('should use the activityName provided via options parameter, if exists', function (done) {
                 config_mock.android_activityName.and.returnValue(undefined);
-                create.create(project_path, config_mock, {activityName: 'AwesomeActivity'}, events_mock).then(function () {
+                create.create(project_path, config_mock, { activityName: 'AwesomeActivity' }, events_mock).then(function () {
                     expect(Manifest_mock.prototype.setName).toHaveBeenCalledWith('AwesomeActivity');
                 }).fail(fail).done(done);
             });
@@ -217,7 +217,7 @@ describe('create', function () {
         });
         describe('happy path', function () {
             it('should copy project templates from a specified custom template', function (done) {
-                create.create(project_path, config_mock, {customTemplate: '/template/path'}, events_mock).then(function () {
+                create.create(project_path, config_mock, { customTemplate: '/template/path' }, events_mock).then(function () {
                     expect(shell.cp).toHaveBeenCalledWith('-r', path.join('/template/path', 'assets'), app_path);
                     expect(shell.cp).toHaveBeenCalledWith('-r', path.join('/template/path', 'res'), app_path);
                     expect(shell.cp).toHaveBeenCalledWith(path.join('/template/path', 'gitignore'), path.join(project_path, '.gitignore'));

--- a/spec/unit/emulator.spec.js
+++ b/spec/unit/emulator.spec.js
@@ -206,7 +206,7 @@ describe('emulator', () => {
             emu.__set__('Adb', AdbSpy);
 
             return emu.list_started().then(() => {
-                expect(AdbSpy.devices).toHaveBeenCalledWith({emulators: true});
+                expect(AdbSpy.devices).toHaveBeenCalledWith({ emulators: true });
             });
         });
     });
@@ -388,9 +388,9 @@ describe('emulator', () => {
 
         it('should call itself again if shell fails for a known reason', () => {
             AdbSpy.shell.and.returnValues(
-                Promise.reject({message: 'device not found'}),
-                Promise.reject({message: 'device offline'}),
-                Promise.reject({message: 'device still connecting'}),
+                Promise.reject({ message: 'device not found' }),
+                Promise.reject({ message: 'device offline' }),
+                Promise.reject({ message: 'device still connecting' }),
                 Promise.resolve('1')
             );
 

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -105,73 +105,73 @@ describe('android project handler', function () {
 
             // TODO: renumber these tests and other tests below
             it('Test#00a6 : should allow installing sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'), false);
             });
 
             it('Test#006b : should allow installing jar lib file from sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/TestLib.jar', temp, path.join('app/libs/TestLib.jar'), false);
             });
 
             it('Test#006c : should allow installing aar lib file from sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/TestAar.aar', temp, path.join('app/libs/TestAar.aar'), false);
             });
 
             it('Test#006d : should allow installing xml file from sources with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/mysettings.xml', temp,
                     path.join('app/src/main/res/xml/mysettings.xml'), false);
             });
 
             it('Test#006e : should allow installing file with other extension from sources with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/other.extension', temp,
                     path.join('app/src/main/res/values/other.extension'), false);
             });
 
             it('Test#006f : should allow installing aidl file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/myapi.aidl', temp,
                     path.join('app/src/main/aidl/com/mytest/myapi.aidl'), false);
             });
 
             it('Test#006g : should allow installing aar lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/testaar2.aar', temp,
                     path.join('app/libs/testaar2.aar'), false);
             });
 
             it('Test#006h : should allow installing jar lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/testjar2.jar', temp,
                     path.join('app/libs/testjar2.jar'), false);
             });
 
             it('Test#006i : should allow installing .so lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/jniLibs/x86/libnative.so', temp,
                     path.join('app/src/main/jniLibs/x86/libnative.so'), false);
             });
 
             it('Test#006j : should allow installing sources with target-dir that includes "app"', function () {
-                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'), false);
             });
 
             it('Test#006k : should allow installing sources with target-dir that includes "app" in its first directory', function () {
-                android['source-file'].install(valid_source[11], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[11], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/appco/src/DummyPlugin2.java'), false);
             });
@@ -202,19 +202,19 @@ describe('android project handler', function () {
             });
 
             it('Test#008 : should install framework without "parent" attribute into project root', function () {
-                var framework = {src: 'plugin-lib'};
+                var framework = { src: 'plugin-lib' };
                 android.framework.install(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.addSystemLibrary).toHaveBeenCalledWith(dummyProject.projectDir, someString);
             });
 
             it('Test#009 : should install framework with "parent" attribute into parent framework dir', function () {
-                var childFramework = {src: 'plugin-lib2', parent: 'plugin-lib'};
+                var childFramework = { src: 'plugin-lib2', parent: 'plugin-lib' };
                 android.framework.install(childFramework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.addSystemLibrary).toHaveBeenCalledWith(path.resolve(dummyProject.projectDir, childFramework.parent), someString);
             });
 
             it('Test#010 : should not copy anything if "custom" attribute is not set', function () {
-                var framework = {src: 'plugin-lib'};
+                var framework = { src: 'plugin-lib' };
                 var cpSpy = spyOn(shell, 'cp');
                 android.framework.install(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.addSystemLibrary).toHaveBeenCalledWith(someString, framework.src);
@@ -222,14 +222,14 @@ describe('android project handler', function () {
             });
 
             it('Test#011 : should copy framework sources if "custom" attribute is set', function () {
-                var framework = {src: 'plugin-lib', custom: true};
+                var framework = { src: 'plugin-lib', custom: true };
                 android.framework.install(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.addSubProject).toHaveBeenCalledWith(dummyProject.projectDir, someString);
                 expect(copyNewFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, framework.src, dummyProject.projectDir, someString, false);
             });
 
             it('Test#012 : should install gradleReference using project.addGradleReference', function () {
-                var framework = {src: 'plugin-lib', custom: true, type: 'gradleReference'};
+                var framework = { src: 'plugin-lib', custom: true, type: 'gradleReference' };
                 android.framework.install(framework, dummyPluginInfo, dummyProject);
                 expect(copyNewFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, framework.src, dummyProject.projectDir, someString, false);
                 expect(dummyProject.addGradleReference).toHaveBeenCalledWith(dummyProject.projectDir, someString);
@@ -237,7 +237,7 @@ describe('android project handler', function () {
         });
 
         describe('of <js-module> elements', function () {
-            var jsModule = {src: 'www/dummyplugin.js'};
+            var jsModule = { src: 'www/dummyplugin.js' };
             var wwwDest, platformWwwDest;
 
             beforeEach(function () {
@@ -247,7 +247,7 @@ describe('android project handler', function () {
             });
 
             it('Test#013 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                android['js-module'].install(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                android['js-module'].install(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
                 expect(fs.writeFileSync).toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
             });
@@ -260,7 +260,7 @@ describe('android project handler', function () {
         });
 
         describe('of <asset> elements', function () {
-            var asset = {src: 'www/dummyPlugin.js', target: 'foo/dummy.js'};
+            var asset = { src: 'www/dummyPlugin.js', target: 'foo/dummy.js' };
             var wwwDest; /* eslint no-unused-vars: "off" */
             var platformWwwDest; /* eslint no-unused-vars: "off" */
 
@@ -270,7 +270,7 @@ describe('android project handler', function () {
             });
 
             it('Test#015 : should put asset to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                android.asset.install(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                android.asset.install(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.www, asset.target);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.platformWww, asset.target);
             });
@@ -332,62 +332,62 @@ describe('android project handler', function () {
             });
 
             it('Test#019a : should remove stuff by calling common.deleteJava for Android Studio projects, with specific app target-dir', function () {
-                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[1], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'));
             });
 
             it('Test#019b : should remove stuff by calling common.removeFile for Android Studio projects, of jar with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[2], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/libs/TestLib.jar'));
             });
 
             it('Test#019c : should remove stuff by calling common.removeFile for Android Studio projects, of aar with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[3], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/libs/TestAar.aar'));
             });
 
             it('Test#019d : should remove stuff by calling common.removeFile for Android Studio projects, of xml with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[4], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/res/xml/mysettings.xml'));
             });
 
             it('Test#019e : should remove stuff by calling common.removeFile for Android Studio projects, of file with other extension with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[5], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/res/values/other.extension'));
             });
 
             it('Test#019f : should remove stuff by calling common.removeFile for Android Studio projects, of aidl with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/aidl/com/mytest/myapi.aidl'));
             });
 
             it('Test#019g : should remove stuff by calling common.removeFile for Android Studio projects, of aar with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[7], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/libs/testaar2.aar'));
             });
 
             it('Test#019h : should remove stuff by calling common.removeFile for Android Studio projects, of jar with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[8], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/libs/testjar2.jar'));
             });
 
             it('Test#019i : should remove stuff by calling common.removeFile for Android Studio projects, of .so lib file with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(removeFileSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/jniLibs/x86/libnative.so'));
             });
 
             it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "app"', function () {
-                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
-                android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject, {android_studio: true});
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'));
             });
         });
@@ -409,26 +409,26 @@ describe('android project handler', function () {
             });
 
             it('Test#021 : should uninstall framework without "parent" attribute into project root', function () {
-                var framework = {src: 'plugin-lib'};
+                var framework = { src: 'plugin-lib' };
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.removeSystemLibrary).toHaveBeenCalledWith(dummyProject.projectDir, someString);
             });
 
             it('Test#022 : should uninstall framework with "parent" attribute into parent framework dir', function () {
-                var childFramework = {src: 'plugin-lib2', parent: 'plugin-lib'};
+                var childFramework = { src: 'plugin-lib2', parent: 'plugin-lib' };
                 android.framework.uninstall(childFramework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.removeSystemLibrary).toHaveBeenCalledWith(path.resolve(dummyProject.projectDir, childFramework.parent), someString);
             });
 
             it('Test#023 : should remove framework sources if "custom" attribute is set', function () {
-                var framework = {src: 'plugin-lib', custom: true};
+                var framework = { src: 'plugin-lib', custom: true };
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.removeSubProject).toHaveBeenCalledWith(dummyProject.projectDir, someString);
                 expect(removeFileSpy).toHaveBeenCalledWith(dummyProject.projectDir, someString);
             });
 
             it('Test#24 : should install gradleReference using project.removeGradleReference', function () {
-                var framework = {src: 'plugin-lib', custom: true, type: 'gradleReference'};
+                var framework = { src: 'plugin-lib', custom: true, type: 'gradleReference' };
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
                 expect(removeFileSpy).toHaveBeenCalledWith(dummyProject.projectDir, someString);
                 expect(dummyProject.removeGradleReference).toHaveBeenCalledWith(dummyProject.projectDir, someString);
@@ -436,7 +436,7 @@ describe('android project handler', function () {
         });
 
         describe('of <js-module> elements', function () {
-            var jsModule = {src: 'www/dummyPlugin.js'};
+            var jsModule = { src: 'www/dummyPlugin.js' };
             var wwwDest;
             var platformWwwDest;
 
@@ -454,7 +454,7 @@ describe('android project handler', function () {
             });
 
             it('Test#025 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith('-Rf', wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith('-Rf', platformWwwDest);
             });
@@ -467,7 +467,7 @@ describe('android project handler', function () {
         });
 
         describe('of <asset> elements', function () {
-            var asset = {src: 'www/dummyPlugin.js', target: 'foo/dummy.js'};
+            var asset = { src: 'www/dummyPlugin.js', target: 'foo/dummy.js' };
             var wwwDest, platformWwwDest;
 
             beforeEach(function () {
@@ -484,7 +484,7 @@ describe('android project handler', function () {
             });
 
             it('Test#027 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                android.asset.uninstall(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                android.asset.uninstall(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });

--- a/spec/unit/prepare.spec.js
+++ b/spec/unit/prepare.spec.js
@@ -216,7 +216,7 @@ describe('updateIcons method', function () {
 
         // mock data.
         cordovaProject.projectConfig.getIcons = function () {
-            return [mockGetIconItem({density: 'mdpi'})];
+            return [mockGetIconItem({ density: 'mdpi' })];
         };
 
         expect(function () {
@@ -231,7 +231,7 @@ describe('updateIcons method', function () {
 
         // mock data.
         cordovaProject.projectConfig.getIcons = function () {
-            return [mockGetIconItem({density: 'mdpi'})];
+            return [mockGetIconItem({ density: 'mdpi' })];
         };
 
         expect(function () {
@@ -246,7 +246,7 @@ describe('updateIcons method', function () {
 
         // mock data.
         cordovaProject.projectConfig.getIcons = function () {
-            return [mockGetIconItem({height: '192'})];
+            return [mockGetIconItem({ height: '192' })];
         };
 
         expect(function () {
@@ -261,7 +261,7 @@ describe('updateIcons method', function () {
 
         // mock data.
         cordovaProject.projectConfig.getIcons = function () {
-            return [mockGetIconItem({width: '192'})];
+            return [mockGetIconItem({ width: '192' })];
         };
 
         expect(function () {
@@ -525,7 +525,7 @@ describe('prepareIcons method', function () {
         let icons = [ldpi, mdpi];
         let actual = prepareIcons(icons);
         let expected = {
-            android_icons: {ldpi, mdpi},
+            android_icons: { ldpi, mdpi },
             default_icon: undefined
         };
 
@@ -548,7 +548,7 @@ describe('prepareIcons method', function () {
         let icons = [ldpi, mdpi];
         let actual = prepareIcons(icons);
         let expected = {
-            android_icons: {ldpi, mdpi},
+            android_icons: { ldpi, mdpi },
             default_icon: undefined
         };
 

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -181,7 +181,7 @@ describe('run', () => {
             deviceSpyObj.resolveTarget.and.returnValue(deviceTarget);
 
             return run.run().then(() => {
-                expect(deviceSpyObj.install).toHaveBeenCalledWith(deviceTarget, {apkPaths: [], buildType: 'debug'});
+                expect(deviceSpyObj.install).toHaveBeenCalledWith(deviceTarget, { apkPaths: [], buildType: 'debug' });
             });
         });
 
@@ -193,7 +193,7 @@ describe('run', () => {
             emulatorSpyObj.wait_for_boot.and.returnValue(Promise.resolve());
 
             return run.run().then(() => {
-                expect(emulatorSpyObj.install).toHaveBeenCalledWith(emulatorTarget, {apkPaths: [], buildType: 'debug'});
+                expect(emulatorSpyObj.install).toHaveBeenCalledWith(emulatorTarget, { apkPaths: [], buildType: 'debug' });
             });
         });
     });


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
This PR contains final preparations for the Cordova 9 release goals. 

See [Cordova 9 Release Plan](https://github.com/apache/cordova/issues/10).
 
- Remove unused promise-matchers dependency
- Bumped `cordova-common@^3.1.0`
- Bumped Dev Dependencies with ESLint Correction
  - `eslint@^5.12.0`
  - `eslint-config-semistandard@^13.0.0`
  - `eslint-config-standard@^12.0.0`
  - `eslint-plugin-import@^2.14.0`
  - `eslint-plugin-node@^8.0.1`
  - `eslint-plugin-promise@^4.0.1`
  - `eslint-plugin-standard@^4.0.0`
  - `jasmine@^3.3.1`
  - `rewire@^4.0.1`
- Updated Dependencies
  - `elementtree@^0.1.7`
  - `nopt@^4.0.1`
  - `properties-parser@^0.3.1`
- Replace istanbul dependency with `nyc@^13.1.0`
- `package.json` cleanup
  - Dropped `npm-run-all`

### What testing has been done on this change?
- `npm t`
  - eslint
  - coverage (unit testing)
  - java unit test
- [Travis CI](https://travis-ci.org/erisu/cordova-android/builds/477286097)
- [AppVeyor](https://ci.appveyor.com/project/erisu/cordova-android/builds/21489376)
- Platform Add, Build and Run
  ```
  $ npx cordova@nightly create androidTest com.foobar.androidTest
  $ npx cordova@nightly platform add github:erisu/cordova-android\#cordova9-prep
  $ npx cordova@nightly run android
  $ npx cordova@nightly build android
  ```