### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - TERM=dumb # Keep gradle from crapping all over the log
   matrix:
-    - nodejs_version=6
-    - nodejs_version=8
     - nodejs_version=10
     - nodejs_version=12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ environment:
     SDK_TOOLS_URL: https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip
 
     matrix:
-        - nodejs_version: 6
-        - nodejs_version: 8
         - nodejs_version: 10
         - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rewire": "^4.0.1"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "engineStrict": true,
   "nyc": {


### PR DESCRIPTION
### Motivation and Context

* Follow inline with Node Support
* Prepare for next major
* https://github.com/apache/cordova/issues/79

### Description

* Removes Node 6 and 8 from CI Testing Services
* Bump `engines.node` to `>=10` in `package.json`

### Testing

- `npm t`
- CI services continue to pass

### Checklist

- [x] I've run the tests to see all new and existing tests pass
