### PR TITLE
Support SDK versions with pre-release identifiers

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -19,6 +19,7 @@
 
 import java.util.regex.Pattern
 import groovy.swing.SwingBuilder
+import com.g00fy2.versioncompare.Version
 
 String doEnsureValueExists(filePath, props, key) {
     if (props.get(key) == null) {
@@ -39,14 +40,15 @@ String doGetProjectTarget() {
     return doEnsureValueExists('project.properties', props, 'target')
 }
 
-String[] getAvailableBuildTools() {
+Version[] getAvailableBuildTools() {
     def buildToolsDir = new File(getAndroidSdkDir(), "build-tools")
     buildToolsDir.list()
-        .findAll { it ==~ /[0-9.]+/ }
-        .sort { a, b -> compareVersions(b, a) }
+        .collect { new Version(it) } // Invalid inputs will be handled as 0.0.0
+        .findAll { it.isHigherThan('0.0.0') }
+        .sort { a, b -> a.isHigherThan(b) ? -1 : 1 }
 }
 
-String doFindLatestInstalledBuildTools(String minBuildToolsVersion) {
+String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
     def availableBuildToolsVersions
     try {
         availableBuildToolsVersions = getAvailableBuildTools()
@@ -56,39 +58,18 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersion) {
     }
     if (availableBuildToolsVersions.length > 0) {
         def highestBuildToolsVersion = availableBuildToolsVersions[0]
-        if (compareVersions(highestBuildToolsVersion, minBuildToolsVersion) < 0) {
+        if (highestBuildToolsVersion.isLowerThan(minBuildToolsVersionString)) {
             throw new RuntimeException(
                 "No usable Android build tools found. Highest installed version is " +
-                highestBuildToolsVersion + "; minimum version required is " +
-                minBuildToolsVersion + ".")
+                highestBuildToolsVersion.getOriginalString() + "; minimum version required is " +
+                minBuildToolsVersionString + ".")
         }
-        highestBuildToolsVersion
+        highestBuildToolsVersion.getOriginalString()
     } else {
         throw new RuntimeException(
             "No installed build tools found. Install the Android build tools version " +
-            minBuildToolsVersion + " or higher.")
+            minBuildToolsVersionString + " or higher.")
     }
-}
-
-// Return the first non-zero result of subtracting version list elements
-// pairwise. If they are all identical, return the difference in length of
-// the two lists.
-int compareVersionList(Collection aParts, Collection bParts) {
-    def pairs = ([aParts, bParts]).transpose()
-    pairs.findResult(aParts.size()-bParts.size()) {it[0] - it[1] != 0 ? it[0] - it[1] : null}
-}
-
-// Compare two version strings, such as "19.0.0" and "18.1.1.0". If all matched
-// elements are identical, the longer version is the largest by this method.
-// Examples:
-//   "19.0.0" > "19"
-//   "19.0.1" > "19.0.0"
-//   "19.1.0" > "19.0.1"
-//   "19" > "18.999.999"
-int compareVersions(String a, String b) {
-    def aParts = a.tokenize('.').collect {it.toInteger()}
-    def bParts = b.tokenize('.').collect {it.toInteger()}
-    compareVersionList(aParts, bParts)
 }
 
 String getAndroidSdkDir() {
@@ -203,3 +184,12 @@ ext {
     cdvHelpers.getConfigPreference = { name, defaultValue -> doGetConfigPreference(name, defaultValue) }
 }
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.g00fy2:versioncompare:1.3.1@jar'
+    }
+}


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Fixes #708

### Description
<!-- Describe your changes in detail -->
I changed the regular expression for versions of build tools in **cordova.gradle** file in order to accept all possible versions. And I removed the tag of release life cycle in version string when comparing them.

> 29.0.0-rc1 => 29.0.0

### Testing
I built an example project with both Android SDK Build-Tools **28.0.0** and **29.0.0-rc1**.



### Checklist

- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
