### PR TITLE
Simplify apkSorter using compare-func package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "android-versions": "^1.3.0",
+    "compare-func": "^1.3.2",
     "cordova-common": "^3.1.0",
     "nopt": "^4.0.1",
     "properties-parser": "^0.3.1",

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -252,7 +252,7 @@ describe('ProjectBuilder', () => {
 
             const fsSpy = jasmine.createSpyObj('fs', ['statSync']);
             fsSpy.statSync.and.callFake(filename => {
-                return { mtime: APKs[filename].getTime() };
+                return { mtime: APKs[filename] };
             });
             ProjectBuilder.__set__('fs', fsSpy);
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When reviewing #779 I had a hard time understanding what the behavior of `apkSorter` was. I find that is a common issue with complex sort callbacks in JavaScript.

IMHO it's often makes for way more readable and less repetitive code to have a `sortBy` style approach. That's what I implemented in this PR for `apkSorter`.


### Description
<!-- Describe your changes in detail -->


Implement `apkSorter` in a `sortBy` style using the `compare-func` module.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I used the existing unit tests. One of them had to be fixed, since it stubbed `fs.statSync` incorrectly (`mtime` is a `Date`, not a timestamp)
