### PR TITLE
Docs: Updated README to reflect what Android requires more accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ at the core, applications written with web technology: HTML, CSS and JavaScript.
 
 ## Requires
 
-- Java JDK 1.8 or greater
+- Java JDK 1.8
 - Android SDK [http://developer.android.com](http://developer.android.com)
 
 


### PR DESCRIPTION
Java 8 is required, not anything less, not anything greater. Java 1.8.x specifically is required by the android sdk.
