### PR TITLE
fix: test failure with shebang interpreter in rewired files

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -17,6 +17,15 @@
     under the License.
 */
 
+/**
+ * @todo update coho to update this line.
+ * @todo use `package.json` instead but first
+ *  figure out how this fit in with the platform-centered workflow structure.
+ *  This workflow would not have the `package.json` file.
+ */
+// Coho updates this line
+const VERSION = '9.0.0-dev';
+
 var path = require('path');
 
 var AndroidProject = require('./lib/AndroidProject');
@@ -88,7 +97,7 @@ class Api {
         result.locations = this.locations;
         result.root = this.root;
         result.name = this.platform;
-        result.version = require('./version');
+        result.version = Api.version();
         result.projectConfig = this._config;
 
         return result;
@@ -364,6 +373,10 @@ class Api {
             throw (e);
         }
         return result;
+    }
+
+    static version () {
+        return VERSION;
     }
 }
 

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/device.js
+++ b/bin/templates/cordova/lib/device.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/log.js
+++ b/bin/templates/cordova/lib/log.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/retry.js
+++ b/bin/templates/cordova/lib/retry.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/version
+++ b/bin/templates/cordova/version
@@ -19,11 +19,6 @@
        under the License.
 */
 
-// Coho updates this line:
-var VERSION = '9.0.0-dev';
+const Api = require('./Api');
 
-module.exports.version = VERSION;
-
-if (!module.parent) {
-    console.log(VERSION);
-}
+console.log(Api.version());


### PR DESCRIPTION
### Motivation and Context

fixes: #938

Bin files that contains the shebang interpreter fails when being rewired.

### Description

* Remove shebang from logical files that do not need it.
* Move version logic into `Api.js` and stop requiring the bin file

### Testing

- `npm t`
- `cordova create`
- `cordova platform add android`
- `cordova build android`
- `cordova run android`
- `cordova prepare android`
- Create platform though Platform-Centered workflow

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
