### PR TITLE
Added allprojects repositories to Framework Build Gradle

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -37,6 +37,13 @@ buildscript {
     }
 }
 
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'


### PR DESCRIPTION
### Platforms affected
android

### Motivation and Context
To be able to release the Cordova Android Framework to JFrog Bintray.

### Description
Was not able to release the framework to Bintray because of build failures.

```
Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details
> Task :packageReleaseResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':_internal_aapt2_binary'.
> Could not find com.android.tools.build:aapt2:3.3.0-5013011.
  Searched in the following locations:
    - file:/Android/sdk/extras/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011.pom
    - file:/Android/sdk/extras/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011-osx.jar
    - file:/Android/sdk/extras/google/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011.pom
    - file:/Android/sdk/extras/google/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011-osx.jar
    - file:/Android/sdk/extras/android/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011.pom
    - file:/Android/sdk/extras/android/m2repository/com/android/tools/build/aapt2/3.3.0-5013011/aapt2-3.3.0-5013011-osx.jar
  Required by:
      project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 55s
5 actionable tasks: 5 executed
```

This issue was fixed by adding to the `cordova-android/framework/build.gradle` file:

```
allprojects {
    repositories {
        google()
        jcenter()
    }
}
```

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
