### PR TITLE
Remove gradle.daemon from default forced settings

### DIFF
--- a/bin/templates/cordova/lib/config/GradlePropertiesParser.js
+++ b/bin/templates/cordova/lib/config/GradlePropertiesParser.js
@@ -30,9 +30,6 @@ class GradlePropertiesParser {
     */
     constructor (platformDir) {
         this._defaults = {
-            // 10 seconds -> 6 seconds
-            'org.gradle.daemon': 'true',
-
             // to allow dex in process
             'org.gradle.jvmargs': '-Xmx2048m',
 


### PR DESCRIPTION
### Platforms affected

All.

### Motivation and Context

Closes https://github.com/apache/cordova-android/issues/982

### Description

This removes the forced setting of `gradle.daemon` to be true. Because gradle does daemon by default, this won't impact behavior. Except that now if users set gradle.daemon to false, it will respect that instead of overwriting.

In theory there's still a bad behavior in the code of not allowing defaults to be overwritten at all, but it's beyond the scope of this PR.


### Testing

`npm test` passes (and leaves a daemon behind).


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
