### PR TITLE
Do not clobber console.log to spy on it

### DIFF
--- a/spec/unit/android_sdk.spec.js
+++ b/spec/unit/android_sdk.spec.js
@@ -45,16 +45,14 @@ describe('android_sdk', () => {
     describe('print_newest_available_sdk_target', () => {
         it('should log the newest version', () => {
             const sortedIds = ['android-27', 'android-24', 'android-23', 'android-19'];
-            const logSpy = jasmine.createSpy('log');
 
             spyOn(android_sdk, 'list_targets').and.returnValue(Promise.resolve(sortedIds));
             spyOn(sortedIds, 'sort');
-
-            android_sdk.__set__({ console: { log: logSpy } });
+            spyOn(console, 'log');
 
             return android_sdk.print_newest_available_sdk_target().then(() => {
                 expect(sortedIds.sort).toHaveBeenCalledWith(android_sdk.__get__('sort_by_largest_numerical_suffix'));
-                expect(logSpy).toHaveBeenCalledWith(sortedIds[0]);
+                expect(console.log).toHaveBeenCalledWith(sortedIds[0]);
             });
         });
     });

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -200,9 +200,7 @@ describe('run', () => {
 
     describe('help', () => {
         it('should print out usage and help', () => {
-            const logSpy = jasmine.createSpy();
-            const errorSpy = jasmine.createSpy();
-            run.__set__({ console: { log: logSpy, error: errorSpy } });
+            spyOn(console, 'log');
 
             // Rewiring the process object in entirety does not work on NodeJS 12.
             // Rewiring members of process however does work
@@ -213,7 +211,7 @@ describe('run', () => {
             run.__set__('process.argv', ['', '']);
 
             run.help();
-            expect(logSpy).toHaveBeenCalledWith(jasmine.stringMatching(/^Usage:/));
+            expect(console.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Usage:/));
         });
     });
 });


### PR DESCRIPTION
Fix for the problem described in https://github.com/apache/cordova-android/pull/778#issuecomment-511229607

Properties that are replaced with `spyOn` are restored after each test. The manually set spies that existed previously clobbered the `console.log` property permanently. This broke the test output with the new reporter.