### PR TITLE
ci(travis): Fix Android SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
         - nodejs_version=6
         - nodejs_version=8
         - nodejs_version=10
+        - nodejs_version=12
 
 install:
     # Install a sdkmanager version that supports the --licenses switch and

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ env:
     - ANDROID_API_LEVEL=28
     - ANDROID_BUILD_TOOLS_VERSION=28.0.
     - TERM=dumb # Keep gradle from crapping all over the log
-
+  matrix:
+    - nodejs_version=6
+    - nodejs_version=8
+    - nodejs_version=10
+    - nodejs_version=12
+  
 language: android
 jdk:
   - oraclejdk8
@@ -19,19 +24,13 @@ android:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
-    
-matrix:
-  - nodejs_version=6
-  - nodejs_version=8
-  - nodejs_version=10
-  - nodejs_version=12
 
 before_install:
-  - nvm install $TRAVIS_NODE_VERSION  
+  - nvm install $nodejs_version 
   - node --version
   - npm --version
   - gradle --version
-    
+
 install:
   - npm install
   - npm install -g codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   global:
     - ANDROID_API_LEVEL=28
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.
+    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - TERM=dumb # Keep gradle from crapping all over the log
   matrix:
     - nodejs_version=6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - nodejs_version=6
     - nodejs_version=8
     - nodejs_version=10
-    - nodejs_version=12
   
 language: android
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,44 @@
-language: android
 sudo: false
+
+env:
+  global:
+    - ANDROID_API_LEVEL=28
+    - ANDROID_BUILD_TOOLS_VERSION=28.0.
+    - TERM=dumb # Keep gradle from crapping all over the log
+
+language: android
 jdk:
-    - oraclejdk8
+  - oraclejdk8
 
 android:
-    components:
-        - build-tools-28.0.3
-env:
-    global:
-        # Keep gradle from crapping all over the log
-        - TERM=dumb
-    matrix:
-        - nodejs_version=6
-        - nodejs_version=8
-        - nodejs_version=10
-        - nodejs_version=12
+  components:
+    - tools
+    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
+    - android-$ANDROID_API_LEVEL
+  licenses:
+    - 'android-sdk-preview-license-.+'
+    - 'android-sdk-license-.+'
+    - 'google-gdk-license-.+'
+    
+matrix:
+  - nodejs_version=6
+  - nodejs_version=8
+  - nodejs_version=10
+  - nodejs_version=12
 
+before_install:
+  - nvm install $TRAVIS_NODE_VERSION  
+  - node --version
+  - npm --version
+  - gradle --version
+    
 install:
-    # Install a sdkmanager version that supports the --licenses switch and
-    # accept any Android SDK licenses. The output redirection prevents us from
-    # hitting the travis log size limit of 4MB which would fail the build.
-    - yes | sdkmanager tools > /dev/null
-    - yes | sdkmanager --licenses > /dev/null
-
-    - nvm install $nodejs_version
-    - npm install
-    - npm install -g codecov
+  - npm install
+  - npm install -g codecov
 
 script:
-    - gradle --version
-    - node --version
-    - npm --version
-    - npm test
-    - npm run cover
+  - npm test
+  - npm run cover
 
 after_script:
-    - codecov
+  - codecov


### PR DESCRIPTION
CI is currently broken (noticed in https://github.com/apache/cordova-android/pull/764), probably because Travis updated their images:

```
$ yes | sdkmanager tools > /dev/null
/home/travis/.travis/functions: line 104: sdkmanager: command not found
The command "yes | sdkmanager tools > /dev/null" failed and exited with 127 during .
```

We already updated the [`.travis.yml` of paramedic](https://github.com/apache/cordova-paramedic/blob/master/.travis.yml) to solve similar problems, so I used that as a template to get this one here working again as well. Restructed and reformatted the file along the way as well - but no functional changes.