### PR TITLE
Stop webview from restarting when activity resizes

### DIFF
--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -37,7 +37,7 @@
                 android:launchMode="singleTop"
                 android:theme="@android:style/Theme.DeviceDefault.NoActionBar"
                 android:windowSoftInputMode="adjustResize"
-                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale">
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode">
             <intent-filter android:label="@string/launcher_name">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change stops the webview from restarting when the activity window resizes while using Android's split-screen feature.

Fixes #799

### Description
This change adds some new attributes to the default list of `configChanges` including:

#### smallestScreenSize

> The current available screen size has changed.
This represents a change in the currently available size, relative to the current aspect ratio, so will change when the user switches between landscape and portrait.

#### screenLayout

> The screen layout has changed — a different display might now be active.

#### uiMode

>The user interface mode has changed — the user has placed the device into a desk or car dock, or the night mode has changed. For more information about the different UI modes, see [UiModeManager](https://developer.android.com/reference/android/app/UiModeManager.html).

All of these will allow the webview to respond to screen changes more gracefully allowing the webview to adapt to the new change without restarting the webview or reloading the page.

### Testing
I've ran `npm test` and tested on a physical Samsung Galaxy Note 9 device running Android 9.

Special thanks to @ttencate for not only opening up an issue, but also providing the solution to the issue.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
