### PR TITLE
rewire workaround for NodeJS 12

### DIFF
--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -207,6 +207,7 @@ describe('run', () => {
             // Rewiring the process object in entirety does not work on NodeJS 12.
             // Rewiring members of process however does work
             // https://github.com/apache/cordova-android/issues/768
+            // https://github.com/jhnns/rewire/issues/167
             run.__set__('process.exit', _ => null);
             run.__set__('process.cwd', _ => '');
             run.__set__('process.argv', ['', '']);

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -202,8 +202,14 @@ describe('run', () => {
         it('should print out usage and help', () => {
             const logSpy = jasmine.createSpy();
             const errorSpy = jasmine.createSpy();
-            const procStub = { exit: _ => null, cwd: _ => '', argv: ['', ''] };
-            run.__set__({ console: { log: logSpy, error: errorSpy }, process: procStub });
+            run.__set__({ console: { log: logSpy, error: errorSpy } });
+
+            // Rewiring the process object in entirety does not work on NodeJS 12.
+            // Rewiring members of process however does work
+            // https://github.com/apache/cordova-android/issues/768
+            run.__set__('process.exit', _ => null);
+            run.__set__('process.cwd', _ => '');
+            run.__set__('process.argv', ['', '']);
 
             run.help();
             expect(logSpy).toHaveBeenCalledWith(jasmine.stringMatching(/^Usage:/));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android tests


### Motivation and Context
Fixes jasmine output on NodeJS 12.
Fixes #768 



### Description
Rewiring the `process` object no longer works as of NodeJS 12. However you can still rewire members of the `process` object. This PR rewires individual `process` members as required by the test, instead of rewiring the `process` object entirely.


### Testing
I've ran npm test and observed full jasmine output on Node 12. Note, due to another issue as reported #767 here, there is still 1 test failing on NodeJS 12.

I've also ran the tests successfully on NodeJS 10.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
