### PR TITLE
Increased default target sdk to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ dist: trusty
 
 env:
   global:
-    - ANDROID_API_LEVEL=28
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
+    - ANDROID_API_LEVEL=29
+    - ANDROID_BUILD_TOOLS_VERSION=29.0.2
     - TERM=dumb # Keep gradle from crapping all over the log
   matrix:
     - nodejs_version=6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
     - set PATH=%PATH%;"%ANDROID_HOME%\tools\bin"
 
     - yes 2> nul | sdkmanager --licenses > nul
-    - sdkmanager "build-tools;28.0.3"
+    - sdkmanager "build-tools;29.0.2"
 
     - choco install gradle --version 3.4.1
 

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -40,10 +40,10 @@ allprojects {
 
     //This replaces project.properties w.r.t. build settings
     project.ext {
-      defaultBuildToolsVersion="28.0.3" //String
+      defaultBuildToolsVersion="29.0.2" //String
       defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      defaultTargetSdkVersion=28 //Integer - We ALWAYS target the latest by default
-      defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
+      defaultTargetSdkVersion=29 //Integer - We ALWAYS target the latest by default
+      defaultCompileSdkVersion=29 //Integer - We ALWAYS compile with the latest by default
     }
 }
 

--- a/framework/project.properties
+++ b/framework/project.properties
@@ -5,7 +5,7 @@
 split.density=false
 
 # Project target.
-target=android-28
+target=android-29
 apk-configurations=
 renderscript.opt.level=O0
 android.library=true

--- a/spec/fixtures/android_studio_project/app/build.gradle
+++ b/spec/fixtures/android_studio_project/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "com.example.anis.myapplication"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/test/app/build.gradle
+++ b/test/app/build.gradle
@@ -19,13 +19,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "org.apache.cordova.unittests"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Increases the default target/compile SDK version to 29, up from API level 28.

Fixes #830 

### Description
<!-- Describe your changes in detail -->
Changed build tools to version 29.0.2
changed target SDK to 29
Changed compile SDK to 29
Changed the tests to use version 29.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
