### PR TITLE
fix: ANDROID_SDK_ROOT variable

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -81,7 +81,11 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
 String getAndroidSdkDir() {
     def rootDir = project.rootDir
     def androidSdkDir = null
-    String envVar = System.getenv("ANDROID_HOME")
+    String envVar = System.getenv("ANDROID_SDK_ROOT")
+    if (envVar == null) {
+        envVar = System.getenv("ANDROID_HOME")
+    }
+    
     def localProperties = new File(rootDir, 'local.properties')
     String systemProperty = System.getProperty("android.home")
     if (envVar != null) {

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -49,23 +49,23 @@ describe('check_reqs', function () {
                     spyOn(which, 'sync').and.returnValue(null);
                     spyOn(fs, 'existsSync').and.returnValue(true);
                 });
-                it('it should set ANDROID_HOME on Windows', () => {
+                it('it should set ANDROID_SDK_ROOT on Windows', () => {
                     spyOn(check_reqs, 'isWindows').and.returnValue(true);
                     process.env.LOCALAPPDATA = 'windows-local-app-data';
                     process.env.ProgramFiles = 'windows-program-files';
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_HOME).toContain('windows-local-app-data');
+                        expect(process.env.ANDROID_SDK_ROOT).toContain('windows-local-app-data');
                     }).finally(function () {
                         delete process.env.LOCALAPPDATA;
                         delete process.env.ProgramFiles;
                     });
                 });
-                it('it should set ANDROID_HOME on Darwin', () => {
+                it('it should set ANDROID_SDK_ROOT on Darwin', () => {
                     spyOn(check_reqs, 'isWindows').and.returnValue(false);
                     spyOn(check_reqs, 'isDarwin').and.returnValue(true);
                     process.env.HOME = 'home is where the heart is';
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_HOME).toContain('home is where the heart is');
+                        expect(process.env.ANDROID_SDK_ROOT).toContain('home is where the heart is');
                     }).finally(function () {
                         delete process.env.HOME;
                     });
@@ -77,7 +77,7 @@ describe('check_reqs', function () {
                         return path;
                     });
                 });
-                it('should set ANDROID_HOME based on `android` command if command exists in a SDK-like directory structure', () => {
+                it('should set ANDROID_SDK_ROOT based on `android` command if command exists in a SDK-like directory structure', () => {
                     spyOn(fs, 'existsSync').and.returnValue(true);
                     spyOn(which, 'sync').and.callFake(function (cmd) {
                         if (cmd === 'android') {
@@ -87,7 +87,7 @@ describe('check_reqs', function () {
                         }
                     });
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_HOME).toEqual('/android/sdk');
+                        expect(process.env.ANDROID_SDK_ROOT).toEqual('/android/sdk');
                     });
                 });
                 it('should error out if `android` command exists in a non-SDK-like directory structure', () => {
@@ -105,7 +105,7 @@ describe('check_reqs', function () {
                         expect(err.message).toContain('update your PATH to include valid path');
                     });
                 });
-                it('should set ANDROID_HOME based on `adb` command if command exists in a SDK-like directory structure', () => {
+                it('should set ANDROID_SDK_ROOT based on `adb` command if command exists in a SDK-like directory structure', () => {
                     spyOn(fs, 'existsSync').and.returnValue(true);
                     spyOn(which, 'sync').and.callFake(function (cmd) {
                         if (cmd === 'adb') {
@@ -115,7 +115,7 @@ describe('check_reqs', function () {
                         }
                     });
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_HOME).toEqual('/android/sdk');
+                        expect(process.env.ANDROID_SDK_ROOT).toEqual('/android/sdk');
                     });
                 });
                 it('should error out if `adb` command exists in a non-SDK-like directory structure', () => {
@@ -133,7 +133,7 @@ describe('check_reqs', function () {
                         expect(err.message).toContain('update your PATH to include valid path');
                     });
                 });
-                it('should set ANDROID_HOME based on `avdmanager` command if command exists in a SDK-like directory structure', () => {
+                it('should set ANDROID_SDK_ROOT based on `avdmanager` command if command exists in a SDK-like directory structure', () => {
                     spyOn(fs, 'existsSync').and.returnValue(true);
                     spyOn(which, 'sync').and.callFake(function (cmd) {
                         if (cmd === 'avdmanager') {
@@ -143,7 +143,7 @@ describe('check_reqs', function () {
                         }
                     });
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_HOME).toEqual('/android/sdk');
+                        expect(process.env.ANDROID_SDK_ROOT).toEqual('/android/sdk');
                     });
                 });
                 it('should error out if `avdmanager` command exists in a non-SDK-like directory structure', () => {
@@ -163,14 +163,65 @@ describe('check_reqs', function () {
                 });
             });
         });
+
+        describe('ANDROID_SDK_ROOT environment variable detection', () => {
+            beforeEach(() => {
+                delete process.env.ANDROID_SDK_ROOT;
+                delete process.env.ANDROID_HOME;
+                check_reqs.__set__('forgivingWhichSync', jasmine.createSpy().and.returnValue(''));
+            });
+
+            const expectedAndroidSdkPath = path.sep + 'android' + path.sep + 'sdk';
+            const expectedAndroidRootSdkPath = path.sep + 'android' + path.sep + 'sdk' + path.sep + 'root';
+
+            it('should error if neither ANDROID_SDK_ROOT or ANDROID_HOME is defined', () => {
+                spyOn(fs, 'existsSync').and.returnValue(true);
+                return check_reqs.check_android().catch((error) => {
+                    expect(error.toString()).toContain('Failed to find \'ANDROID_SDK_ROOT\' environment variable.');
+                });
+            });
+
+            it('should use ANDROID_SDK_ROOT if defined', () => {
+                spyOn(fs, 'existsSync').and.returnValue(true);
+                process.env.ANDROID_SDK_ROOT = '/android/sdk';
+                return check_reqs.check_android().then(() => {
+                    expect(process.env.ANDROID_SDK_ROOT).toContain(expectedAndroidSdkPath);
+                });
+            });
+
+            it('should use ANDROID_HOME if defined and ANDROID_SDK_ROOT is not defined', () => {
+                spyOn(fs, 'existsSync').and.returnValue(true);
+                process.env.ANDROID_HOME = '/android/sdk';
+                return check_reqs.check_android().then(() => {
+                    expect(process.env.ANDROID_SDK_ROOT).toContain(expectedAndroidSdkPath);
+                });
+            });
+
+            it('should use ANDROID_SDK_ROOT if defined and ANDROID_HOME is defined', () => {
+                spyOn(fs, 'existsSync').and.returnValue(true);
+                process.env.ANDROID_SDK_ROOT = '/android/sdk/root';
+                process.env.ANDROID_HOME = '/android/sdk';
+                return check_reqs.check_android().then(() => {
+                    expect(process.env.ANDROID_SDK_ROOT).toContain(expectedAndroidRootSdkPath);
+                });
+            });
+
+            it('should throw if ANDROID_SDK_ROOT points to an invalid path', () => {
+                process.env.ANDROID_SDK_ROOT = '/android/sdk';
+                return check_reqs.check_android().catch((error) => {
+                    expect(error.toString()).toContain('\'ANDROID_SDK_ROOT\' environment variable is set to non-existent path:');
+                });
+            });
+        });
+
         describe('set PATH for various Android binaries if not available', function () {
             beforeEach(function () {
                 spyOn(which, 'sync').and.returnValue(null);
-                process.env.ANDROID_HOME = 'let the children play';
+                process.env.ANDROID_SDK_ROOT = 'let the children play';
                 spyOn(fs, 'existsSync').and.returnValue(true);
             });
             afterEach(function () {
-                delete process.env.ANDROID_HOME;
+                delete process.env.ANDROID_SDK_ROOT;
             });
             it('should add tools/bin,tools,platform-tools to PATH if `avdmanager`,`android`,`adb` is not found', () => {
                 return check_reqs.check_android().then(function () {
@@ -178,6 +229,51 @@ describe('check_reqs', function () {
                     expect(process.env.PATH).toContain('let the children play' + path.sep + 'platform-tools');
                     expect(process.env.PATH).toContain('let the children play' + path.sep + 'tools' + path.sep + 'bin');
                 });
+            });
+        });
+    });
+
+    describe('check_gradle', () => {
+        describe('environment variable checks', () => {
+            beforeEach(() => {
+                delete process.env.ANDROID_SDK_ROOT;
+                delete process.env.ANDROID_HOME;
+                spyOn(check_reqs, 'get_gradle_wrapper').and.callFake(() => {
+                    return (process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME) + '/bin/gradle';
+                });
+            });
+
+            it('with ANDROID_SDK_ROOT / without ANDROID_HOME', () => {
+                process.env.ANDROID_SDK_ROOT = '/android/sdk/root';
+                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
+            });
+
+            it('with ANDROID_SDK_ROOT / with ANDROID_HOME', () => {
+                process.env.ANDROID_SDK_ROOT = '/android/sdk/root';
+                process.env.ANDROID_HOME = '/android/sdk/home';
+                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
+            });
+
+            it('without ANDROID_SDK_ROOT / with ANDROID_HOME', () => {
+                process.env.ANDROID_HOME = '/android/sdk/home';
+                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/home/bin/gradle');
+            });
+
+            it('without ANDROID_SDK_ROOT / without ANDROID_HOME', () => {
+                return check_reqs.check_gradle().catch((error) => {
+                    expect(error.toString()).toContain('Could not find gradle wrapper within Android SDK. Could not find Android SDK directory.');
+                });
+            });
+        });
+
+        it('should error if sdk is installed but no gradle found', () => {
+            process.env.ANDROID_SDK_ROOT = '/android/sdk';
+            spyOn(check_reqs, 'get_gradle_wrapper').and.callFake(() => {
+                return '';
+            });
+
+            return check_reqs.check_gradle().catch((error) => {
+                expect(error.toString()).toContain('Could not find an installed version of Gradle');
             });
         });
     });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #949 which describes a functional issue
Fixes #670 which describes a cosmetic issue that is loosely related.

### Description
<!-- Describe your changes in detail -->
This PR depends on two other PRs: #959 #960 

This PR does the following:
- Makes ANDROID_SDK_ROOT the primary variable to look for the Android SDK location.
- Makes ANDROID_HOME the fallback variable, if ANDROID_SDK_ROOT is not present/valid.

~~Gradle updates:~~
~~Note that the following gradle updates were required, otherwise the android gradle plugin did not honour the ANDROID_SDK_ROOT variable.~~

- ~~Updates the framework's android studio's gradle plugin from version 3.3.0 to 3.5.3.
	Not only this is required for android's gradle to obey ANDROID_SDK_ROOT, it is now in sync with the Android test project/~~
- ~~Updates the Androidx test project to use gralde plugin from version 3.3.0 to 3.5.3, to match Android Test & framework.~~
	- ~~Consequentially, this required to also upgrade AndroidX test project to use Gradle 6.1, which also matches both the Android test project & framework~~

Gradle updates have been moved to independent PRs #959 #960 

These changes above fixes #949

Additionally, since we update the environment variables dynamically, the environment variable printout produced misleading information.
The environment variable printout will now print out the variable as defined by the user (before the tooling messes with them). An additional log
is printed that tells the user exactly what Cordova is going to use for the Android SDK path. This should fix #670

Tests was also changed to mainly use `ANDROID_SDK_ROOT` instead of `ANDROID_HOME`. Additional tests were added to ensure things works with either variable, but `ANDROID_SDK_ROOT` now takes precedence over `ANDROID_HOME`, should both be defined.

### Testing
<!-- Please describe in detail how you tested your changes. -->
npm test passes successfully, both old and new.
I've ran npm test in every combination of:
- with `ANDROID_SDK_ROOT` / with `ANDROID_HOME`
- with `ANDROID_SDK_ROOT` / without `ANDROID_HOME`
- without `ANDROID_SDK_ROOT` / with `ANDROID_HOME`
- without `ANDROID_SDK_ROOT` / without `ANDROID_HOME`

Additionally, I've tested each of these combinations with a hello world cordova test app, to ensure `build` runs successfully.

This PR should be accompanied with a cordova-docs PR to update the [Environment Variables](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#setting-environment-variables) documentation, which has not been done yet.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
