### PR TITLE
Prevent exit fullscreen mode from closing application 

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -517,6 +517,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
         }
         @Override
 
+
         public void onPageStarted(String newUrl) {
             LOG.d(TAG, "onPageDidNavigate(" + newUrl + ")");
             boundKeyCodes.clear();

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -517,7 +517,6 @@ public class CordovaWebViewImpl implements CordovaWebView {
         }
         @Override
 
-
         public void onPageStarted(String newUrl) {
             LOG.d(TAG, "onPageDidNavigate(" + newUrl + ")");
             boundKeyCodes.clear();

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -244,6 +244,22 @@ public class CordovaWebViewImpl implements CordovaWebView {
         }
     }
 
+
+    private static class WrapperView extends FrameLayout {
+
+        private final CordovaWebViewEngine engine;
+
+        public WrapperView(Context context, CordovaWebViewEngine engine) {
+            super(context);
+            this.engine = engine;
+        }
+
+        @Override
+        public boolean dispatchKeyEvent(KeyEvent event) {
+            return engine.getView().dispatchKeyEvent(event);
+        }
+    }
+
     @Override
     @Deprecated
     public void showCustomView(View view, WebChromeClient.CustomViewCallback callback) {
@@ -255,13 +271,16 @@ public class CordovaWebViewImpl implements CordovaWebView {
             return;
         }
 
+        WrapperView wrapperView = new WrapperView(getContext(), engine);
+        wrapperView.addView(view);
+
         // Store the view and its callback for later (to kill it properly)
-        mCustomView = view;
+        mCustomView = wrapperView;
         mCustomViewCallback = callback;
 
         // Add the custom view to its container.
         ViewGroup parent = (ViewGroup) engine.getView().getParent();
-        parent.addView(view, new FrameLayout.LayoutParams(
+        parent.addView(wrapperView, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 Gravity.CENTER));
@@ -497,8 +516,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
         public void clearLoadTimeoutTimer() {
             loadUrlTimeout++;
         }
-
         @Override
+
         public void onPageStarted(String newUrl) {
             LOG.d(TAG, "onPageDidNavigate(" + newUrl + ")");
             boundKeyCodes.clear();

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -515,8 +515,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
         public void clearLoadTimeoutTimer() {
             loadUrlTimeout++;
         }
-        @Override
 
+        @Override
         public void onPageStarted(String newUrl) {
             LOG.d(TAG, "onPageDidNavigate(" + newUrl + ")");
             boundKeyCodes.clear();

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -244,7 +244,6 @@ public class CordovaWebViewImpl implements CordovaWebView {
         }
     }
 
-
     private static class WrapperView extends FrameLayout {
 
         private final CordovaWebViewEngine engine;


### PR DESCRIPTION


### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR proposes a simple, quick, solution to overcome a problem with full screen mode that, when on and back button is pressed, the application is closed instead of exiting full screen. 

For more details see #822 and also https://bugs.chromium.org/p/chromium/issues/detail?id=999212

Fixes #822 

### Description

The custom view provided by WebKit on SystemWebChromeClients's `onShowCustomView` method is wrapped in a custom FrameLayout in order to be able to grab key events and redirect them into `SystemWebView`'s `dispatchKeyEvent`. 

Given that the custom view is the one with the focus, that's the one handling input, for this reason, we can hijack those key events and redirect them so that they end up closing the custom view because, as stated on the linked chromium bug ([#999212](https://bugs.chromium.org/p/chromium/issues/detail?id=999212)), the `onHideCustomView` method from the WebChromeClient subclass is not being executed for recent versions of Chrome, hence, not exiting full screen mode and instead, closing the MainActivity/ Application.


### Testing

Manual tests on a Pixel (Android 7.1.2) and Pixel 2 XL (Android 10) with Chrome updated to the most recent version.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
