### PR TITLE
Ignore auto-generated eclipse buildship files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ node_modules/
 coverage/
 .nyc_output/
 package-lock.json
+# Eclipse Buildship files
+**/.project

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ coverage/
 .nyc_output/
 package-lock.json
 # Eclipse Buildship files
-**/.project
+.project


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
None


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Eclipse buildship `.project` files are being added to several directories automatically from my code editor (VS Code) when working on `cordova-android` tasks. I think it makes sense for these files to be git ignored.


### Description
<!-- Describe your changes in detail -->
Added `**/.project` line in `.gitignore`


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
