### PR TITLE
test: synced androidx gradle versions to the same version as the android test

### DIFF
--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -55,3 +55,6 @@ dependencies {
         exclude group: 'androidx.test.espresso', module: 'androidx.annotation'
     })
 }
+repositories {
+    jcenter()
+}

--- a/test/androidx/build.gradle
+++ b/test/androidx/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '4.10.3'
+    gradleVersion = '6.1'
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes androidx test versions, who was still on gradle 4 and android gradle plugin 3.5.3, inconsistent with its `android` test sibling.


### Description
<!-- Describe your changes in detail -->
Upgrade gradle version pins


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
