### PR TITLE
Added Missing License Headers

### DIFF
--- a/test/wrapper.gradle
+++ b/test/wrapper.gradle
@@ -1,3 +1,21 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
 wrapper {
     gradleVersion = '4.10.3'
 }


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Cordova 9's Release Process

### Description
- Adds the missing license header.

### Testing
Not required