### PR TITLE
Increased detectArchitecture() timeout

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -210,7 +210,7 @@ module.exports.detectArchitecture = function (target) {
     // To fix it, either unplug & replug device, or restart adb server.
     return Promise.race([
         helper(),
-        timeout(1000, new CordovaError(
+        timeout(5000, new CordovaError(
             'Device communication timed out. Try unplugging & replugging the device.'
         ))
     ]).catch(err => {


### PR DESCRIPTION
The timeout for detectArchitecture() is sometimes too low when devices are on wifi network connections and even sometimes over USB. The command can take up to 3 seconds to execute and return. Currently the timeout is set to 1000 ms and setting it to 5000 ms seems to be a good compromise.


### Platforms affected

Android

### Motivation and Context

https://github.com/apache/cordova-android/issues/963

### Description

Increased the detectArchitecture() method timeout from 1000 ms to 5000 ms

### Testing

Changing the timeout does not affect and unit tests.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
