### PR TITLE
 Do not explicitly require modules from project directory

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -142,8 +142,8 @@ function writeProjectProperties (projectPath, target_api) {
 
 // This makes no sense, what if you're building with a different build system?
 function prepBuildFiles (projectPath) {
-    var buildModule = require(path.resolve(projectPath, 'cordova/lib/builders/builders'));
-    buildModule.getBuilder().prepBuildFiles();
+    var buildModule = require('../templates/cordova/lib/builders/builders');
+    buildModule.getBuilder(projectPath).prepBuildFiles();
 }
 
 function copyBuildRules (projectPath, isLegacy) {

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -99,8 +99,7 @@ Api.createPlatform = function (destination, config, options, events) {
     var result;
     try {
         result = require('../../lib/create').create(destination, config, options, events).then(function (destination) {
-            var PlatformApi = require(path.resolve(destination, 'cordova/Api'));
-            return new PlatformApi(PLATFORM, destination, events);
+            return new Api(PLATFORM, destination, events);
         });
     } catch (e) {
         events.emit('error', 'createPlatform is not callable from the android project API.');
@@ -130,8 +129,7 @@ Api.updatePlatform = function (destination, options, events) {
     var result;
     try {
         result = require('../../lib/create').update(destination, options, events).then(function (destination) {
-            var PlatformApi = require(path.resolve(destination, 'cordova/Api'));
-            return new PlatformApi('android', destination, events);
+            return new Api(PLATFORM, destination, events);
         });
     } catch (e) {
         events.emit('error', 'updatePlatform is not callable from the android project API, you will need to do this manually.');

--- a/bin/templates/cordova/lib/builders/builders.js
+++ b/bin/templates/cordova/lib/builders/builders.js
@@ -24,10 +24,10 @@ const CordovaError = require('cordova-common').CordovaError;
  *
  * @return {Builder} A builder instance for specified build type.
  */
-module.exports.getBuilder = function () {
+module.exports.getBuilder = function (projectPath) {
     try {
         const Builder = require('./ProjectBuilder');
-        return new Builder();
+        return new Builder(projectPath);
     } catch (err) {
         throw new CordovaError('Failed to instantiate ProjectBuilder builder: ' + err);
     }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Before this change, the following would fail if `cordova-android` or one of its dependencies are not resolvable from `dir`:
```js
require('cordova-android').createPlatform(dir, configParser, null, events)
```

This happens for example if you want to setup a platform-centered App from scratch. In my case I wanted to create a project in a temp folder during `plugman` test setups in `cordova-lib`.

The problem is, that during project creation `cordova-android` requires some of the modules that have been checked-out to the project directory instead of the ones relative to the running modules (looking at the actual changes will probably clarify what I'm trying to say here).

### Description
Instead of switching to the checked-out modules in the created platform-project, we simply use the identical modules relative to the active ones.


### Testing
Ran the automated test suite. Ran tests in `cordova-lib` that use `cordova-android` using this updated version.

