### PR TITLE
fix: Plugin install fails when preview sdk is installed

### DIFF
--- a/bin/templates/cordova/lib/android_sdk.js
+++ b/bin/templates/cordova/lib/android_sdk.js
@@ -29,17 +29,14 @@ var suffix_number_regex = /(\d+)$/;
 // the number at the end, the more recent the target, the closer to the
 // start of the array.
 function sort_by_largest_numerical_suffix (a, b) {
-    var suffix_a = a.match(suffix_number_regex);
-    var suffix_b = b.match(suffix_number_regex);
-    if (suffix_a && suffix_b) {
-        // If the two targets being compared have suffixes, return less than
-        // zero, or greater than zero, based on which suffix is larger.
-        return (parseInt(suffix_a[1]) > parseInt(suffix_b[1]) ? -1 : 1);
-    } else {
-        // If no suffix numbers were detected, leave the order as-is between
-        // elements a and b.
-        return 0;
-    }
+    let suffix_a = a.match(suffix_number_regex);
+    let suffix_b = b.match(suffix_number_regex);
+    // If no number is detected (eg: preview version like android-R),
+    // designate a suffix of 0 so it gets moved to the end
+    suffix_a = suffix_a || ['0', '0'];
+    suffix_b = suffix_b || ['0', '0'];
+    // Return < zero, or > zero, based on which suffix is larger.
+    return (parseInt(suffix_a[1]) > parseInt(suffix_b[1]) ? -1 : 1);
 }
 
 module.exports.print_newest_available_sdk_target = function () {

--- a/spec/unit/android_sdk.spec.js
+++ b/spec/unit/android_sdk.spec.js
@@ -33,14 +33,21 @@ describe('android_sdk', () => {
 
     describe('sort_by_largest_numerical_suffix', () => {
         it('should return the newest version first', () => {
-            const ids = ['android-24', 'android-19', 'android-27', 'android-23'];
-            const sortedIds = ['android-27', 'android-24', 'android-23', 'android-19'];
+            const ids = ['android-P', 'android-24', 'android-19', 'android-27', 'android-23'];
+            const sortedIds = ['android-27', 'android-24', 'android-23', 'android-19', 'android-P'];
             expect(ids.sort(android_sdk.__get__('sort_by_largest_numerical_suffix'))).toEqual(sortedIds);
         });
 
-        it('should return 0 (no sort) if one of the versions has no number', () => {
-            const ids = ['android-27', 'android-P'];
-            expect(android_sdk.__get__('sort_by_largest_numerical_suffix')(ids[0], ids[1])).toBe(0);
+        describe('should return release version over preview versions', () => {
+            it('Test #001', () => {
+                const ids = ['android-27', 'android-P'];
+                expect(android_sdk.__get__('sort_by_largest_numerical_suffix')(ids[0], ids[1])).toBe(-1);
+            });
+
+            it('Test #002', () => {
+                const ids = ['android-P', 'android-27'];
+                expect(android_sdk.__get__('sort_by_largest_numerical_suffix')(ids[0], ids[1])).toBe(1);
+            });
         });
     });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #981 

If a plugin declares a `android-sdk` engine requirement such as `<engine name="android-sdk" version=">=26" />` the plugin may unexpectedly fail if the following conditions are met:

1. You have an appropriate SDK version installed (such as version `android-28`)
2. You have android preview SDK installed.

If the android preview SDK is installed, it was treated as the highest sdk version, even if it has no numerical value. This then led to errors such as:

```
Installing "cordova-plugin-local-notification" for android
Failed to install 'cordova-plugin-local-notification': TypeError: Invalid Version: android-R
    at new SemVer (/home/norman/.nvm/versions/node/v14.2.0/lib/node_modules/cordova/node_modules/semver/semver.js:323:11)
    at Range.test (/home/norman/.nvm/versions/node/v14.2.0/lib/node_modules/cordova/node_modules/semver/semver.js:1203:15)
    at Function.satisfies (/home/norman/.nvm/versions/node/v14.2.0/lib/node_modules/cordova/node_modules/semver/semver.js:1257:16)
    at checkEngines (/home/norman/.nvm/versions/node/v14.2.0/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:113:20)
    at /home/norman/.nvm/versions/node/v14.2.0/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:305:16
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
Invalid Version: android-R
```

### Description
<!-- Describe your changes in detail -->
This PR changes the `sort_by_largest_numerical_suffix` and give preview SDKs a numerical value of 0, thus preview SDKs are put to the bottom of the stack.

This does mean that preview SDKs will never be chosen, but I believe this should be the default behaviour. If the user wants to use a preview SDK, I think that should be an opt-in feature, and it is out of scope of this PR.

Existing tests were modified to ensure that preview SDKs were ordered properly.

Special thanks to @timpark for supplying a patch that fixes the `sort_by_largest_numerical_suffix` method.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I've ran `npm test`
I've tested against the my local fork with the PR applied, using the following commands on an empty project.

```
cordova platform add (android | android-fork)
cordova plugin add https://github.com/Steffaan/cordova-plugin-local-notifications
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
