### PR TITLE
Android - added default and extra mime types as fallback for invalid types in fileChooserParams

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -56,6 +56,7 @@ public class SystemWebChromeClient extends WebChromeClient {
 
     private static final int FILECHOOSER_RESULTCODE = 5173;
     private static final String LOG_TAG = "SystemWebChromeClient";
+    private static final String DEFAULT_MIME_TYPE = "image/*";
     private long MAX_QUOTA = 100 * 1024 * 1024;
     protected final SystemWebViewEngine parentEngine;
 
@@ -251,6 +252,8 @@ public class SystemWebChromeClient extends WebChromeClient {
     @Override
     public boolean onShowFileChooser(WebView webView, final ValueCallback<Uri[]> filePathsCallback, final WebChromeClient.FileChooserParams fileChooserParams) {
         Intent intent = fileChooserParams.createIntent();
+        intent.setType(DEFAULT_MIME_TYPE);
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, fileChooserParams.getAcceptTypes());
         try {
             parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
                 @Override


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
This PR solved the issue raised [here](https://github.com/apache/cordova-android/issues/695). 

[ng-file-upload](https://github.com/danialfarid/ng-file-upload/issues/2111) without this change does not work with Cordova. This issue on their repository had been raised a while back and many users had this unsolved issue: https://github.com/danialfarid/ng-file-upload/issues/480

### Description
Added a default mime type and extra mime types in case the mime types passed in through fileChooserParams are not supported.

Outcome after changes:

2019-04-01 00:18:00.503 2225-2921/system_process I/ActivityManager: START u0 {act=android.intent.action.GET_CONTENT cat=[android.intent.category.OPENABLE] typ=image/* cmp=com.android.documentsui/.picker.PickActivity (has extras)} from uid 10105

### Testing
Tested on Android simulator and physical device. The file picker is now correctly opened using ng-file-upload.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [V] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [V] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
