### PR TITLE
Bugfix: Fixes clean command

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -45,25 +45,20 @@ class ProjectBuilder {
 
     getArgs (cmd, opts) {
         let args;
+        let buildCmd = cmd;
         if (opts.packageType === PackageType.BUNDLE) {
-            let buildCmd;
             if (cmd === 'release') {
                 buildCmd = ':app:bundleRelease';
             } else if (cmd === 'debug') {
                 buildCmd = ':app:bundleDebug';
-            } else {
-                buildCmd = cmd;
             }
 
             args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];
         } else {
-            let buildCmd;
             if (cmd === 'release') {
                 buildCmd = 'cdvBuildRelease';
             } else if (cmd === 'debug') {
                 buildCmd = 'cdvBuildDebug';
-            } else {
-                buildCmd = cmd;
             }
 
             args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -51,6 +51,8 @@ class ProjectBuilder {
                 buildCmd = ':app:bundleRelease';
             } else if (cmd === 'debug') {
                 buildCmd = ':app:bundleDebug';
+            } else {
+                buildCmd = cmd;
             }
 
             args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];
@@ -60,6 +62,8 @@ class ProjectBuilder {
                 buildCmd = 'cdvBuildRelease';
             } else if (cmd === 'debug') {
                 buildCmd = 'cdvBuildDebug';
+            } else {
+                buildCmd = cmd;
             }
 
             args = [buildCmd, '-b', path.join(this.root, 'build.gradle')];

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -100,6 +100,20 @@ describe('ProjectBuilder', () => {
 
             expect(args).toContain(`-PcdvBuildArch=${arch}`);
         });
+
+        it('should clean apk', () => {
+            const args = builder.getArgs('clean', {
+                packageType: 'apk'
+            });
+            expect(args[0]).toBe('clean');
+        });
+
+        it('should clean bundle', () => {
+            const args = builder.getArgs('clean', {
+                packageType: 'bundle'
+            });
+            expect(args[0]).toBe('clean');
+        });
     });
 
     describe('runGradleWrapper', () => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the `cordova clean` command, a reprecussion bug from https://github.com/apache/cordova-android/pull/764
Fixes https://github.com/apache/cordova-android/issues/813


### Description
<!-- Describe your changes in detail -->
Due to some code style refactoring, it became possible for the `buildCmd` to stay `undefined`, when it used to default to the incoming parameter `cmd` value. This fixes `ProjectBuilder.getArgs` to fallback to `cmd` value if it doesn't enter in any `if` conditions.



### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` & manually testing.

~Note that at the time of working on this issue, master currently did not pass `npm test`. So I have "all new and existing tests pass" checkbox unchecked and checking that box is blocked by https://github.com/apache/cordova-android/issues/814~

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
