### PR TITLE
[WIP] Quick fix for inconsistent SDK versions

### DIFF
--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -102,6 +102,9 @@ if (hasBuildExtras2) {
     apply from: '../build-extras.gradle'
 }
 
+// Needed for quick fix below:
+def customCompileSdkVersion = cdvCompileSdkVersion;
+
 // Set property defaults after extension .gradle files.
 if (ext.cdvCompileSdkVersion == null) {
     ext.cdvCompileSdkVersion = privateHelpers.getProjectTarget()
@@ -123,6 +126,10 @@ ext.cdvBuildMultipleApks = cdvBuildMultipleApks == null ? false : cdvBuildMultip
 ext.cdvVersionCodeForceAbiDigit = cdvVersionCodeForceAbiDigit == null ? false : cdvVersionCodeForceAbiDigit.toBoolean();
 ext.cdvMinSdkVersion = cdvMinSdkVersion == null ? defaultMinSdkVersion : Integer.parseInt('' + cdvMinSdkVersion)
 ext.cdvVersionCode = cdvVersionCode == null ? null : Integer.parseInt('' + cdvVersionCode)
+
+// Quick fix:
+def appTargetSdkVersion =
+    (customCompileSdkVersion == null) ? defaultTargetSdkVersion : Integer.parseInt('' + cdvCompileSdkVersion)
 
 def computeBuildTargetName(debugBuild) {
     def ret = 'assemble'
@@ -170,6 +177,9 @@ android {
         if (cdvMinSdkVersion != null) {
             minSdkVersion cdvMinSdkVersion
         }
+
+        // Quick fix:
+        targetSdkVersion appTargetSdkVersion
     }
 
     lintOptions {

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -41,9 +41,9 @@ allprojects {
     //This replaces project.properties w.r.t. build settings
     project.ext {
       defaultBuildToolsVersion="28.0.3" //String
-      defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      defaultTargetSdkVersion=28 //Integer - We ALWAYS target the latest by default
-      defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
+      defaultMinSdkVersion=19 //Integer - updated from app/AndroidManifest.xml, minimum requirement should be Android 4.4
+      defaultTargetSdkVersion=28 //Integer - updated from app/AndroidManifest.xml, should target the latest by default
+      defaultCompileSdkVersion=28 //Integer - updated from app/AndroidManifest.xml, should target the latest by default
     }
 }
 

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -88,26 +88,74 @@ describe('ProjectBuilder', () => {
         });
     });
 
-    describe('extractRealProjectNameFromManifest', () => {
+    describe('getAndroidManifestInfo', () => {
         it('should get the project name from the Android Manifest', () => {
             const projectName = 'unittestproject';
             const projectId = `io.cordova.${projectName}`;
-            const manifest = `<?xml version="1.0" encoding="utf-8"?>
-            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="${projectId}"></manifest>`;
+            const manifest =
+                `<?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${projectId}">
+                <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28"/>
+                </manifest>`;
 
             spyOn(fs, 'readFileSync').and.returnValue(manifest);
 
-            expect(builder.extractRealProjectNameFromManifest()).toBe(projectName);
+            expect(builder.getAndroidManifestInfo().packageName).toBe(projectId);
+        });
+
+        it('should get the min & target SDK versions from the Android Manifest', () => {
+            const projectName = 'unittestproject';
+            const projectId = `io.cordova.${projectName}`;
+            const manifest =
+                `<?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${projectId}">
+                <uses-sdk android:minSdkVersion="22" android:targetSdkVersion="25"/>
+                </manifest>`;
+
+            spyOn(fs, 'readFileSync').and.returnValue(manifest);
+
+            expect(builder.getAndroidManifestInfo().minSdkVersion).toBe(22);
+            expect(builder.getAndroidManifestInfo().targetSdkVersion).toBe(25);
         });
 
         it('should throw an error if there is no package in the Android manifest', () => {
-            const manifest = `<?xml version="1.0" encoding="utf-8"?>
-            <manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>`;
+            const manifest =
+                `<?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28"/>
+                </manifest>`;
 
             spyOn(fs, 'readFileSync').and.returnValue(manifest);
 
-            expect(() => builder.extractRealProjectNameFromManifest()).toThrow(jasmine.any(CordovaError));
+            expect(() => builder.getAndroidManifestInfo()).toThrow(jasmine.any(CordovaError));
+        });
+
+        it('should throw an error if there is no android:minSdkVersion in the Android manifest', () => {
+            const projectName = 'unittestproject';
+            const projectId = `io.cordova.${projectName}`;
+            const manifest =
+                `<?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${projectId}">
+                <uses-sdk android:targetSdkVersion="25"/>
+                </manifest>`;
+
+            spyOn(fs, 'readFileSync').and.returnValue(manifest);
+
+            expect(() => builder.getAndroidManifestInfo()).toThrow(jasmine.any(CordovaError));
+        });
+
+        it('should throw an error if there is no android:targetSdkVersion in the Android manifest', () => {
+            const projectName = 'unittestproject';
+            const projectId = `io.cordova.${projectName}`;
+            const manifest =
+                `<?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${projectId}">
+                <uses-sdk android:minSdkVersion="19"/>
+                </manifest>`;
+
+            spyOn(fs, 'readFileSync').and.returnValue(manifest);
+
+            expect(() => builder.getAndroidManifestInfo()).toThrow(jasmine.any(CordovaError));
         });
     });
 


### PR DESCRIPTION
Resolves #508 - Inconsistent handling of min/target SDK values

This is a quick fix to use the minimum & target SDK version values from AndroidManifest.xml.

I have tested it in a newly generated Cordova project from the command line.

This proposal also resolves #631 - Target SDK version not consistent with defaults in root build.gradle bug

~~TODO items:~~

- [x] ~~update unit tests to succeed with the new code change~~
- [x] ~~update unit tests to cover extracting minimum & target SDK version values from AndroidManifest.xml~~

Unfortunately this does NOT resolve the issue reported in #629 (errors encountered on Android Studio 3.2 & 3.3).

I really hope this kind of a solution will be part of the upcoming major release for Cordova 9 (apache/cordova#10).