### PR TITLE
Feature: JVM Args flag

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -34,6 +34,7 @@ var PluginManager = require('cordova-common').PluginManager;
 var CordovaLogger = require('cordova-common').CordovaLogger;
 var selfEvents = require('cordova-common').events;
 var ConfigParser = require('cordova-common').ConfigParser;
+const prepare = require('./lib/prepare').prepare;
 
 var PLATFORM = 'android';
 
@@ -120,7 +121,7 @@ class Api {
     prepare (cordovaProject, prepareOptions) {
         cordovaProject.projectConfig = new ConfigParser(cordovaProject.locations.rootConfigXml || cordovaProject.projectConfig.path);
 
-        return require('./lib/prepare').prepare.call(this, cordovaProject, prepareOptions);
+        return prepare.call(this, cordovaProject, prepareOptions);
     }
 
     /**

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -19,6 +19,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
+const nopt = require('nopt');
 var events = require('cordova-common').events;
 var AndroidManifest = require('./AndroidManifest');
 var checkReqs = require('./check_reqs');
@@ -33,8 +34,20 @@ const utils = require('./utils');
 
 const GradlePropertiesParser = require('./config/GradlePropertiesParser');
 
+function parseArguments (argv) {
+    return nopt({
+        // `jvmargs` is a valid option however, we don't actually want to parse it because we want the entire string as is.
+        // jvmargs: String
+    }, {}, argv || [], 0);
+}
+
 module.exports.prepare = function (cordovaProject, options) {
     var self = this;
+
+    let args = {};
+    if (options && options.options) {
+        args = parseArguments(options.options.argv);
+    }
 
     var platformJson = PlatformJson.load(this.locations.root, this.platform);
     var munger = new PlatformMunger(this.platform, this.locations.root, platformJson, new PluginInfoProvider());
@@ -53,6 +66,7 @@ module.exports.prepare = function (cordovaProject, options) {
     if (minSdkVersion) gradlePropertiesUserConfig.cdvMinSdkVersion = minSdkVersion;
     if (maxSdkVersion) gradlePropertiesUserConfig.cdvMaxSdkVersion = maxSdkVersion;
     if (targetSdkVersion) gradlePropertiesUserConfig.cdvTargetSdkVersion = targetSdkVersion;
+    if (args.jvmargs) gradlePropertiesUserConfig['org.gradle.jvmargs'] = args.jvmargs;
     if (isGradlePluginKotlinEnabled) {
         gradlePropertiesUserConfig['kotlin.code.style'] = gradlePluginKotlinCodeStyle || 'official';
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Provides a `--jvmargs` flag to pass through JVM args to gradle. This is mostly useful for changing the `-Xmx` flag, allowing the JVM to use more memory on larger projects.

There was no feature request made, but it does closes https://github.com/apache/cordova-android/pull/945 ; a PR that changes the default memory size to 4096m.

I believe this is a better alternative as I believe it is better to keep the `-Xmx` as low as possible and for most users, our default value of 2048m is probably fine, but allows the flexibility for users to change the value based on their own unique needs. Additionally, this accepts any [JVM args](https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory), so not necessary limited to `-Xmx` flag.

The flag works on `prepare`, `build`, and `run` cordova commands. Example is given below:

`cordova prepare android -- --jvmargs='-Xmx4g'`

Do note the double set of dashes. Value memory size units are `k`, `m`, and `g` and is case-insensitive. This matches what JVM supports.


### Description
<!-- Describe your changes in detail -->
This PR looks at the option vargs in `prepare` and sets the appropriate key for `GradlePropertiesParser` for jvm args.

Some changes were made to the `Api` class, which was required to get unit tests configured properly. (The entire `prepare` function was not unit tested at all). Unit tests changes are made in a separate commit.

Lastly, there is an informational log that was printed to the console if the user changes the `-Xmx` option to something other than the cordova default. I've changed this to only produce that log if the numerical size value is smaller than the cordova default. Code was added to parse the byte value for comparison. Unit tests were also added. This particular part is made in a separate commit from the jvmargs flag implementation.

This PR is accompanied by a `cordova-docs` PR: https://github.com/apache/cordova-docs/pull/1078

### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` was ran with all existing and new tests passing.
I have also manually tested these changes in a dummy project, ensuring that the `gradle.properties` file produced expected results both with and without the flag.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [] I've updated the documentation if necessary
