### PR TITLE
Consistent order from ProjectBuilder.apkSorter

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -301,21 +301,22 @@ class ProjectBuilder {
 module.exports = ProjectBuilder;
 
 function apkSorter (fileA, fileB) {
-    // De-prioritize arch specific builds
-    var archSpecificRE = /-x86|-arm/;
-    if (archSpecificRE.exec(fileA)) {
-        return 1;
-    } else if (archSpecificRE.exec(fileB)) {
-        return -1;
-    }
+    const archSpecificRE = /-x86|-arm/;
 
-    // De-prioritize unsigned builds
-    var unsignedRE = /-unsigned/;
-    if (unsignedRE.exec(fileA)) {
-        return 1;
-    } else if (unsignedRE.exec(fileB)) {
-        return -1;
-    }
+    const unsignedRE = /-unsigned/;
+
+    // De-prioritize arch-specific builds & unsigned builds
+    const lower = (fileName) => {
+        return archSpecificRE.exec(fileName)
+            ? -2
+            : unsignedRE.exec(fileName)
+                ? -1
+                : 0;
+    };
+
+    const lowerDiff = lower(fileB) - lower(fileA);
+
+    if (lowerDiff !== 0) return lowerDiff;
 
     var timeDiff = fs.statSync(fileB).mtime - fs.statSync(fileA).mtime;
     return timeDiff === 0 ? fileA.length - fileB.length : timeDiff;

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -248,7 +248,7 @@ describe('ProjectBuilder', () => {
             };
 
             const expectedResult = ['app-release.apk', 'app-debug.apk', 'app-release-unsigned.apk',
-                'app-release-arm.apk', 'app-debug-arm.apk', 'app-release-x86.apk', 'app-debug-x86.apk'];
+                'app-release-arm.apk', 'app-release-x86.apk', 'app-debug-x86.apk', 'app-debug-arm.apk'];
 
             const fsSpy = jasmine.createSpyObj('fs', ['statSync']);
             fsSpy.statSync.and.callFake(filename => {


### PR DESCRIPTION
The existing implementation of this function gives a different order depending on the behavior of `Array.prototype.sort()`, which has led to a test failure on Node.js 12 (see apache/cordova-android#767).

This update gives a consistent sort order, regardless of the JavaScript engine implementation, now succeeds on Node.js versions 6, 8, 10, and 12.

Resolves #767

I hope this explanation is clear enough. If anyone can think of a better explanation or has any criticism, feedback would be much appreciated.

For reference:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

/cc @breautek