### PR TITLE
chore: remove appveyor residual

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -3,7 +3,6 @@ bin
 gen
 proguard-project.txt
 spec
-appveyor.yml
 framework/build
 ic_launcher.png
 build

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 #
 -->
 
-[![Build status](https://ci.appveyor.com/api/projects/status/github/apache/cordova-android?branch=master)](https://ci.appveyor.com/project/Humbedooh/cordova-android)
 [![Build Status](https://travis-ci.org/apache/cordova-android.svg?branch=master)](https://travis-ci.org/apache/cordova-android)
 [![codecov.io](https://codecov.io/github/apache/cordova-android/coverage.svg?branch=master)](https://codecov.io/github/apache/cordova-android?branch=master)
 


### PR DESCRIPTION
### Motivation and Context

Remove residual references of AppVeyor

### Description

Removed from RAT and README

### Testing

No Testing Required