### PR TITLE
Don't filter gradle's stderr anymore

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -250,25 +250,8 @@ class ProjectBuilder {
         var wrapper = path.join(this.root, 'gradlew');
         var args = this.getArgs(opts.buildType === 'debug' ? 'debug' : 'release', opts);
 
-        return spawn(wrapper, args, { stdio: 'pipe' })
-            .progress(function (stdio) {
-                if (stdio.stderr) {
-                    /*
-                    * Workaround for the issue with Java printing some unwanted information to
-                    * stderr instead of stdout.
-                    * This function suppresses 'Picked up _JAVA_OPTIONS' message from being
-                    * printed to stderr. See https://issues.apache.org/jira/browse/CB-9971 for
-                    * explanation.
-                    */
-                    var suppressThisLine = /^Picked up _JAVA_OPTIONS: /i.test(stdio.stderr.toString());
-                    if (suppressThisLine) {
-                        return;
-                    }
-                    process.stderr.write(stdio.stderr);
-                } else {
-                    process.stdout.write(stdio.stdout);
-                }
-            }).catch(function (error) {
+        return spawn(wrapper, args, { stdio: 'inherit' })
+            .catch(function (error) {
                 if (error.toString().indexOf('failed to find target with hash string') >= 0) {
                     return check_reqs.check_android_target(error).then(function () {
                         // If due to some odd reason - check_android_target succeeds


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When building the project by running `gradlew`, we filter its output on `stderr` to omit a specific diagnostic message. This complicated refactorings in the past and also affects upcoming refactorings regarding `Q` and `superspawn`.

The [reason this code exists](https://issues.apache.org/jira/browse/CB-9971) is a weak one IMHO. The Visual Studio integration deemed the build to have failed if anything has been output on `stderr`. Thus the aforementioned diagnostic message on `stderr` caused successful builds to count as failed ones.

IMHO, the current behavior should be removed for various reasons:
- Diagnostics on `stderr` are not uncommon, so the success of the command should be determined from the returned `Promise` or the process' exit code respectively
- Unclear if code works correctly & reliably: the code is written as if only complete lines were passed into `progress`. But [`superspawn` calls `notify` for every `chunk` it receives in a `data` event on `stderr`](https://github.com/apache/cordova-common/blob/8bd95b4c11b3c0d9b42e6607d51778077da58746/src/superspawn.js#L111-L115). AFAIK it is not guaranteed that these chunks will be individual and complete lines.
- Unclear if code is up-to-date
- Code is untested
- Complicates refactorings


### Description
<!-- Describe your changes in detail -->
This PR removes all output filtering in `ProjectBuilder.prototype.build`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Automated tests still pass.

