### PR TITLE
breaking(npm): bump packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",
     "jasmine": "^3.5.0",
-    "jasmine-spec-reporter": "^4.2.1",
-    "nyc": "^14.1.1",
-    "rewire": "^4.0.1"
+    "jasmine-spec-reporter": "^5.0.1",
+    "nyc": "^15.0.1",
+    "rewire": "^5.0.0"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
-    "android-versions": "^1.4.0",
-    "cordova-common": "^3.2.0",
-    "execa": "^3.2.0",
-    "fs-extra": "^8.1.0",
-    "nopt": "^4.0.1",
+    "android-versions": "^1.5.0",
+    "cordova-common": "^4.0.0",
+    "execa": "^4.0.0",
+    "fs-extra": "^9.0.0",
+    "nopt": "^4.0.3",
     "properties-parser": "^0.3.1",
-    "which": "^1.3.1"
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",


### PR DESCRIPTION
### Motivation and Context

Use latest npm dependencies

Requires #953

### Description

**Bump Dev Dependencies**

* jasmine-spec-reporter@^5.0.1
* nyc@^15.0.1
* rewire@^5.0.0

**Bump Production Dependencies**

* android-versions@^1.5.0
* cordova-common@^4.0.0
* execa@^4.0.0
* fs-extra@^9.0.0
* nopt@^4.0.3
* which@^2.0.2

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
