### PR TITLE
chore: set AndroidX off by default

### DIFF
--- a/bin/templates/cordova/lib/config/GradlePropertiesParser.js
+++ b/bin/templates/cordova/lib/config/GradlePropertiesParser.js
@@ -37,8 +37,8 @@ class GradlePropertiesParser {
             'org.gradle.jvmargs': '-Xmx2048m',
 
             // Android X
-            'android.useAndroidX': 'true',
-            'android.enableJetifier': 'true'
+            'android.useAndroidX': 'false',
+            'android.enableJetifier': 'false'
 
             // Shaves another 100ms, but produces a "try at own risk" warning. Not worth it (yet):
             // 'org.gradle.parallel': 'true'


### PR DESCRIPTION
### Motivation, Context & Description

* User plugins are most likely not ready to support AndroidX.
* Users are most likely not be aware of the AndroidX support roadmap and that this major would have been enabled by default but instead to be pushed back for next major.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
