### PR TITLE
Update check_reqs.js - allow JDK > 1.8

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -392,12 +392,14 @@ module.exports.run = function () {
         console.log('Checking Java JDK and Android SDK versions');
         console.log('ANDROID_SDK_ROOT=' + process.env['ANDROID_SDK_ROOT'] + ' (recommended setting)');
         console.log('ANDROID_HOME=' + process.env['ANDROID_HOME'] + ' (DEPRECATED)');
-
-        if (!String(values[0]).startsWith('1.8.')) {
+           
+        if (values[0] === undefined) {
             throw new CordovaError(
-                'Requirements check failed for JDK 8 (\'1.8.*\')! Detected version: ' + values[0] + '\n' +
-                'Check your ANDROID_SDK_ROOT / JAVA_HOME / PATH environment variables.'
+                'Requirements check for Java Development Kit failed. Detected version: ' + values[0] + '\n' +
+                'Check your Java installation and ANDROID_SDK_ROOT / JAVA_HOME / PATH environment variables.'
             );
+        } else {
+          console.log('Detected JDK version: ' + values[0] + '\n');
         }
 
         if (!values[1]) {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -399,7 +399,7 @@ module.exports.run = function () {
                 'Check your Java installation and ANDROID_SDK_ROOT / JAVA_HOME / PATH environment variables.'
             );
         } else {
-          console.log('Detected JDK version: ' + values[0] + '\n');
+            console.log('Detected JDK version: ' + values[0] + '\n');
         }
 
         if (!values[1]) {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -392,7 +392,7 @@ module.exports.run = function () {
         console.log('Checking Java JDK and Android SDK versions');
         console.log('ANDROID_SDK_ROOT=' + process.env['ANDROID_SDK_ROOT'] + ' (recommended setting)');
         console.log('ANDROID_HOME=' + process.env['ANDROID_HOME'] + ' (DEPRECATED)');
-           
+
         if (values[0] === undefined) {
             throw new CordovaError(
                 'Requirements check for Java Development Kit failed. Detected version: ' + values[0] + '\n' +


### PR DESCRIPTION
Checking JDK should not fail when there is another version installed like 11.0.6 for example. 
Redme file declares clearly

> Requires

    > Java JDK 1.8 or greater

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
I have another verison installed. It fails but shouldn't.


