### PR TITLE
Use java package name for loading BuildConfig

### DIFF
--- a/framework/src/org/apache/cordova/BuildHelper.java
+++ b/framework/src/org/apache/cordova/BuildHelper.java
@@ -51,7 +51,7 @@ public class BuildHelper {
     {
         try
         {
-            Class<?> clazz = Class.forName(ctx.getPackageName() + ".BuildConfig");
+            Class<?> clazz = Class.forName(ctx.getClass().getPackage().getName() + ".BuildConfig");
             Field field = clazz.getField(key);
             return field.get(null);
         } catch (ClassNotFoundException e) {
@@ -61,6 +61,9 @@ public class BuildHelper {
             LOG.d(TAG, key + " is not a valid field. Check your build.gradle");
         } catch (IllegalAccessException e) {
             LOG.d(TAG, "Illegal Access Exception: Let's print a stack trace.");
+            e.printStackTrace();
+        } catch (NullPointerException e) {
+            LOG.d(TAG, "Null Pointer Exception: Let's print a stack trace.");
             e.printStackTrace();
         }
 

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -389,7 +389,7 @@ public class CoreAndroid extends CordovaPlugin {
     {
         try
         {
-            Class<?> clazz = Class.forName(ctx.getPackageName() + ".BuildConfig");
+            Class<?> clazz = Class.forName(ctx.getClass().getPackage().getName() + ".BuildConfig");
             Field field = clazz.getField(key);
             return field.get(null);
         } catch (ClassNotFoundException e) {
@@ -399,6 +399,9 @@ public class CoreAndroid extends CordovaPlugin {
             LOG.d(TAG, key + " is not a valid field. Check your build.gradle");
         } catch (IllegalAccessException e) {
             LOG.d(TAG, "Illegal Access Exception: Let's print a stack trace.");
+            e.printStackTrace();
+        } catch (NullPointerException e) {
+            LOG.d(TAG, "Null Pointer Exception: Let's print a stack trace.");
             e.printStackTrace();
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolving `BuildConfig` using android package name (`Context.getPackageName`) will only work when java and android package names are the same.

Android package name is effectively its `applicationId` which does not have to match java package name.
A common practice is to use different android package names for different built variants/flavours, ie:
```
debug {
	applicationIdSuffix ".debug"
}
```
Now the applicationId (and android package name) might be something like `com.example.debug`, but `BuildConfig `will still resolve by `com.example.BuildConfig` instead of `com.example.debug.ClassName`

This pull request resolves issue #513.

### Description
<!-- Describe your changes in detail -->
Now using `java.lang.Class.getPackage()` instead of `android.content.Context.getPackageName()`


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested with and without `applicationIdSuffix` with single Android 9 device.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
