### PR TITLE
Fix deprecation warning in SystemCookieManager

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -57,6 +57,7 @@ class SystemCookieManager implements ICordovaCookieManager {
         return cookieManager.getCookie(url);
     }
 
+    @SuppressWarnings("deprecation")
     public void clearCookies() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             cookieManager.removeAllCookies(null);


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When building, there's a deprecation warning printed about `SystemCookieManager.java uses or overrides a deprecated API.`


### Description
<!-- Describe your changes in detail -->
Added the correct annotation to silence the warning.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Built an app and no deprecation warning was printed.
