### PR TITLE
ci(travis): set `dist: trusty` in `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: trusty
+
 env:
   global:
     - ANDROID_API_LEVEL=28

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 
+# NOTE: dist is added here to ensure that Travis CI works consistently
+# on Node.js 12. It is desired to remove it once this issue is resolved
+# or otherwise goes away.
 dist: trusty
 
 env:


### PR DESCRIPTION
to avoid errored Travis CI build on Node.js 12 (see WIP PR #770)