### PR TITLE
Revert "Remove uses-sdk from AndroidManifest.xml (#664)"

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -321,6 +321,7 @@ exports.create = function (project_path, config, options, events) {
 
                 var manifest = new AndroidManifest(path.join(project_template_dir, 'AndroidManifest.xml'));
                 manifest.setPackageId(package_name)
+                    .setTargetSdkVersion(target_api.split('-')[1])
                     .getActivity().setName(safe_activity_name);
 
                 var manifest_path = path.join(app_path, 'AndroidManifest.xml');

--- a/bin/templates/cordova/lib/AndroidManifest.js
+++ b/bin/templates/cordova/lib/AndroidManifest.js
@@ -18,6 +18,7 @@
 */
 
 var fs = require('fs');
+var et = require('elementtree');
 var xml = require('cordova-common').xmlHelpers;
 
 var DEFAULT_ORIENTATION = 'default';
@@ -97,6 +98,31 @@ AndroidManifest.prototype.getActivity = function () {
     };
 };
 
+['minSdkVersion', 'maxSdkVersion', 'targetSdkVersion'].forEach(function (sdkPrefName) {
+    // Copy variable reference to avoid closure issues
+    var prefName = sdkPrefName;
+
+    AndroidManifest.prototype['get' + capitalize(prefName)] = function () {
+        var usesSdk = this.doc.getroot().find('./uses-sdk');
+        return usesSdk && usesSdk.attrib['android:' + prefName];
+    };
+
+    AndroidManifest.prototype['set' + capitalize(prefName)] = function (prefValue) {
+        var usesSdk = this.doc.getroot().find('./uses-sdk');
+
+        if (!usesSdk && prefValue) { // if there is no required uses-sdk element, we should create it first
+            usesSdk = new et.Element('uses-sdk');
+            this.doc.getroot().append(usesSdk);
+        }
+
+        if (prefValue) {
+            usesSdk.attrib['android:' + prefName] = prefValue;
+        }
+
+        return this;
+    };
+});
+
 AndroidManifest.prototype.getDebuggable = function () {
     return this.doc.getroot().find('./application').attrib['android:debuggable'] === 'true';
 };
@@ -124,3 +150,7 @@ AndroidManifest.prototype.write = function (destPath) {
 };
 
 module.exports = AndroidManifest;
+
+function capitalize (str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -199,6 +199,9 @@ function updateProjectAccordingTo (platformConfig, locations) {
     manifest.setVersionName(platformConfig.version())
         .setVersionCode(platformConfig.android_versionCode() || default_versionCode(platformConfig.version()))
         .setPackageId(androidPkgName)
+        .setMinSdkVersion(platformConfig.getPreference('android-minSdkVersion', 'android'))
+        .setMaxSdkVersion(platformConfig.getPreference('android-maxSdkVersion', 'android'))
+        .setTargetSdkVersion(platformConfig.getPreference('android-targetSdkVersion', 'android'))
         .write();
 
     // Java file paths shouldn't be hard coded

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "android-versions": "^1.3.0",
     "cordova-common": "^3.1.0",
+    "elementtree": "^0.1.7",
     "nopt": "^4.0.1",
     "properties-parser": "^0.3.1",
     "q": "^1.4.1",

--- a/spec/unit/AndroidManifest.spec.js
+++ b/spec/unit/AndroidManifest.spec.js
@@ -190,6 +190,78 @@ describe('AndroidManifest', () => {
         });
     });
 
+    describe('minSdkVersion', () => {
+        it('should get minSdkVersion', () => {
+            expect(manifest.getMinSdkVersion()).toBe(MIN_SDK_VERSION);
+        });
+
+        it('should set minSdkVersion', () => {
+            const newMinSdkVersion = `${MIN_SDK_VERSION}111`;
+            manifest.setMinSdkVersion(newMinSdkVersion);
+            expect(manifest.getMinSdkVersion()).toBe(newMinSdkVersion);
+        });
+
+        it('should create the uses-sdk node if it does not exist when setting minSdkVersion', () => {
+            const root = manifest.doc.getroot();
+            root.remove(root.find('./uses-sdk'));
+
+            expect(root.find('./uses-sdk')).toBe(null);
+
+            manifest.setMinSdkVersion(1);
+
+            expect(root.find('./uses-sdk')).not.toBe(null);
+            expect(manifest.getMinSdkVersion()).toBe(1);
+        });
+    });
+
+    describe('maxSdkVersion', () => {
+        it('should get maxSdkVersion', () => {
+            expect(manifest.getMaxSdkVersion()).toBe(MAX_SDK_VERSION);
+        });
+
+        it('should set maxSdkVersion', () => {
+            const newMaxSdkVersion = `${MAX_SDK_VERSION}999`;
+            manifest.setMaxSdkVersion(newMaxSdkVersion);
+            expect(manifest.getMaxSdkVersion()).toBe(newMaxSdkVersion);
+        });
+
+        it('should create the uses-sdk node if it does not exist when setting maxSdkVersion', () => {
+            const root = manifest.doc.getroot();
+            root.remove(root.find('./uses-sdk'));
+
+            expect(root.find('./uses-sdk')).toBe(null);
+
+            manifest.setMaxSdkVersion(1);
+
+            expect(root.find('./uses-sdk')).not.toBe(null);
+            expect(manifest.getMaxSdkVersion()).toBe(1);
+        });
+    });
+
+    describe('targetSdkVersion', () => {
+        it('should get targetSdkVersion', () => {
+            expect(manifest.getTargetSdkVersion()).toBe(TARGET_SDK_VERSION);
+        });
+
+        it('should set targetSdkVersion', () => {
+            const newTargetSdkVersion = `${TARGET_SDK_VERSION}555`;
+            manifest.setTargetSdkVersion(newTargetSdkVersion);
+            expect(manifest.getTargetSdkVersion()).toBe(newTargetSdkVersion);
+        });
+
+        it('should create the uses-sdk node if it does not exist when setting targetSdkVersion', () => {
+            const root = manifest.doc.getroot();
+            root.remove(root.find('./uses-sdk'));
+
+            expect(root.find('./uses-sdk')).toBe(null);
+
+            manifest.setTargetSdkVersion(1);
+
+            expect(root.find('./uses-sdk')).not.toBe(null);
+            expect(manifest.getTargetSdkVersion()).toBe(1);
+        });
+    });
+
     describe('debuggable', () => {
         it('should get debuggable', () => {
             expect(manifest.getDebuggable()).toBe(true);


### PR DESCRIPTION
needed to quickly resolve bug #666 in order to continue with the major release as part of Cordova 9 (apache/cordova#10)

as agreed in the following thread: <https://lists.apache.org/thread.html/aad8b9e6bd47a8401f14d00d960174a2c0cb78f8d8e397791cdf916e@%3Cdev.cordova.apache.org%3E>