### PR TITLE
feat: Build app bundles (.aab files)

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -302,12 +302,12 @@ Api.prototype.build = function (buildOptions) {
         return require('./lib/build').run.call(self, buildOptions);
     }).then(function (buildResults) {
         // Cast build result to array of build artifacts
-        return buildResults.apkPaths.map(function (apkPath) {
+        return buildResults.paths.map(function (apkPath) {
             return {
                 buildType: buildResults.buildType,
                 buildMethod: buildResults.buildMethod,
                 path: apkPath,
-                type: 'apk'
+                type: path.extname(apkPath).replace(/\./g, '')
             };
         });
     });

--- a/bin/templates/cordova/lib/PackageType.js
+++ b/bin/templates/cordova/lib/PackageType.js
@@ -1,0 +1,25 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const PackageType = {
+    APK: 'apk',
+    BUNDLE: 'bundle'
+};
+
+module.exports = PackageType;

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -114,13 +114,13 @@ function parseOpts (options, resolvedTarget, projectRoot) {
         let shouldWarn = false;
         const signingKeys = ['keystore', 'alias', 'storePassword', 'password', 'keystoreType'];
 
-        Object.keys(packageArgs).forEach((key) => {
+        for (let key in packageArgs) {
             if (!shouldWarn && signingKeys.indexOf(key) > -1) {
                 // If we enter this condition, we have a key used for signing a build,
                 // but we are missing some required signing properties
                 shouldWarn = true;
             }
-        });
+        }
 
         if (shouldWarn) {
             events.emit('warn', '\'keystore\' and \'alias\' need to be specified to generate a signed archive.');

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -98,8 +98,6 @@ function parseOpts (options, resolvedTarget, projectRoot) {
             ['alias', 'storePassword', 'password', 'keystoreType', 'packageType'].forEach(function (key) {
                 packageArgs[key] = packageArgs[key] || androidInfo[key];
             });
-
-            ret.packageType = packageArgs.packageType;
         }
     }
 
@@ -114,11 +112,13 @@ function parseOpts (options, resolvedTarget, projectRoot) {
         }
     }
 
-    if (ret.packageType) {
+    if (packageArgs.packageType) {
         const VALID_PACKAGE_TYPES = [PackageType.APK, PackageType.BUNDLE];
-        if (VALID_PACKAGE_TYPES.indexOf(ret.packageType) === -1) {
-            events.emit('warn', '"' + ret.packageType + '" is an invalid packageType. Valid values are: ' + VALID_PACKAGE_TYPES.join(', ') + '\nDefaulting packageType to ' + PackageType.APK);
+        if (VALID_PACKAGE_TYPES.indexOf(packageArgs.packageType) === -1) {
+            events.emit('warn', '"' + packageArgs.packageType + '" is an invalid packageType. Valid values are: ' + VALID_PACKAGE_TYPES.join(', ') + '\nDefaulting packageType to ' + PackageType.APK);
             ret.packageType = PackageType.APK;
+        } else {
+            ret.packageType = packageArgs.packageType;
         }
     } else {
         ret.packageType = PackageType.APK;

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -107,7 +107,20 @@ function parseOpts (options, resolvedTarget, projectRoot) {
     }
 
     if (!ret.packageInfo) {
-        if (Object.keys(packageArgs).length > 0) {
+        // The following loop is to decide whether to print a warning about generating a signed archive
+        // We only want to produce a warning if they are using a config property that is related to signing, but
+        // missing the required properties for signing. We don't want to produce a warning if they are simply
+        // using a build property that isn't related to singing, such as --packageType
+        let shouldWarn = false;
+        const signingKeys = ['keystore', 'alias', 'storePassword', 'password', 'keystoreType'];
+        for (let key in packageArgs) {
+            if (signingKeys.indexOf(key) > -1) {
+                shouldWarn = true;
+                break;
+            }
+        }
+
+        if (shouldWarn) {
             events.emit('warn', '\'keystore\' and \'alias\' need to be specified to generate a signed archive.');
         }
     }

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -110,15 +110,17 @@ function parseOpts (options, resolvedTarget, projectRoot) {
         // The following loop is to decide whether to print a warning about generating a signed archive
         // We only want to produce a warning if they are using a config property that is related to signing, but
         // missing the required properties for signing. We don't want to produce a warning if they are simply
-        // using a build property that isn't related to singing, such as --packageType
+        // using a build property that isn't related to signing, such as --packageType
         let shouldWarn = false;
         const signingKeys = ['keystore', 'alias', 'storePassword', 'password', 'keystoreType'];
-        for (let key in packageArgs) {
-            if (signingKeys.indexOf(key) > -1) {
+
+        Object.keys(packageArgs).forEach((key) => {
+            if (!shouldWarn && signingKeys.indexOf(key) > -1) {
+                // If we enter this condition, we have a key used for signing a build,
+                // but we are missing some required signing properties
                 shouldWarn = true;
-                break;
             }
-        }
+        });
 
         if (shouldWarn) {
             events.emit('warn', '\'keystore\' and \'alias\' need to be specified to generate a signed archive.');

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -384,7 +384,14 @@ function findOutputApksHelper (dir, build_type, arch) {
     return ret;
 }
 
+// This method was a copy of findOutputApksHelper and modified to look for bundles
+// While replacing shell with fs-extra, it might be a good idea to see if we can
+// generalise these findOutput methods.
 function findOutputBundlesHelper (dir, build_type) {
+    // This is an unused variable that was copied from findOutputApksHelper
+    // we are pretty sure it was meant to reset shell.config.silent back to
+    // the original value. However shell is planned to be replaced,
+    // it was left as is to avoid unintended consequences.
     const shellSilent = shell.config.silent;
     shell.config.silent = true;
 

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -43,23 +43,25 @@ class ProjectBuilder {
     }
 
     getArgs (cmd, opts) {
-        var args;
+        let args;
         if (opts.packageType === PackageType.BUNDLE) {
+            let buildCmd;
             if (cmd === 'release') {
-                cmd = ':app:bundleRelease';
+                buildCmd = ':app:bundleRelease';
             } else if (cmd === 'debug') {
-                cmd = ':app:bundleDebug';
+                buildCmd = ':app:bundleDebug';
             }
 
-            args = [cmd, '-b', path.join(this.root, 'build.gradle')];
+            args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];
         } else {
+            let buildCmd;
             if (cmd === 'release') {
-                cmd = 'cdvBuildRelease';
+                buildCmd = 'cdvBuildRelease';
             } else if (cmd === 'debug') {
-                cmd = 'cdvBuildDebug';
+                buildCmd = 'cdvBuildDebug';
             }
 
-            args = [cmd, '-b', path.join(this.root, 'build.gradle')];
+            args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];
 
             if (opts.arch) {
                 args.push('-PcdvBuildArch=' + opts.arch);
@@ -383,16 +385,14 @@ function findOutputApksHelper (dir, build_type, arch) {
 }
 
 function findOutputBundlesHelper (dir, build_type) {
-    var shellSilent = shell.config.silent;
+    const shellSilent = shell.config.silent;
     shell.config.silent = true;
 
     // list directory recursively
-    var ret = shell.ls('-R', dir).map(function (file) {
-        // ls does not include base directory
-        return path.join(dir, file);
+    const ret = shell.ls('-R', dir).map(function (file) {
+        return path.join(dir, file); // ls does not include base directory
     }).filter(function (file) {
-        // find all bundles
-        return file.match(/\.aab?$/i);
+        return file.match(/\.aab?$/i); // find all bundles
     }).filter(function (candidate) {
         // Need to choose between release and debug bundle.
         if (build_type === 'debug') {

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -108,8 +108,9 @@ module.exports.run = function (runOptions) {
 
             // Android app bundles cannot be deployed directly to the device
             if (buildOptions.packageType === PackageType.BUNDLE) {
-                events.emit('error', 'Package type "bundle" is not supported during cordova run.');
-                throw '---'; // XXX TBD ???
+                const packageTypeErrorMessage = 'Package type "bundle" is not supported during cordova run.';
+                events.emit('error', packageTypeErrorMessage);
+                throw packageTypeErrorMessage;
             }
 
             resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -109,6 +109,7 @@ module.exports.run = function (runOptions) {
             // Android app bundles cannot be deployed directly to the device
             if (buildOptions.packageType === PackageType.BUNDLE) {
                 events.emit('error', 'Package type "bundle" is not supported during cordova run.');
+                throw '---'; // XXX TBD ???
             }
 
             resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -23,6 +23,7 @@ var path = require('path');
 var emulator = require('./emulator');
 var device = require('./device');
 var Q = require('q');
+var PackageType = require('./PackageType');
 var events = require('cordova-common').events;
 
 function getInstallTarget (runOptions) {
@@ -104,6 +105,12 @@ module.exports.run = function (runOptions) {
         return new Promise((resolve) => {
             const builder = require('./builders/builders').getBuilder();
             const buildOptions = require('./build').parseBuildOptions(runOptions, null, self.root);
+
+            // Android app bundles cannot be deployed directly to the device
+            if (buildOptions.packageType === PackageType.BUNDLE) {
+                events.emit('error', 'Package type "bundle" is not supported during cordova run.');
+            }
+
             resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));
         }).then(function (buildResults) {
             if (resolvedTarget && resolvedTarget.isEmulator) {

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -23,7 +23,6 @@ var path = require('path');
 var emulator = require('./emulator');
 var device = require('./device');
 var Q = require('q');
-var PackageType = require('./PackageType');
 var events = require('cordova-common').events;
 
 function getInstallTarget (runOptions) {
@@ -105,12 +104,6 @@ module.exports.run = function (runOptions) {
         return new Promise((resolve) => {
             const builder = require('./builders/builders').getBuilder();
             const buildOptions = require('./build').parseBuildOptions(runOptions, null, self.root);
-
-            // Android app bundles cannot be deployed directly to the device
-            if (buildOptions.packageType === PackageType.BUNDLE) {
-                events.emit('error', 'Package type "bundle" is not supported during cordova run.');
-            }
-
             resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));
         }).then(function (buildResults) {
             if (resolvedTarget && resolvedTarget.isEmulator) {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "^3.4.0",
-    "nyc": "^14.1.1",
+    "jasmine": "^3.3.1",
+    "nyc": "^13.1.0",
     "rewire": "^4.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "^3.3.1",
-    "nyc": "^13.1.0",
+    "jasmine": "^3.4.0",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1"
   },
   "engines": {

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -66,6 +66,20 @@ describe('ProjectBuilder', () => {
             expect(args[0]).toBe('cdvBuildDebug');
         });
 
+        it('should set bundle release', () => {
+            const args = builder.getArgs('release', {
+                isBundle: true
+            });
+            expect(args[0]).withContext(args).toBe(':app:bundleRelease');
+        });
+
+        it('should set bundle debug', () => {
+            const args = builder.getArgs('debug', {
+                isBundle: true
+            });
+            expect(args[0]).toBe(':app:bundleDebug');
+        });
+
         it('should add architecture if it is passed', () => {
             const arch = 'unittest';
             const args = builder.getArgs('debug', { arch });

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -66,18 +66,32 @@ describe('ProjectBuilder', () => {
             expect(args[0]).toBe('cdvBuildDebug');
         });
 
+        it('should set apk release', () => {
+            const args = builder.getArgs('release', {
+                packageType: 'apk'
+            });
+            expect(args[0]).withContext(args).toBe('cdvBuildRelease');
+        });
+
+        it('should set apk debug', () => {
+            const args = builder.getArgs('debug', {
+                packageType: 'apk'
+            });
+            expect(args[0]).withContext(args).toBe('cdvBuildDebug');
+        });
+
         it('should set bundle release', () => {
             const args = builder.getArgs('release', {
-                isBundle: true
+                packageType: 'bundle'
             });
             expect(args[0]).withContext(args).toBe(':app:bundleRelease');
         });
 
         it('should set bundle debug', () => {
             const args = builder.getArgs('debug', {
-                isBundle: true
+                packageType: 'bundle'
             });
-            expect(args[0]).toBe(':app:bundleDebug');
+            expect(args[0]).withContext(args).toBe(':app:bundleDebug');
         });
 
         it('should add architecture if it is passed', () => {

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -196,6 +196,18 @@ describe('run', () => {
                 expect(emulatorSpyObj.install).toHaveBeenCalledWith(emulatorTarget, { apkPaths: [], buildType: 'debug' });
             });
         });
+
+        it('should fail with the error message if --packageType=bundle setting is used', () => {
+            const deviceList = ['testDevice1', 'testDevice2'];
+            getInstallTargetSpy.and.returnValue(null);
+
+            deviceSpyObj.list.and.returnValue(Promise.resolve(deviceList));
+
+            return run.run({ argv: ['--packageType=bundle'] }).then(
+                () => fail('Expected error to be thrown'),
+                err => expect(err).toContain('???') // XXX TBD ???
+            );
+        });
     });
 
     describe('help', () => {

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -205,7 +205,7 @@ describe('run', () => {
 
             return run.run({ argv: ['--packageType=bundle'] }).then(
                 () => fail('Expected error to be thrown'),
-                err => expect(err).toContain('???') // XXX TBD ???
+                err => expect(err).toContain('Package type "bundle" is not supported during cordova run.')
             );
         });
     });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
-  Android


### Motivation and Context
This PR adds support to build android bundle (aab) files.
Fixes:  #729 



### Description

~Adds an `--bundle` flag to the `cordova build` command. If present, cordova will do the necessary steps to run the `gradlew bundleDebug` command (or `gradlew bundleRelease` if `--release` flag is present)~

Accepts `packageType` property from `build.json`, or optionally the `--packageType=apk|bundle` command line argument. The `packageType` property was chosen to keep consistency with the iOS platform. 

This PR does not change the current build commands. Building APKs is still necessary for deploying apps to test devices, or of course to upload to the Google Play store using the traditional way. Bundle files are *exclusively* for deploying to Google Play Store. 

You can however use the google provided `bundletool` program to build APKs from a bundle file so this PR still provides the ability to build bundles in both debug and release variants.

If `build.json` is present in the cordova project, just like building APKs, bundles will automatically be signed using the key and password as defined in `build.json`.

This PR does alter a previous constraint where if a signing property is present, but is missing the required properties for signing a warning would be displayed. This was altered to only show the warning if a property for signing is present is missing the required properties for signing. In other words, if `packageType` is the only property defined in the `build.json` file, then a warning about missing required properties for signing won't be emitted.

The `cordova run android` command has been modified to produce an error if `packageType` is set to `bundle`. This is because you cannot execute/deploy a bundle directly to the phone. I believe it is possible to replace all usages of the `adb` tool and instead use Google's `bundletool`, which provides tools to deploy bundle files to devices and thus support the `cordova run` command using bundles, but that would be another PR for another day.

### Testing

I have done the following:
- Added unit tests for using the `--packageType` flag
- Ran `npm test` and ensure all tests passed (Running Node 10.x & cordova@9)
-  I installed `cordova-android` platform to a test app via `cordova platform add https://github.com/breautek/cordova-android.git#app-bundle` and manually ran build commands and all combinations of `--debug`, `--release`, and `--bundle`
- I have created a test app on Google Play store to ensure that google will accept a signed aab file created by `cordova build android --bundle --release`.
- I have tested app-bundle branch against one of my work projects which involves a more complicated project structure and includes the use of native libraries (crosswalk) and observed successful builds.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary

### TODO

- [x] Additionally fallback to build.json `packageType` to decide whether to build an APK or bundle. Overridable by --packageType (Removing the --bundle flag)
- [x] Update build.json documentation
- [x] Fix the added unit test so that they are consistent (one uses `withContext`, the other doesn't)
- [x] Revert devDependencies `nyc` and `jasmine`