### PR TITLE
Accept multiple mime types on file input

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -220,6 +220,13 @@ public class SystemWebChromeClient extends WebChromeClient {
         }
         Intent intent = fileChooserParams.createIntent();
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, selectMultiple);
+        
+        // Uses Intent.EXTRA_MIME_TYPES to pass multiple mime types.
+        String[] acceptTypes = fileChooserParams.getAcceptTypes();
+        if (acceptTypes.length > 1) {
+            intent.setType("*/*"); // Accept all, filter mime types by Intent.EXTRA_MIME_TYPES.
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, acceptTypes);
+        }
         try {
             parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
                 @Override


### PR DESCRIPTION
Accept multiple mime types on file input
### Platforms affected

Android

### Motivation and Context
Accept multiple mime types when using file chooser

### Description
Replace: https://github.com/apache/cordova-android/pull/707
Fix: https://github.com/apache/cordova-android/issues/695

### Testing
Tested on Android devices.

### Checklist

- [ x] I've run the tests to see all new and existing tests pass
- [ x] I added automated test coverage as appropriate for this change
- [ x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ x] I've updated the documentation if necessary
