### PR TITLE
fix: wait_for_boot waiting forever

### DIFF
--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -352,8 +352,8 @@ module.exports.wait_for_emulator = function (port) {
  */
 module.exports.wait_for_boot = function (emulator_id, time_remaining) {
     var self = this;
-    return Adb.shell(emulator_id, 'ps').then(function (output) {
-        if (output.match(/android\.process\.acore/)) {
+    return Adb.shell(emulator_id, 'getprop sys.boot_completed').then(function (output) {
+        if (output.match(/1/)) {
             return true;
         } else if (time_remaining === 0) {
             return false;

--- a/spec/unit/emulator.spec.js
+++ b/spec/unit/emulator.spec.js
@@ -452,7 +452,7 @@ describe('emulator', () => {
         it('should resolve with true if the system has booted', () => {
             AdbSpy.shell.and.callFake((emuId, shellArgs) => {
                 expect(emuId).toBe(emulatorId);
-                expect(shellArgs).toContain('ps');
+                expect(shellArgs).toContain('getprop sys.boot_completed');
 
                 return Promise.resolve(psOutput);
             });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes: #698 


### Description
<!-- Describe your changes in detail -->
Changes `wait_for_boot` from using `ps` shell command to check for `android.process.acore` to `getprop sys.boot_completed`

`android.process.acore` is a process that (despite it's name) is used for the `ContactsProvider`. The process is launched on boot, but will get killed after some amount of inactivity. When this happens, emulators that are opened for approximately 15 minutes or more will cause `cordova run android` to hang indefinitely.

Using `getprop sys.boot_completed` is a more reliable way to determine if the simulator has been booted.

A longer research comment I have posted on the issue ticket at https://github.com/apache/cordova-android/issues/698#issuecomment-632300908

Additionally one unit test has been updated to reflect this change.

I believe this is a safe change to make as all android emulators available via the android sdk of the API levels cordova-android@9 will support all appear to support the `sys.boot_completed` prop. It is possible other third-party simulators may not support this flag, but I don't believe this is a Cordova's concern.

### Testing
<!-- Please describe in detail how you tested your changes. -->
- Ran `npm test`
- Tested android emulators between API 22 through R (API 30) to ensure that `getprop sys.boot_completed` indeed returns a value when expected to.
- Ran `cordova run android` while the emulator was off to ensure emulator starts and installs the app properly.
- Tested on Android Emulator 30.0.12 (Latest version as the time of this PR)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
