### PR TITLE
feat: add google services support

### DIFF
--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.google.gms:google-services:3.2.1'
     }
 }
 
@@ -355,4 +356,8 @@ for (def func : cdvPluginPostBuildExtras) {
 //     ext.postBuildExtras = { ... code here ... }
 if (hasProperty('postBuildExtras')) {
     postBuildExtras()
+}
+
+if (cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
+    apply plugin: 'com.google.gms.google-services'
 }

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -32,8 +32,22 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.3.0'
 
         if(cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
-            println 'Adding classpath "com.google.gms:google-services:4.2.0"'
-            classpath 'com.google.gms:google-services:4.2.0'
+            String defaultGoogleServiceVersion = '4.2.0'
+
+            /**
+             * Fetches the user's defined Google Services Plugin Version from config.xml.
+             * If the version is not set or invalid, it will default to the ${defaultGoogleServiceVersion}
+             */
+            String googleServicesVersion = cdvHelpers.getConfigPreference('GoogleServicesPluginVersion', defaultGoogleServiceVersion)
+            if(!cdvHelpers.isVersionValid(googleServicesVersion)) {
+                println("The defined Google Services plugin version (${googleServicesVersion}) does not appear to be a valid version. Falling back to version: ${defaultGoogleServiceVersion}.")
+                googleServicesVersion = defaultGoogleServiceVersion
+            }
+
+            // Create the Google Services classpath and set it.
+            String googleServicesClassPath = "com.google.gms:google-services:${googleServicesVersion}"
+            println "Adding classpath: ${googleServicesClassPath}"
+            classpath googleServicesClassPath
         }
     }
 }

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -31,14 +31,14 @@ buildscript {
 
         classpath 'com.android.tools.build:gradle:3.3.0'
 
-        if(cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
+        if(cdvHelpers.getConfigPreference('GoogleServicesEnable', 'false').toBoolean()) {
             String defaultGoogleServiceVersion = '4.2.0'
 
             /**
              * Fetches the user's defined Google Services Plugin Version from config.xml.
              * If the version is not set or invalid, it will default to the ${defaultGoogleServiceVersion}
              */
-            String googleServicesVersion = cdvHelpers.getConfigPreference('GoogleServicesPluginVersion', defaultGoogleServiceVersion)
+            String googleServicesVersion = cdvHelpers.getConfigPreference('GoogleServicesVersion', defaultGoogleServiceVersion)
             if(!cdvHelpers.isVersionValid(googleServicesVersion)) {
                 println("The defined Google Services plugin version (${googleServicesVersion}) does not appear to be a valid version. Falling back to version: ${defaultGoogleServiceVersion}.")
                 googleServicesVersion = defaultGoogleServiceVersion
@@ -378,6 +378,6 @@ if (hasProperty('postBuildExtras')) {
     postBuildExtras()
 }
 
-if (cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
+if (cdvHelpers.getConfigPreference('GoogleServicesEnable', 'false').toBoolean()) {
     apply plugin: 'com.google.gms.google-services'
 }

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -31,7 +31,7 @@ buildscript {
 
         classpath 'com.android.tools.build:gradle:3.3.0'
 
-        if(cdvHelpers.getConfigPreference('GoogleServicesEnable', 'false').toBoolean()) {
+        if(cdvHelpers.getConfigPreference('GoogleServicesEnabled', 'false').toBoolean()) {
             String defaultGoogleServiceVersion = '4.2.0'
 
             /**
@@ -378,6 +378,6 @@ if (hasProperty('postBuildExtras')) {
     postBuildExtras()
 }
 
-if (cdvHelpers.getConfigPreference('GoogleServicesEnable', 'false').toBoolean()) {
+if (cdvHelpers.getConfigPreference('GoogleServicesEnabled', 'false').toBoolean()) {
     apply plugin: 'com.google.gms.google-services'
 }

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -27,8 +27,15 @@ buildscript {
     }
 
     dependencies {
+        apply from: '../CordovaLib/cordova.gradle'
+
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:3.2.1'
+
+        if(cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
+            println 'Adding classpath "com.google.gms:google-services:3.2.1"'
+
+            classpath 'com.google.gms:google-services:3.2.1'
+        }
     }
 }
 

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -32,9 +32,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.3.0'
 
         if(cdvHelpers.getConfigPreference('EnableGoogleServicesPlugin', 'false').toBoolean()) {
-            println 'Adding classpath "com.google.gms:google-services:3.2.1"'
-
-            classpath 'com.google.gms:google-services:3.2.1'
+            println 'Adding classpath "com.google.gms:google-services:4.2.0"'
+            classpath 'com.google.gms:google-services:4.2.0'
         }
     }
 }

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -48,6 +48,10 @@ Version[] getAvailableBuildTools() {
         .sort { a, b -> a.isHigherThan(b) ? -1 : 1 }
 }
 
+Boolean isVersionValid(version) {
+    return !(new Version(version)).isEqual('0.0.0')
+}
+
 String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
     def availableBuildToolsVersions
     try {


### PR DESCRIPTION
### Motivation and Context

To finish off the change requests and close out PR #438 

closes: #438

### Description

What this PR does:
1. Cherry-picks commit changes from #438
2. Wraps the Google Services classpath with the `GoogleServicesEnabled` flag.
3.  Introduces the `GoogleServicesVersion` preference variable that allows users to override the default to use older or newer Google Services classpath. (Defaults to: `4.2.0`)

### Testing

- `npm t`
- `cordova platform add`
- `cordova build android`
  - build with no `preference` attributes.
  - build with preference `GoogleServicesEnabled` set to `true`
  - build with preference `GoogleServicesEnabled` set to `true` and `GoogleServicesVersion` set to `4.1.0`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
