### PR TITLE
Fix: Cordova requirements consider the android-targetSdkVersion

### DIFF
--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -26,7 +26,7 @@ var path = require('path');
 var events = require('cordova-common').events;
 
 // This should match /bin/templates/project/build.gradle
-const DEFAULT_TARGET_API = 28;
+const DEFAULT_TARGET_API = 29;
 
 describe('check_reqs', function () {
     var original_env;
@@ -258,7 +258,7 @@ describe('check_reqs', function () {
 
             expect(getPreferenceSpy).toHaveBeenCalledWith('android-targetSdkVersion', 'android');
             expect(target).toBe('android-' + DEFAULT_TARGET_API);
-            expect(events.emit).toHaveBeenCalledWith('warn', 'android-targetSdkVersion must be greater than or equal to ' + DEFAULT_TARGET_API + '.');
+            expect(events.emit).toHaveBeenCalledWith('warn', 'android-targetSdkVersion should be greater than or equal to ' + DEFAULT_TARGET_API + '.');
         });
     });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes `cordova requirements android` to consider the desired target SDK as defined by the `android-targetSdkVersion` preference in the project's `config.xml`.

Fixes #846 

Currently, while `cordova-android` *can* use a higher target... it fails the `cordova requirements android` check if the hard-coded defined target is not installed on the system.

### Description
<!-- Describe your changes in detail -->
I've changed `check_reqs.js` `get_target` to do the following:

1. Get the default/minimum required target sdk, as defined by `cordova-android`
2. Check if `config.xml` exists in the repo.
3. If so, then attempt to read the `android-targetSdkVersion` preference.
3. 1. If read... check for validity
3. 1. 1. If valid, and is >= the default target sdk, then change the target to the preference value
3. 1. 2. If not valid, then fallback to default.
3. 1. 3. If not valid because preference target is < default target, then produce a warning.
3. 2. if `config.xml`, then fall back to default.

Naturally, if `get_target` returns 29, then the user must have the android 29 SDK installed, otherwise `check_android_target` will fail, as expected.

Unit tests were added to thoroughly test `get_target`.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`, with newly added unit tests.
Also tested the code in a real project and manually observing the results of `cordova requirements android`.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
