### PR TITLE
breaking: reduce combined response cutoff to 16 MB

### DIFF
--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -39,7 +39,7 @@ public class NativeToJsMessageQueue {
     // Arbitrarily chosen upper limit for how much data to send to JS in one shot.
     // This currently only chops up on message boundaries. It may be useful
     // to allow it to break up messages.
-    private static int MAX_PAYLOAD_SIZE = 16 * 1024 * 1024;
+    private static int COMBINED_RESPONSE_CUTOFF = 16 * 1024 * 1024;
 
     /**
      * When true, the active listener is not fired upon enqueue. When set to false,
@@ -124,7 +124,7 @@ public class NativeToJsMessageQueue {
 
     /**
      * Combines and returns queued messages combined into a single string.
-     * Combines as many messages as possible, while staying under MAX_PAYLOAD_SIZE.
+     * Combines as many messages as possible, while staying under COMBINED_RESPONSE_CUTOFF.
      * Returns null if the queue is empty.
      */
     public String popAndEncode(boolean fromOnlineEvent) {
@@ -140,7 +140,7 @@ public class NativeToJsMessageQueue {
             int numMessagesToSend = 0;
             for (JsMessage message : queue) {
                 int messageSize = calculatePackedMessageLength(message);
-                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > MAX_PAYLOAD_SIZE && MAX_PAYLOAD_SIZE > 0) {
+                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF && COMBINED_RESPONSE_CUTOFF > 0) {
                     break;
                 }
                 totalPayloadLen += messageSize;
@@ -175,7 +175,7 @@ public class NativeToJsMessageQueue {
             int numMessagesToSend = 0;
             for (JsMessage message : queue) {
                 int messageSize = message.calculateEncodedLength() + 50; // overestimate.
-                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > MAX_PAYLOAD_SIZE && MAX_PAYLOAD_SIZE > 0) {
+                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF && COMBINED_RESPONSE_CUTOFF > 0) {
                     break;
                 }
                 totalPayloadLen += messageSize;

--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -39,7 +39,7 @@ public class NativeToJsMessageQueue {
     // Arbitrarily chosen upper limit for how much data to send to JS in one shot.
     // This currently only chops up on message boundaries. It may be useful
     // to allow it to break up messages.
-    private static int MAX_PAYLOAD_SIZE = 50 * 1024 * 10240;
+    private static int MAX_PAYLOAD_SIZE = 16 * 1024 * 1024;
 
     /**
      * When true, the active listener is not fired upon enqueue. When set to false,

--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -144,7 +144,10 @@ public class NativeToJsMessageQueue {
             int numMessagesToSend = 0;
             for (JsMessage message : queue) {
                 int messageSize = calculatePackedMessageLength(message);
-                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF && COMBINED_RESPONSE_CUTOFF > 0) {
+                if (numMessagesToSend > 0 &&
+                    COMBINED_RESPONSE_CUTOFF > 0 &&
+                    totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF
+                   ) {
                     break;
                 }
                 totalPayloadLen += messageSize;
@@ -179,7 +182,10 @@ public class NativeToJsMessageQueue {
             int numMessagesToSend = 0;
             for (JsMessage message : queue) {
                 int messageSize = message.calculateEncodedLength() + 50; // overestimate.
-                if (numMessagesToSend > 0 && totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF && COMBINED_RESPONSE_CUTOFF > 0) {
+                if (numMessagesToSend > 0 &&
+                    COMBINED_RESPONSE_CUTOFF > 0 &&
+                    totalPayloadLen + messageSize > COMBINED_RESPONSE_CUTOFF
+                   ) {
                     break;
                 }
                 totalPayloadLen += messageSize;

--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -36,9 +36,10 @@ public class NativeToJsMessageQueue {
     // exec() is asynchronous. Set this to true when running bridge benchmarks.
     static final boolean DISABLE_EXEC_CHAINING = false;
 
-    // Arbitrarily chosen upper limit for how much data to send to JS in one shot.
-    // This currently only chops up on message boundaries. It may be useful
-    // to allow it to break up messages.
+    // A hopefully reasonable upper limit of how much combined payload data
+    // to send to the JavaScript in one shot.
+    // This currently only chops up on message boundaries.
+    // It may be useful to split and reassemble response messages someday.
     private static int COMBINED_RESPONSE_CUTOFF = 16 * 1024 * 1024;
 
     /**
@@ -124,7 +125,10 @@ public class NativeToJsMessageQueue {
 
     /**
      * Combines and returns queued messages combined into a single string.
-     * Combines as many messages as possible, while staying under COMBINED_RESPONSE_CUTOFF.
+     *
+     * Combines as many messages as possible, without exceeding
+     * COMBINED_RESPONSE_CUTOFF in case of multiple response messages.
+     *
      * Returns null if the queue is empty.
      */
     public String popAndEncode(boolean fromOnlineEvent) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
__Updated__

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

see #986 - I think this is needed to avoid crash with JSON memory issue in case of a large number of moderately-sized plugin response messages

_Note that this would affect the size of combined responses sent to the JavaScript and **not** the maximum size of any individual response message._

I hope we can consider this change for cordova-android 9.0.0 which should be coming in the near future.

### Description
<!-- Describe your changes in detail -->

- reduce the internal payload cutoff constant from 500 MB to 16 MB, as I had proposed in #986
- rename the payload cutoff constant to `COMBINED_RESPONSE_CUTOFF`
- update some comments
- cleanup: split if statements into multiple lines

note that this does **not** completely resolve the issues I raised in #986 due to the ugly warning messages still lurking

### Testing
<!-- Please describe in detail how you tested your changes. -->

- [x] tested with [`github:brodybits/cordova-big-android-response-payload-test`](https://github.com/brodybits/cordova-big-android-response-payload-test), with `NATIVE_RESPONSE_COUNT` changed from 20 to 400, as discussed in issue #986.
- [x] tested with the `spec` test app in my `cordova-sqlite-storage` plugin (sanity test)

### Remaining quirks

As I said in #986:

- missing module warning message issue is uncovered, see #986 for more details
- without background threading, not all response messages make it to the JavaScript side

I hope someone will have time to get to the bottom of these remaining quirks, someday.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue,~~ I linked to the issue in the text above ~~(and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~
