### PR TITLE
Run prepare with the correct ConfigParser version

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -25,6 +25,7 @@ var PluginManager = require('cordova-common').PluginManager;
 
 var CordovaLogger = require('cordova-common').CordovaLogger;
 var selfEvents = require('cordova-common').events;
+var ConfigParser = require('cordova-common').ConfigParser;
 
 var PLATFORM = 'android';
 
@@ -174,6 +175,8 @@ Api.prototype.getPlatformInfo = function () {
  *   CordovaError instance.
  */
 Api.prototype.prepare = function (cordovaProject, prepareOptions) {
+    cordovaProject.projectConfig = new ConfigParser(cordovaProject.locations.rootConfigXml || cordovaProject.projectConfig.path);
+
     return require('./lib/prepare').prepare.call(this, cordovaProject, prepareOptions);
 };
 

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -72,10 +72,7 @@ function Api (platform, platformRootDir, events) {
         strings: path.join(appRes, 'values', 'strings.xml'),
         manifest: path.join(appMain, 'AndroidManifest.xml'),
         build: path.join(this.root, 'build'),
-        javaSrc: path.join(appMain, 'java'),
-        // NOTE: Due to platformApi spec we need to return relative paths here
-        cordovaJs: 'bin/templates/project/assets/www/cordova.js',
-        cordovaJsSrc: 'cordova-js-src'
+        javaSrc: path.join(appMain, 'java')
     };
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See #690 : The ConfigParser passed in by cordova-lib is constructed from the cordova-common version that cordova-lib is using, rather than the one that cordova-ios is using.


### Description
<!-- Describe your changes in detail -->
Initialize the ConfigParser at the platform API level so that it uses the expected version.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))