### PR TITLE
fix (adb): shell to return expected stdout

### DIFF
--- a/bin/templates/cordova/lib/Adb.js
+++ b/bin/templates/cordova/lib/Adb.js
@@ -83,10 +83,9 @@ Adb.shell = function (target, shellCommand) {
     events.emit('verbose', 'Running adb shell command "' + shellCommand + '" on target ' + target + '...');
     var args = ['-s', target, 'shell'];
     shellCommand = shellCommand.split(/\s+/);
-    return execa('adb', args.concat(shellCommand), { cwd: os.tmpdir() }).catch((error) => {
-        return Promise.reject(new CordovaError('Failed to execute shell command "' +
-            shellCommand + '"" on device: ' + error));
-    });
+    return execa('adb', args.concat(shellCommand), { cwd: os.tmpdir() })
+        .then(({ stdout }) => stdout)
+        .catch(error => Promise.reject(new CordovaError(`Failed to execute shell command "${shellCommand}" on device: ${error}`)));
 };
 
 Adb.start = function (target, activityName) {


### PR DESCRIPTION
### Motivation and Context

Fix error when executing `cordova run android` to launch on emulator.

### Description

When executing `cordova run android` to launch the app on an emulator, the Adb shell is not returning the expected stdout and results in an error `output.match is not a function`.

### Testing

- `npm t`
- `cordova run android`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
