### PR TITLE
[WIP] lint: (semi)standard lint updates

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,3 +8,5 @@ rules:
   padded-blocks: off
   operator-linebreak: off
   no-throw-literal: off
+  quote-props: off
+  prefer-const: off

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "eslint": "^5.12.0",
-    "eslint-config-semistandard": "^13.0.0",
-    "eslint-config-standard": "^12.0.0",
+    "eslint-config-semistandard": "^14.0.0",
+    "eslint-config-standard": "^13.0.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -2,3 +2,4 @@ env:
     jasmine: true
 rules:
     prefer-promise-reject-errors: off
+    array-bracket-spacing: off


### PR DESCRIPTION
- eslint-config-semistandard@14.0.0 update
- eslint-config-standard@13 update
- ignore 2 more rules in top-level `.eslintrc.yml`
- ignore yet another rule in `spec/.eslintrc.yml`

These changes seem to be OK back to Node.js 6.

FUTURE TODO items:

- eslint@6 & eslint-plugin-node@9 updates once we can drop Node.js 6 build
- enable some rules that are disabled in `.eslintrc.yml` & `spec/.eslintrc.yml`, and resolve the resulting lint issues