### PR TITLE
Do not clobber process properties with test mocks

### DIFF
--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -201,14 +201,7 @@ describe('run', () => {
     describe('help', () => {
         it('should print out usage and help', () => {
             spyOn(console, 'log');
-
-            // Rewiring the process object in entirety does not work on NodeJS 12.
-            // Rewiring members of process however does work
-            // https://github.com/apache/cordova-android/issues/768
-            // https://github.com/jhnns/rewire/issues/167
-            run.__set__('process.exit', _ => null);
-            run.__set__('process.cwd', _ => '');
-            run.__set__('process.argv', ['', '']);
+            spyOn(process, 'exit');
 
             run.help();
             expect(console.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Usage:/));


### PR DESCRIPTION
According to the last section _Dot notation_ in the [`rewire` docs](https://www.npmjs.com/package/rewire#caveats), the code from #774 permanently clobbers various properties on the `process` global. This PR fixes #768 without permanently altering `process`.

CC @breautek 