### PR TITLE
(android) Additional WebView preferences: 'UseWideViewport', 'SaveFormData', 'SavePassword'

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -148,6 +148,8 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         webView.setVerticalScrollBarEnabled(false);
         // Enable JavaScript
         final WebSettings settings = webView.getSettings();
+        settings.setUseWideViewPort(preferences.getBoolean("UseWideViewPort", false));
+
         settings.setJavaScriptEnabled(true);
         settings.setJavaScriptCanOpenWindowsAutomatically(true);
         settings.setLayoutAlgorithm(LayoutAlgorithm.NORMAL);
@@ -156,8 +158,8 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         LOG.d(TAG, "CordovaWebView is running on device made by: " + manufacturer);
 
         //We don't save any form data in the application
-        settings.setSaveFormData(false);
-        settings.setSavePassword(false);
+        settings.setSaveFormData(preferences.getBoolean("SaveFormData", false));
+        settings.setSavePassword(preferences.getBoolean("SavePassword", false));
 
         // Jellybean rightfully tried to lock this down. Too bad they didn't give us a whitelist
         // while we do this


### PR DESCRIPTION
### Platforms affected
android


### Motivation and Context
Now its not possible to set some useful android WebView settings such UseWideViewport, that give a developer define meta viewport tag in cordova apps. Also 'SaveFormData' & 'SavePassword' give more browser like user experience.



### Description
Values for WebView settings are loads from config.xml preferences: 
- UseWideViewport 
- SaveFormData 
- SavePassword

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
