### PR TITLE
chore: replace superspawn & child_process with execa

### DIFF
--- a/bin/templates/cordova/lib/Adb.js
+++ b/bin/templates/cordova/lib/Adb.js
@@ -19,8 +19,8 @@
 
 var Q = require('q');
 var os = require('os');
+var execa = require('execa');
 var events = require('cordova-common').events;
-var spawn = require('cordova-common').superspawn.spawn;
 var CordovaError = require('cordova-common').CordovaError;
 
 var Adb = {};
@@ -44,7 +44,7 @@ function isEmulator (line) {
  *   devices/emulators
  */
 Adb.devices = function (opts) {
-    return spawn('adb', ['devices'], { cwd: os.tmpdir() }).then(function (output) {
+    return execa('adb', ['devices'], { cwd: os.tmpdir() }).then(({ stdout: output }) => {
         return output.split('\n').filter(function (line) {
             // Filter out either real devices or emulators, depending on options
             return (line && opts && opts.emulators) ? isEmulator(line) : isDevice(line);
@@ -58,7 +58,7 @@ Adb.install = function (target, packagePath, opts) {
     events.emit('verbose', 'Installing apk ' + packagePath + ' on target ' + target + '...');
     var args = ['-s', target, 'install'];
     if (opts && opts.replace) args.push('-r');
-    return spawn('adb', args.concat(packagePath), { cwd: os.tmpdir() }).then(function (output) {
+    return execa('adb', args.concat(packagePath), { cwd: os.tmpdir() }).then(({ stdout: output }) => {
         // 'adb install' seems to always returns no error, even if installation fails
         // so we catching output to detect installation failure
         if (output.match(/Failure/)) {
@@ -77,24 +77,24 @@ Adb.install = function (target, packagePath, opts) {
 
 Adb.uninstall = function (target, packageId) {
     events.emit('verbose', 'Uninstalling package ' + packageId + ' from target ' + target + '...');
-    return spawn('adb', ['-s', target, 'uninstall', packageId], { cwd: os.tmpdir() });
+    return execa('adb', ['-s', target, 'uninstall', packageId], { cwd: os.tmpdir() }).then(({ stdout }) => stdout);
 };
 
 Adb.shell = function (target, shellCommand) {
     events.emit('verbose', 'Running adb shell command "' + shellCommand + '" on target ' + target + '...');
     var args = ['-s', target, 'shell'];
     shellCommand = shellCommand.split(/\s+/);
-    return spawn('adb', args.concat(shellCommand), { cwd: os.tmpdir() }).catch(function (output) {
+    return execa('adb', args.concat(shellCommand), { cwd: os.tmpdir() }).catch((error) => {
         return Q.reject(new CordovaError('Failed to execute shell command "' +
-            shellCommand + '"" on device: ' + output));
+            shellCommand + '"" on device: ' + error));
     });
 };
 
 Adb.start = function (target, activityName) {
     events.emit('verbose', 'Starting application "' + activityName + '" on target ' + target + '...');
-    return Adb.shell(target, 'am start -W -a android.intent.action.MAIN -n' + activityName).catch(function (output) {
+    return Adb.shell(target, 'am start -W -a android.intent.action.MAIN -n' + activityName).catch((error) => {
         return Q.reject(new CordovaError('Failed to start application "' +
-            activityName + '"" on device: ' + output));
+            activityName + '"" on device: ' + error));
     });
 };
 

--- a/bin/templates/cordova/lib/android_sdk.js
+++ b/bin/templates/cordova/lib/android_sdk.js
@@ -17,7 +17,7 @@
        under the License.
 */
 
-var superspawn = require('cordova-common').superspawn;
+const execa = require('execa');
 
 var suffix_number_regex = /(\d+)$/;
 // Used for sorting Android targets, example strings to sort:
@@ -77,11 +77,11 @@ function parse_targets (output) {
 }
 
 module.exports.list_targets_with_android = function () {
-    return superspawn.spawn('android', ['list', 'target']).then(parse_targets);
+    return execa('android', ['list', 'target']).then(result => parse_targets(result.stdout));
 };
 
 module.exports.list_targets_with_avdmanager = function () {
-    return superspawn.spawn('avdmanager', ['list', 'target']).then(parse_targets);
+    return execa('avdmanager', ['list', 'target']).then(result => parse_targets(result.stdout));
 };
 
 module.exports.list_targets = function () {

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -28,7 +28,7 @@ var Adb = require('./Adb');
 
 var builders = require('./builders/builders');
 var events = require('cordova-common').events;
-var spawn = require('cordova-common').superspawn.spawn;
+const execa = require('execa');
 var CordovaError = require('cordova-common').CordovaError;
 var PackageType = require('./PackageType');
 
@@ -212,11 +212,11 @@ module.exports.detectArchitecture = function (target) {
             // Could probably find a x-platform version of killall, but I'm not actually
             // sure that this scenario even happens on non-OSX machines.
             events.emit('verbose', 'adb timed out while detecting device/emulator architecture. Killing adb and trying again.');
-            return spawn('killall', ['adb']).then(function () {
+            return execa('killall', ['adb']).then(function () {
                 return helper().then(null, function () {
                     // The double kill is sadly often necessary, at least on mac.
                     events.emit('warn', 'adb timed out a second time while detecting device/emulator architecture. Killing adb and trying again.');
-                    return spawn('killall', ['adb']).then(function () {
+                    return execa('killall', ['adb']).then(function () {
                         return helper().then(null, function () {
                             return Q.reject(new CordovaError('adb timed out a third time while detecting device/emulator architecture. Try unplugging & replugging the device.'));
                         });

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -21,7 +21,6 @@
 
 const execa = require('execa');
 var shelljs = require('shelljs');
-var child_process = require('child_process');
 var Q = require('q');
 var path = require('path');
 var fs = require('fs');
@@ -89,7 +88,7 @@ module.exports.get_gradle_wrapper = function () {
     // OK, This hack only works on Windows, not on Mac OS or Linux.  We will be deleting this eventually!
     if (module.exports.isWindows()) {
 
-        var result = child_process.spawnSync(path.join(__dirname, 'getASPath.bat'));
+        var result = execa.sync(path.join(__dirname, 'getASPath.bat'));
         // console.log('result.stdout =' + result.stdout.toString());
         // console.log('result.stderr =' + result.stderr.toString());
 
@@ -194,11 +193,9 @@ module.exports.check_java = function () {
             }
         }
     }).then(function () {
-        return Q.denodeify(child_process.exec)('javac -version')
-            .then(outputs => {
-                // outputs contains two entries: stdout and stderr
+        return execa('javac', ['-version'], { all: true })
+            .then(({ all: output }) => {
                 // Java <= 8 writes version info to stderr, Java >= 9 to stdout
-                const output = outputs.join('').trim();
                 const match = /javac\s+([\d.]+)/i.exec(output);
                 return match && match[1];
             }, () => {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -19,6 +19,7 @@
        under the License.
 */
 
+const execa = require('execa');
 var shelljs = require('shelljs');
 var child_process = require('child_process');
 var Q = require('q');
@@ -28,7 +29,6 @@ var os = require('os');
 var REPO_ROOT = path.join(__dirname, '..', '..', '..', '..');
 var PROJECT_ROOT = path.join(__dirname, '..', '..');
 var CordovaError = require('cordova-common').CordovaError;
-var superspawn = require('cordova-common').superspawn;
 var android_sdk = require('./android_sdk');
 
 function forgivingWhichSync (cmd) {
@@ -71,7 +71,7 @@ module.exports.get_target = function () {
 
 // Returns a promise. Called only by build and clean commands.
 module.exports.check_ant = function () {
-    return superspawn.spawn('ant', ['-version']).then(function (output) {
+    return execa('ant', ['-version']).then(({ stdout: output }) => {
         // Parse Ant version from command output
         return /version ((?:\d+\.)+(?:\d+))/i.exec(output)[1];
     }).catch(function (err) {
@@ -157,8 +157,8 @@ module.exports.check_java = function () {
                 var find_java = '/usr/libexec/java_home';
                 var default_java_error_msg = 'Failed to find \'JAVA_HOME\' environment variable. Try setting it manually.';
                 if (fs.existsSync(find_java)) {
-                    return superspawn.spawn(find_java).then(function (stdout) {
-                        process.env['JAVA_HOME'] = stdout.trim();
+                    return execa(find_java).then(({ stdout }) => {
+                        process.env['JAVA_HOME'] = stdout;
                     }).catch(function (err) {
                         if (err) {
                             throw new CordovaError(default_java_error_msg);

--- a/bin/templates/cordova/lib/device.js
+++ b/bin/templates/cordova/lib/device.js
@@ -19,11 +19,11 @@
        under the License.
 */
 
+const execa = require('execa');
 var build = require('./build');
 var path = require('path');
 var Adb = require('./Adb');
 var AndroidManifest = require('./AndroidManifest');
-var spawn = require('cordova-common').superspawn.spawn;
 var CordovaError = require('cordova-common').CordovaError;
 var events = require('cordova-common').events;
 
@@ -37,7 +37,7 @@ module.exports.list = function (lookHarder) {
             // adb kill-server doesn't seem to do the trick.
             // Could probably find a x-platform version of killall, but I'm not actually
             // sure that this scenario even happens on non-OSX machines.
-            return spawn('killall', ['adb']).then(function () {
+            return execa('killall', ['adb']).then(function () {
                 events.emit('verbose', 'Restarting adb to see if more devices are detected.');
                 return Adb.devices();
             }, function () {

--- a/bin/templates/cordova/lib/log.js
+++ b/bin/templates/cordova/lib/log.js
@@ -21,8 +21,7 @@
 
 var path = require('path');
 var os = require('os');
-var Q = require('q');
-var child_process = require('child_process');
+var execa = require('execa');
 var ROOT = path.join(__dirname, '..', '..');
 
 /*
@@ -30,8 +29,7 @@ var ROOT = path.join(__dirname, '..', '..');
  * Returns a promise.
  */
 module.exports.run = function () {
-    var d = Q.defer();
-    var adb = child_process.spawn('adb', ['logcat'], { cwd: os.tmpdir() });
+    var adb = execa('adb', ['logcat'], { cwd: os.tmpdir(), stderr: 'inherit' });
 
     adb.stdout.on('data', function (data) {
         var lines = data ? data.toString().split('\n') : [];
@@ -39,14 +37,7 @@ module.exports.run = function () {
         console.log(out.join('\n'));
     });
 
-    adb.stderr.on('data', console.error);
-    adb.on('close', function (code) {
-        if (code > 0) {
-            d.reject('Failed to run logcat command.');
-        } else d.resolve();
-    });
-
-    return d.promise;
+    return adb;
 };
 
 module.exports.help = function () {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "android-versions": "^1.4.0",
     "compare-func": "^1.3.2",
     "cordova-common": "^3.2.0",
+    "execa": "^3.2.0",
     "nopt": "^4.0.1",
     "properties-parser": "^0.3.1",
     "q": "^1.5.1",

--- a/spec/e2e/plugin.spec.js
+++ b/spec/e2e/plugin.spec.js
@@ -21,7 +21,8 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const shell = require('shelljs');
-const { PluginInfoProvider, superspawn } = require('cordova-common');
+const execa = require('execa');
+const { PluginInfoProvider } = require('cordova-common');
 
 const createBin = path.join(__dirname, '../../bin/create');
 const fakePluginPath = path.join(__dirname, 'fixtures/cordova-plugin-fake');
@@ -44,7 +45,7 @@ describe('plugin add', function () {
         const pluginInfo = new PluginInfoProvider().get(fakePluginPath);
 
         return Promise.resolve()
-            .then(() => superspawn.spawn(createBin, [projectPath, projectid, projectname]))
+            .then(() => execa(createBin, [projectPath, projectid, projectname]))
             .then(() => {
                 const Api = require(path.join(projectPath, 'cordova/Api.js'));
                 return new Api('android', projectPath).addPlugin(pluginInfo);

--- a/spec/unit/android_sdk.spec.js
+++ b/spec/unit/android_sdk.spec.js
@@ -17,16 +17,18 @@
     under the License.
 */
 
-const superspawn = require('cordova-common').superspawn;
 const fs = require('fs');
 const path = require('path');
 const rewire = require('rewire');
 
 describe('android_sdk', () => {
     let android_sdk;
+    let execaSpy;
 
     beforeEach(() => {
         android_sdk = rewire('../../bin/templates/cordova/lib/android_sdk');
+        execaSpy = jasmine.createSpy('execa');
+        android_sdk.__set__('execa', execaSpy);
     });
 
     describe('sort_by_largest_numerical_suffix', () => {
@@ -59,14 +61,14 @@ describe('android_sdk', () => {
 
     describe('list_targets_with_android', () => {
         it('should invoke `android` with the `list target` command and _not_ the `list targets` command, as the plural form is not supported in some Android SDK Tools versions', () => {
-            spyOn(superspawn, 'spawn').and.returnValue(new Promise(() => {}, () => {}));
+            execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
             android_sdk.list_targets_with_android();
-            expect(superspawn.spawn).toHaveBeenCalledWith('android', ['list', 'target']);
+            expect(execaSpy).toHaveBeenCalledWith('android', ['list', 'target']);
         });
 
         it('should parse and return results from `android list targets` command', () => {
             const testTargets = fs.readFileSync(path.join('spec', 'fixtures', 'sdk25.2-android_list_targets.txt'), 'utf-8');
-            spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(testTargets));
+            execaSpy.and.returnValue(Promise.resolve({ stdout: testTargets }));
 
             return android_sdk.list_targets_with_android().then(list => {
                 [ 'Google Inc.:Google APIs:23',
@@ -87,7 +89,7 @@ describe('android_sdk', () => {
     describe('list_targets_with_avdmanager', () => {
         it('should parse and return results from `avdmanager list target` command', () => {
             const testTargets = fs.readFileSync(path.join('spec', 'fixtures', 'sdk25.3-avdmanager_list_target.txt'), 'utf-8');
-            spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(testTargets));
+            execaSpy.and.returnValue(Promise.resolve({ stdout: testTargets }));
 
             return android_sdk.list_targets_with_avdmanager().then(list => {
                 expect(list).toContain('android-25');

--- a/spec/unit/device.spec.js
+++ b/spec/unit/device.spec.js
@@ -42,12 +42,12 @@ describe('device', () => {
         });
 
         it('should kill adb and try to get devices again if none are found the first time, and `lookHarder` is set', () => {
-            const spawnSpy = jasmine.createSpy('spawn').and.returnValue(Promise.resolve());
-            device.__set__('spawn', spawnSpy);
+            const execaSpy = jasmine.createSpy('execa').and.returnValue(Promise.resolve());
+            device.__set__('execa', execaSpy);
             AdbSpy.devices.and.returnValues(Promise.resolve([]), Promise.resolve(DEVICE_LIST));
 
             return device.list(true).then(list => {
-                expect(spawnSpy).toHaveBeenCalledWith('killall', ['adb']);
+                expect(execaSpy).toHaveBeenCalledWith('killall', ['adb']);
                 expect(list).toBe(DEVICE_LIST);
                 expect(AdbSpy.devices).toHaveBeenCalledTimes(2);
             });
@@ -55,12 +55,12 @@ describe('device', () => {
 
         it('should return the empty list if killing adb fails', () => {
             const emptyDevices = [];
-            const spawnSpy = jasmine.createSpy('spawn').and.returnValue(Promise.reject());
-            device.__set__('spawn', spawnSpy);
+            const execaSpy = jasmine.createSpy('execa').and.returnValue(Promise.reject());
+            device.__set__('execa', execaSpy);
             AdbSpy.devices.and.returnValues(Promise.resolve(emptyDevices));
 
             return device.list(true).then(list => {
-                expect(spawnSpy).toHaveBeenCalledWith('killall', ['adb']);
+                expect(execaSpy).toHaveBeenCalledWith('killall', ['adb']);
                 expect(list).toBe(emptyDevices);
                 expect(AdbSpy.devices).toHaveBeenCalledTimes(1);
             });

--- a/spec/unit/emulator.spec.js
+++ b/spec/unit/emulator.spec.js
@@ -24,7 +24,6 @@ const shelljs = require('shelljs');
 
 const CordovaError = require('cordova-common').CordovaError;
 const check_reqs = require('../../bin/templates/cordova/lib/check_reqs');
-const superspawn = require('cordova-common').superspawn;
 
 describe('emulator', () => {
     const EMULATOR_LIST = ['emulator-5555', 'emulator-5556', 'emulator-5557'];
@@ -37,7 +36,9 @@ describe('emulator', () => {
     describe('list_images_using_avdmanager', () => {
         it('should properly parse details of SDK Tools 25.3.1 `avdmanager` output', () => {
             const avdList = fs.readFileSync(path.join('spec', 'fixtures', 'sdk25.3-avdmanager_list_avd.txt'), 'utf-8');
-            spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(avdList));
+
+            let execaSpy = jasmine.createSpy('execa').and.returnValue(Promise.resolve({ stdout: avdList }));
+            emu.__set__('execa', execaSpy);
 
             return emu.list_images_using_avdmanager().then(list => {
                 expect(list).toBeDefined();
@@ -51,14 +52,18 @@ describe('emulator', () => {
 
     describe('list_images_using_android', () => {
         it('should invoke `android` with the `list avd` command and _not_ the `list avds` command, as the plural form is not supported in some Android SDK Tools versions', () => {
-            spyOn(superspawn, 'spawn').and.returnValue(new Promise(() => {}, () => {}));
+            let execaSpy = jasmine.createSpy('execa').and.returnValue(Promise.resolve({ stdout: '' }));
+            emu.__set__('execa', execaSpy);
+
             emu.list_images_using_android();
-            expect(superspawn.spawn).toHaveBeenCalledWith('android', ['list', 'avd']);
+            expect(execaSpy).toHaveBeenCalledWith('android', ['list', 'avd']);
         });
 
         it('should properly parse details of SDK Tools pre-25.3.1 `android list avd` output', () => {
             const avdList = fs.readFileSync(path.join('spec', 'fixtures', 'sdk25.2-android_list_avd.txt'), 'utf-8');
-            spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(avdList));
+
+            let execaSpy = jasmine.createSpy('execa').and.returnValue(Promise.resolve({ stdout: avdList }));
+            emu.__set__('execa', execaSpy);
 
             return emu.list_images_using_android().then(list => {
                 expect(list).toBeDefined();

--- a/test/run_java_unit_tests.js
+++ b/test/run_java_unit_tests.js
@@ -21,7 +21,7 @@
 
 var Q = require('q');
 var path = require('path');
-var superspawn = require('cordova-common').superspawn;
+var execa = require('execa');
 var ProjectBuilder = require('../bin/templates/cordova/lib/builders/ProjectBuilder');
 
 Q.resolve()
@@ -42,7 +42,7 @@ process.on('unhandledRejection', err => {
 
 function gradlew () {
     const wrapperPath = path.join(__dirname, 'gradlew');
-    return superspawn.spawn(wrapperPath, Array.from(arguments), {
+    return execa(wrapperPath, Array.from(arguments), {
         stdio: 'inherit',
         cwd: __dirname
     });


### PR DESCRIPTION
### Motivation and Context

https://github.com/apache/cordova/issues/16

Includes commit from #860 (will rebase ASAP). Depends on #832 and #861.

### Description

Replace `superspawn` & `child_process` usage with `execa`.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
