### PR TITLE
fix: GH-873 App bundle builds to obey --versionCode arguments

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -141,9 +141,9 @@ class ProjectBuilder {
             if (opts.arch) {
                 args.push('-PcdvBuildArch=' + opts.arch);
             }
-
-            args.push.apply(args, opts.extraArgs);
         }
+
+        args.push.apply(args, opts.extraArgs);
 
         return args;
     }

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -113,6 +113,23 @@ describe('ProjectBuilder', () => {
             });
             expect(args[0]).toBe('clean');
         });
+
+        describe('should accept extra arguments', () => {
+            it('apk', () => {
+                const args = builder.getArgs('debug', {
+                    extraArgs: ['-PcdvVersionCode=12344']
+                });
+                expect(args).toContain('-PcdvVersionCode=12344');
+            });
+
+            it('bundle', () => {
+                const args = builder.getArgs('debug', {
+                    packageType: 'bundle',
+                    extraArgs: ['-PcdvVersionCode=12344']
+                });
+                expect(args).toContain('-PcdvVersionCode=12344');
+            });
+        });
     });
 
     describe('runGradleWrapper', () => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There was an issue when building app bundles where it did not obey flags. This was an error in the original implementation where arguments was only propagated to gradle if the package type was "apk". This PR corrects this mistake.

Closes #873 


### Description
<!-- Describe your changes in detail -->
Moved a line that pushes gradle arguments outside of the package type condition, as it is applicable 
to both package types.

Unit tests was added for both package types to ensure they both have args filled out as expected.

### Testing
<!-- Please describe in detail how you tested your changes. -->
NPM test runs successfully, including 2 new tests that was added.
I've also ran `aapt` and `bundletool` to inspect the built files to ensure that the versionCode was as expected.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
