### PR TITLE
Android - Added validation of mime types for fileChooserParams. Fixes #695.

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -18,6 +18,8 @@
 */
 package org.apache.cordova.engine;
 
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Arrays;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -33,6 +35,7 @@ import android.webkit.ConsoleMessage;
 import android.webkit.GeolocationPermissions.Callback;
 import android.webkit.JsPromptResult;
 import android.webkit.JsResult;
+import android.webkit.MimeTypeMap;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
@@ -56,6 +59,7 @@ public class SystemWebChromeClient extends WebChromeClient {
 
     private static final int FILECHOOSER_RESULTCODE = 5173;
     private static final String LOG_TAG = "SystemWebChromeClient";
+    private static final String DEFAULT_MIME_TYPE = "*/*";
     private long MAX_QUOTA = 100 * 1024 * 1024;
     protected final SystemWebViewEngine parentEngine;
 
@@ -247,10 +251,42 @@ public class SystemWebChromeClient extends WebChromeClient {
         }, intent, FILECHOOSER_RESULTCODE);
     }
 
+    // Validation utility for mime types
+    private List<String> extractValidMimeTypes(String[] mimeTypes) {
+        List<String> results = new ArrayList<String>();
+        List<String> mimes;
+        if (mimeTypes.length == 1 && mimeTypes[0].contains(",")) {
+            mimes = Arrays.asList(mimeTypes[0].split(","));
+        } else {
+            mimes = Arrays.asList(mimeTypes);
+        }
+        MimeTypeMap mtm = MimeTypeMap.getSingleton();
+        for (String mime : mimes) {
+            if (mime != null && mime.trim().startsWith(".")) {
+                String extensionWithoutDot = mime.trim().substring(1, mime.trim().length());
+                String derivedMime = mtm.getMimeTypeFromExtension(extensionWithoutDot);
+                if (derivedMime != null && !results.contains(derivedMime)) {
+                    // adds valid mime type derived from the file extension
+                    results.add(derivedMime);
+                }
+            } else if (mtm.getExtensionFromMimeType(mime) != null && !results.contains(mime)) {
+                // adds valid mime type checked agains file extensions mappings
+                results.add(mime);
+            }
+        }
+        return results;
+    }
+
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public boolean onShowFileChooser(WebView webView, final ValueCallback<Uri[]> filePathsCallback, final WebChromeClient.FileChooserParams fileChooserParams) {
         Intent intent = fileChooserParams.createIntent();
+        List<String> validMimeTypes = extractValidMimeTypes(fileChooserParams.getAcceptTypes());
+        if (validMimeTypes.isEmpty()) {
+            intent.setType(DEFAULT_MIME_TYPE);
+        } else {
+            intent.setType(String.join(" ", validMimeTypes));
+        }
         try {
             parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
                 @Override


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
This PR solved the issue raised [here](https://github.com/apache/cordova-android/issues/695). 

[ng-file-upload](https://github.com/danialfarid/ng-file-upload/issues/2111) without this change does not work with Cordova. This issue on their repository had been raised a while back and many users had this unsolved issue: https://github.com/danialfarid/ng-file-upload/issues/480

### Description
Added mime types validator/generator in case the mime types passed in through fileChooserParams are not valid. Defaults to "*/*" if not valid mime type is found.

In a nutshell:
```
        Intent intent = fileChooserParams.createIntent();
        List<String> validMimeTypes = extractValidMimeTypes(fileChooserParams.getAcceptTypes());
        if (validMimeTypes.isEmpty()) {
            intent.setType(DEFAULT_MIME_TYPE);
        } else {
            intent.setType(String.join(" ", validMimeTypes));
        }
```

### Testing
Tested on Android simulator and physical device. The file picker is now correctly opened using ng-file-upload.

Utility method tested with various inputs.
Eg. 
- new String[]{null, ".zip", "application/zip", ".pdf", "image/tiff", "text/plain", "boh/bah"} => 
`application/zip application/pdf image/tiff`
- new String[]{".jpg,.png,.tiff,.jpeg,.tif,.pdf"}; => 
`system_process I/ActivityManager: START u0 {act=android.intent.action.GET_CONTENT cat=[android.intent.category.OPENABLE] typ=image/jpeg image/png image/tiff application/pdf cmp=com.android.documentsui/.picker.PickActivity} from uid 10105`
- new String[]{} => used default value

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [V] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [V] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
