### PR TITLE
javac error message fixes in requirements check

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -204,9 +204,11 @@ module.exports.check_java = function () {
             }, () => {
                 var msg =
                 'Failed to run "javac -version", make sure that you have a JDK installed.\n' +
-                'You can get it from: http://www.oracle.com/technetwork/java/javase/downloads.\n';
+                'You can get it from the following location:\n' +
+                'https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html';
                 if (process.env['JAVA_HOME']) {
-                    msg += 'Your JAVA_HOME is invalid: ' + process.env['JAVA_HOME'] + '\n';
+                    msg += '\n\n';
+                    msg += 'Your JAVA_HOME is invalid: ' + process.env['JAVA_HOME'];
                 }
                 throw new CordovaError(msg);
             });


### PR DESCRIPTION
- fix download link
- put download link on its own line
- no punctuation at the end of the download link
  (fixes #618)
- no extra newline at the end
- extra newline spacing in case JAVA_HOME is invalid

in response to #618

I hope we can get this in before we cut the next major release for Cordova 9 (apache/cordova#10).