### PR TITLE
Android build tools 3.3 & Gradle 4.10.3 update

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -214,7 +214,7 @@ class ProjectBuilder {
                 // If it's not set, do nothing, assuming that we're using a future version of gradle that we don't want to mess with.
                 // For some reason, using ^ and $ don't work.  This does the job, though.
                 var distributionUrlRegex = /distributionUrl.*zip/;
-                var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.6-all.zip';
+                var distributionUrl = process.env['CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL'] || 'https\\://services.gradle.org/distributions/gradle-4.10.3-all.zip';
                 var gradleWrapperPropertiesPath = path.join(self.root, 'gradle', 'wrapper', 'gradle-wrapper.properties');
                 shell.chmod('u+w', gradleWrapperPropertiesPath);
                 shell.sed('-i', distributionUrlRegex, 'distributionUrl=' + distributionUrl, gradleWrapperPropertiesPath);

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 
@@ -40,7 +40,7 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.6.0'
+    gradleVersion = '4.10.3'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,7 +31,7 @@ buildscript {
     dependencies {
         // The gradle plugin and the maven plugin have to be updated after each version of Android
         // studio comes out
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/test/wrapper.gradle
+++ b/test/wrapper.gradle
@@ -1,3 +1,3 @@
 wrapper {
-    gradleVersion = '4.6'
+    gradleVersion = '4.10.3'
 }


### PR DESCRIPTION
(Gradle 4.10.1 or higher is needed for Android Studio 3.3.0 ref: <https://developer.android.com/studio/releases/gradle-plugin#3-3-0>)

I hope this will be part of the upcoming major release for Cordova 9 (apache/cordova#10).

For the following issues:
- #634 - Update Gradle classpath for Android Studio 3.3
- #596 - Support Gradle 4.9+

I think it would be ideal to update to Gradle 5.1, not convinced we should squeeze this into Cordova 9.

P.S. I verified that no issues were introduced when I tested this change with `cordova-mobile-spec`.