### PR TITLE
Use wwwExclude preference to filter www files.

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -151,11 +151,11 @@ function updateWww (cordovaProject, destinations) {
         sourceDirs.push(path.join('merges', 'android'));
     }
 
-    var excludes = "";
-    var excludePref = cordovaProject.projectConfig.getPreference("wwwExcludes");
+    var excludes = '';
+    var excludePref = cordovaProject.projectConfig.getPreference('wwwExcludes');
     if (excludePref) {
-        excludes = excludePref.split(",");
-        events.emit("verbose", "excludes: " + excludes.join());
+        excludes = excludePref.split(',');
+        events.emit('verbose', 'excludes: ' + excludes.join());
     }
 
     var targetDir = path.relative(cordovaProject.root, destinations.www);

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -151,11 +151,18 @@ function updateWww (cordovaProject, destinations) {
         sourceDirs.push(path.join('merges', 'android'));
     }
 
+    var excludes = "";
+    var excludePref = cordovaProject.projectConfig.getPreference("wwwExcludes");
+    if (excludePref) {
+        excludes = excludePref.split(",");
+        events.emit("verbose", "excludes: " + excludes.join());
+    }
+
     var targetDir = path.relative(cordovaProject.root, destinations.www);
     events.emit(
         'verbose', 'Merging and updating files from [' + sourceDirs.join(', ') + '] to ' + targetDir);
     FileUpdater.mergeAndUpdateDir(
-        sourceDirs, targetDir, { rootDir: cordovaProject.root }, logFileOp);
+        sourceDirs, targetDir, { rootDir: cordovaProject.root, exclude: excludes }, logFileOp);
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #684 


### Description
<!-- Describe your changes in detail -->
Modified the prepare process to use the wwwExcludes preference to provide a list of glob strings to use as excludes. The list is provided to FileUpdater.mergeAndUpdateDir() in its options.excludes parameter.

With this change, files and directories can be excluded from the list of files copied to the assets www directory.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Used "cordova prepare android -d" before and after the change to prepare.js and reviewed the list of files copied to the assets/www directory.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
