### PR TITLE
[WIP] Add Node.js 12 to CI WIP with known test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-dist: bionic
+dist: trusty
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - nodejs_version=6
     - nodejs_version=8
     - nodejs_version=10
+    - nodejs_version=12
   
 language: android
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: trusty
+
 env:
   global:
     - ANDROID_API_LEVEL=28

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-dist: xenial
+dist: bionic
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-dist: trusty
+dist: xenial
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
         - nodejs_version: 6
         - nodejs_version: 8
         - nodejs_version: 10
+        - nodejs_version: 12
 
 install:
     # Install Android SDK Tools


### PR DESCRIPTION
This includes a change that @janpio pushed to the `janpio-travis_node_12` branch (draft PR #766).

~~I discovered that there is a hidden failure on Node.js 12, as reported by @breautek in #768. While output shows a single `F` character, the build seems ignore this failure on both Travis CI and AppVeyor CI.~~

~~I think that further discussion of the ignored test failure should continue in #768.~~

~~P.S. For some reason Travis CI still does not work on Node.js 12, which is very strange since this does work on my fork. But we can still see the ignored test failure on Node.js 12 on AppVeyor CI.~~

_Now with known test failure on Node.js 12, as reported in #767. The trick is to add `dist: trusty` setting near the beginning of `.travis.yml`._