### PR TITLE
Bump minSdkVersion to 22 and drop pre-Lollipop specific code

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -41,7 +41,7 @@ allprojects {
     //This replaces project.properties w.r.t. build settings
     project.ext {
       defaultBuildToolsVersion="29.0.2" //String
-      defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
+      defaultMinSdkVersion=22 //Integer - Minimum requirement is Android 5.1
       defaultTargetSdkVersion=29 //Integer - We ALWAYS target the latest by default
       defaultCompileSdkVersion=29 //Integer - We ALWAYS compile with the latest by default
     }

--- a/bin/templates/project/legacy/build.gradle
+++ b/bin/templates/project/legacy/build.gradle
@@ -223,22 +223,6 @@ android {
             }
         }
     }
-    /*
-
-    ELSE NOTHING! DON'T MESS WITH THE VERSION CODE IF YOU DON'T HAVE TO!
-
-    else if (!cdvVersionCode) {
-      def minSdkVersion = cdvMinSdkVersion ?: privateHelpers.extractIntFromManifest("minSdkVersion")
-      // Vary versionCode by the two most common API levels:
-      // 14 is ICS, which is the lowest API level for many apps.
-      // 20 is Lollipop, which is the lowest API level for the updatable system webview.
-      if (minSdkVersion >= 20) {
-        defaultConfig.versionCode += 9
-      } else if (minSdkVersion >= 14) {
-        defaultConfig.versionCode += 8
-      }
-    }
-    */
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_6

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -62,7 +62,7 @@ android {
 
     // For the Android Cordova Lib, we will hardcode the minSdkVersion and not allow changes.
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 22
     }
 
     sourceSets {

--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -31,17 +31,12 @@ class SystemCookieManager implements ICordovaCookieManager {
     protected final WebView webView;
     private final CookieManager cookieManager;
 
-    //Added because lint can't see the conditional RIGHT ABOVE this
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public SystemCookieManager(WebView webview) {
         webView = webview;
         cookieManager = CookieManager.getInstance();
 
         cookieManager.setAcceptFileSchemeCookies(true);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cookieManager.setAcceptThirdPartyCookies(webView, true);
-        }
+        cookieManager.setAcceptThirdPartyCookies(webView, true);
     }
 
     public void setCookiesEnabled(boolean accept) {
@@ -58,16 +53,10 @@ class SystemCookieManager implements ICordovaCookieManager {
 
     @SuppressWarnings("deprecation")
     public void clearCookies() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cookieManager.removeAllCookies(null);
-        } else {
-            cookieManager.removeAllCookie();
-        }
+        cookieManager.removeAllCookies(null);
     }
 
     public void flush() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cookieManager.flush();
-        }
+        cookieManager.flush();
     }
 };

--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -155,7 +155,7 @@ public class SystemWebChromeClient extends WebChromeClient {
     {
         if (consoleMessage.message() != null)
             LOG.d(LOG_TAG, "%s: Line %d : %s" , consoleMessage.sourceId() , consoleMessage.lineNumber(), consoleMessage.message());
-         return super.onConsoleMessage(consoleMessage);
+        return super.onConsoleMessage(consoleMessage);
     }
 
     @Override
@@ -176,7 +176,6 @@ public class SystemWebChromeClient extends WebChromeClient {
         {
             geolocation.requestPermissions(0);
         }
-
     }
 
     // API level 7 is required for this, see if we could lower this using something else
@@ -199,7 +198,6 @@ public class SystemWebChromeClient extends WebChromeClient {
      * @return View The progress view.
      */
     public View getVideoLoadingProgressView() {
-
         if (mVideoProgressView == null) {
             // Create a new Loading view programmatically.
 
@@ -218,7 +216,7 @@ public class SystemWebChromeClient extends WebChromeClient {
 
             mVideoProgressView = layout;
         }
-    return mVideoProgressView;
+        return mVideoProgressView;
     }
 
     @Override

--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -221,33 +221,6 @@ public class SystemWebChromeClient extends WebChromeClient {
     return mVideoProgressView;
     }
 
-    // <input type=file> support:
-    // openFileChooser() is for pre KitKat and in KitKat mr1 (it's known broken in KitKat).
-    // For Lollipop, we use onShowFileChooser().
-    public void openFileChooser(ValueCallback<Uri> uploadMsg) {
-        this.openFileChooser(uploadMsg, "*/*");
-    }
-
-    public void openFileChooser( ValueCallback<Uri> uploadMsg, String acceptType ) {
-        this.openFileChooser(uploadMsg, acceptType, null);
-    }
-
-    public void openFileChooser(final ValueCallback<Uri> uploadMsg, String acceptType, String capture)
-    {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*");
-        parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
-            @Override
-            public void onActivityResult(int requestCode, int resultCode, Intent intent) {
-                Uri result = intent == null || resultCode != Activity.RESULT_OK ? null : intent.getData();
-                LOG.d(LOG_TAG, "Receive file chooser URL: " + result);
-                uploadMsg.onReceiveValue(result);
-            }
-        }, intent, FILECHOOSER_RESULTCODE);
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public boolean onShowFileChooser(WebView webView, final ValueCallback<Uri[]> filePathsCallback, final WebChromeClient.FileChooserParams fileChooserParams) {
         // Check if multiple-select is specified
@@ -288,7 +261,6 @@ public class SystemWebChromeClient extends WebChromeClient {
         return true;
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public void onPermissionRequest(final PermissionRequest request) {
         LOG.d(LOG_TAG, "onPermissionRequest: " + Arrays.toString(request.getResources()));

--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -333,7 +333,7 @@ public class SystemWebViewClient extends WebViewClient {
             // Allow plugins to intercept WebView requests.
             Uri remappedUri = resourceApi.remapUri(origUri);
 
-            if (!origUri.equals(remappedUri) || needsSpecialsInAssetUrlFix(origUri) || needsKitKatContentUrlFix(origUri)) {
+            if (!origUri.equals(remappedUri) || needsSpecialsInAssetUrlFix(origUri) || needsContentUrlFix(origUri)) {
                 CordovaResourceApi.OpenForReadResult result = resourceApi.openForRead(remappedUri, true);
                 return new WebResourceResponse(result.mimeType, "UTF-8", result.inputStream);
             }
@@ -348,7 +348,7 @@ public class SystemWebViewClient extends WebViewClient {
         }
     }
 
-    private static boolean needsKitKatContentUrlFix(Uri uri) {
+    private static boolean needsContentUrlFix(Uri uri) {
         return "content".equals(uri.getScheme());
     }
 

--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -113,7 +113,6 @@ public class SystemWebViewClient extends WebViewClient {
      * @param request
      */
     @Override
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public void onReceivedClientCertRequest (WebView view, ClientCertRequest request)
     {
 

--- a/test/android/app/build.gradle
+++ b/test/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         applicationId "org.apache.cordova.unittests"
-        minSdkVersion 19
+        minSdkVersion 22
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId "org.apache.cordova.unittests"
-        minSdkVersion 19
+        minSdkVersion 22
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context
As was discussed on the mailing list, the plan is to raise the minimum supported API level to 22, dropping support for Android 4.4 and 5.0 for the next major `cordova-android` release.

### Description

This PR updates the `defaultMinSdkVersion` to 22. 

There are also a couple of places in the codebase where we have specific logic for older (i.e. KitKat) API-levels which are now no longer needed and can therefore be removed.

I also renamed the `needsKitKatContentUrlFix` function to just `needsContentUrlFix` as it is no longer KitKat specific.

And lastly, I did some minor whitespace fixups and removed an obsolete piece of commented out code.

### Testing

I ran `npm run test` without issues and tested the changes in one of my own apps.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
