### PR TITLE
Updated ANDROID_HOME Test to Follow #656 Change

### DIFF
--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -35,9 +35,10 @@ describe('check_reqs', function () {
         });
     });
     describe('check_android', function () {
-        describe('set ANDROID_HOME if not set', function () {
+        describe('find and set ANDROID_HOME when ANDROID_HOME and ANDROID_SDK_ROOT is not set', function () {
             beforeEach(function () {
                 delete process.env.ANDROID_HOME;
+                delete process.env.ANDROID_SDK_ROOT;
             });
             describe('even if no Android binaries are on the PATH', function () {
                 beforeEach(function () {


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
There was a change in how the export var ANDROID_HOME is being set to follow Android documentation. 

The existing tests which tested an alternative way of find ANDROID_HOME on top of what is in Android documentation were not updated.

The changes were valid and follows Android's documentation, therefore updating the tests were the appropriate solution.


### Testing
- Local Testing
- CI Testing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
