### PR TITLE
chore: bump dependencies for release 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
-    "android-versions": "^1.3.0",
+    "android-versions": "^1.4.0",
     "compare-func": "^1.3.2",
-    "cordova-common": "^3.1.0",
+    "cordova-common": "^3.2.0",
     "nopt": "^4.0.1",
     "properties-parser": "^0.3.1",
-    "q": "^1.4.1",
+    "q": "^1.5.1",
     "shelljs": "^0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation and Context

Update dependencies (minor bump) for Cordova Android minor release 8.1.0

### Description

* Bump Dependency
  * `android-versions@^1.3.0` to `android-versions@^1.4.0`
  * `cordova-common@^3.1.0` to `cordova-common@^3.2.0`
  * `q@^1.4.1` to `q@^1.5.1`

`shelljs` was intentionally left at `^0.5.3`. Bumping caused test failures and would require additional investigation. I was able to fix for Travis CI but there were pathing separator issue within AppVeyor.

### Testing

* `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass