### PR TITLE
[WIP] Cleanup build.gradle defaults not used

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -40,11 +40,13 @@ allprojects {
 
     //This replaces project.properties w.r.t. build settings
     project.ext {
-      // FUTURE TBD
+      // Not used
       // (see <https://github.com/apache/cordova-android/issues/659>):
       // defaultBuildToolsVersion="28.0.3" //String
+
       defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      // FUTURE TBD
+
+      // Not used
       // (should be part of solution to <https://github.com/apache/cordova-android/issues/660>):
       // defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
     }

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -40,10 +40,13 @@ allprojects {
 
     //This replaces project.properties w.r.t. build settings
     project.ext {
-      defaultBuildToolsVersion="28.0.3" //String
+      // FUTURE TBD
+      // (see <https://github.com/apache/cordova-android/issues/659>):
+      // defaultBuildToolsVersion="28.0.3" //String
       defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      defaultTargetSdkVersion=28 //Integer - We ALWAYS target the latest by default
-      defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
+      // FUTURE TBD
+      // (should be part of solution to <https://github.com/apache/cordova-android/issues/660>):
+      // defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
     }
 }
 


### PR DESCRIPTION
- remove `defaultTargetSdkVersion` which was never used
- comment out `defaultBuildToolsVersion` & `defaultCompileSdkVersion` for now

This is a quick-fix solution for #658.