### PR TITLE
fix: support both adaptive and standard icons at the same time

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -457,6 +457,11 @@ function updateIconResourceForAdaptive (preparedIcons, resourceMap, platformReso
         background = android_icons[density].background;
         foreground = android_icons[density].foreground;
 
+        if (!background || !foreground) {
+            // This icon isn't an adaptive icon, so skip it
+            continue;
+        }
+
         if (background.startsWith('@color')) {
             // Colors Use Case
             backgroundVal = background; // Example: @color/background_foobar_1


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fix: #984 


### Description
<!-- Describe your changes in detail -->
Adds a condition check and the android icons loop for dealing with adaptive icons. If `background` or `foreground` is missing, it skips it.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
