### PR TITLE
Add fix to gradle out of memory issue

### DIFF
--- a/bin/templates/cordova/lib/config/GradlePropertiesParser.js
+++ b/bin/templates/cordova/lib/config/GradlePropertiesParser.js
@@ -34,7 +34,7 @@ class GradlePropertiesParser {
             'org.gradle.daemon': 'true',
 
             // to allow dex in process
-            'org.gradle.jvmargs': '-Xmx2048m',
+            'org.gradle.jvmargs': '-Xmx4096m',
 
             // Android X
             'android.useAndroidX': 'true',


### PR DESCRIPTION
- Discovered by @Captain-Ahax

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
TeamCity reported out of memory errors from gradle



### Description
Doubled memory in gradle.properties



### Testing
Executed npm run test



### Checklist

- [ √] I've run the tests to see all new and existing tests pass
- [ √] I added automated test coverage as appropriate for this change
- [ √ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ √ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ √ ] I've updated the documentation if necessary
