### PR TITLE
fix: Removed redundent logcat print

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -151,14 +151,6 @@ public class SystemWebChromeClient extends WebChromeClient {
     }
 
     @Override
-    public boolean onConsoleMessage(ConsoleMessage consoleMessage)
-    {
-        if (consoleMessage.message() != null)
-            LOG.d(LOG_TAG, "%s: Line %d : %s" , consoleMessage.sourceId() , consoleMessage.lineNumber(), consoleMessage.message());
-        return super.onConsoleMessage(consoleMessage);
-    }
-
-    @Override
     /**
      * Instructs the client to show a prompt to ask the user to set the Geolocation permission state for the specified origin.
      *


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The chromium webview will print an informational log already,
we don't need to override the method to do what the webview will already.
Closes #914 


### Description
<!-- Describe your changes in detail -->
Simply removes the `onConsoleMessage` message override, since we don't do anything other than to print a logcat message out, which the super class already does, resulting in duplicate logcat prints.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran npm test and ensured all existing tests passes.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
