### PR TITLE
Don't request focus explicitly if not needed

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -268,9 +268,11 @@ public class CordovaActivity extends Activity {
         if (this.appView == null) {
             return;
         }
-        // Force window to have focus, so application always
-        // receive user input. Workaround for some devices (Samsung Galaxy Note 3 at least)
-        this.getWindow().getDecorView().requestFocus();
+        if (! this.getWindow().getDecorView().hasFocus()) {
+            // Force window to have focus, so application always
+            // receive user input. Workaround for some devices (Samsung Galaxy Note 3 at least)
+            this.getWindow().getDecorView().requestFocus();
+        }
 
         this.appView.handleResume(this.keepRunning);
     }


### PR DESCRIPTION
Related to issue #722.

Requesting the focus explicitly actually makes the child WebView to move the focus to the first visible focusable element on the page. This makes it impossible to simply let the WebView restore the focus to the last focused element, before the activity was paused. To prevent this problem on devices other that the Samsung Galaxy Note 3, only request the focus if necessary (it might as well be possible that the original fix is not needed anymore on newer versions of Android and/or WebView).
