### PR TITLE
[major] feat: Gradle 6.5 & Android Gradle plugin 4.0.0 updates

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -303,7 +303,7 @@ class ProjectBuilder {
                 // update/set the distributionUrl in the gradle-wrapper.properties
                 const gradleWrapperPropertiesPath = path.join(self.root, 'gradle/wrapper/gradle-wrapper.properties');
                 const gradleWrapperProperties = createEditor(gradleWrapperPropertiesPath);
-                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.1-all.zip';
+                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.5-all.zip';
                 gradleWrapperProperties.set('distributionUrl', distributionUrl);
                 gradleWrapperProperties.save();
 

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -53,7 +53,7 @@ buildscript {
     dependencies {
         apply from: '../CordovaLib/cordova.gradle'
 
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         if (cdvHelpers.getConfigPreference('GradlePluginKotlinEnabled', 'false').toBoolean()) {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -89,7 +89,7 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '6.1'
+    gradleVersion = '6.5'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,7 +31,7 @@ buildscript {
     dependencies {
         // The gradle plugin and the maven plugin have to be updated after each version of Android
         // studio comes out
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/test/android/wrapper.gradle
+++ b/test/android/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.1'
+    gradleVersion = '6.5'
 }

--- a/test/androidx/build.gradle
+++ b/test/androidx/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.1'
+    gradleVersion = '6.5'
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Android Studio 4.0 recommended updating to multiple `build.gradle`
- Gradle 6.1.1 update seems to be required to build with Android Gradle plugin 4.0.0 update, may as well go with Gradle 6.5 update

I think it would be ideal if we could make this update before shipping the new major 9.0.0 release.

### Description
<!-- Describe your changes in detail -->

- update to use Gradle 6.5
- update the following `build.gradle` files as suggested by Android Studio 4.0:
  - `bin/templates/project/app/build.gradle`
  - `bin/templates/project/build.gradle`
  - `framework/build.gradle`

Note that this proposal would effectively overwrite some or all changes from the following PRs:

- #962
- #792

/cc @erisu @breautek

### Testing
<!-- Please describe in detail how you tested your changes. -->

- tested with command-line build from Cordova CLI
- tested with Android Studio 4.0

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~