### PR TITLE
fix(pluginHandlers): properly check if path is inside another

### DIFF
--- a/bin/templates/cordova/lib/pluginHandlers.js
+++ b/bin/templates/cordova/lib/pluginHandlers.js
@@ -16,6 +16,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
+var isPathInside = require('is-path-inside');
 var events = require('cordova-common').events;
 var CordovaError = require('cordova-common').CordovaError;
 
@@ -209,12 +210,12 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
     // check that src path is inside plugin directory
     var real_path = fs.realpathSync(src);
     var real_plugin_path = fs.realpathSync(plugin_dir);
-    if (real_path.indexOf(real_plugin_path) !== 0) { throw new CordovaError('File "' + src + '" is located outside the plugin directory "' + plugin_dir + '"'); }
+    if (!isPathInside(real_path, real_plugin_path)) { throw new CordovaError('File "' + src + '" is located outside the plugin directory "' + plugin_dir + '"'); }
 
     dest = path.resolve(project_dir, dest);
 
     // check that dest path is located in project directory
-    if (dest.indexOf(project_dir) !== 0) { throw new CordovaError('Destination "' + dest + '" for source file "' + src + '" is located outside the project'); }
+    if (!isPathInside(dest, project_dir)) { throw new CordovaError('Destination "' + dest + '" for source file "' + src + '" is located outside the project'); }
 
     fs.ensureDirSync(path.dirname(dest));
     if (link) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,6 +1807,11 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "is-path-inside": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cordova-common": "^4.0.1",
     "execa": "^4.0.2",
     "fs-extra": "^9.0.1",
+    "is-path-inside": "^3.0.2",
     "nopt": "^4.0.3",
     "properties-parser": "^0.3.1",
     "which": "^2.0.2"

--- a/spec/unit/pluginHandlers/common.spec.js
+++ b/spec/unit/pluginHandlers/common.spec.js
@@ -108,6 +108,15 @@ describe('common platform handler', function () {
             expect(s).toHaveBeenCalled();
             expect(s).toHaveBeenCalledWith(java_file, resolvedDest);
         });
+
+        it('should handle relative paths when checking for sub paths', () => {
+            fs.outputFileSync(java_file, 'contents');
+            const relativeProjectPath = path.relative(process.cwd(), project_dir);
+
+            expect(() => {
+                copyFile(test_dir, java_file, relativeProjectPath, dest);
+            }).not.toThrow();
+        });
     });
 
     describe('copyNewFile', function () {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The current check for _"Is path A inside path B?"_ relies solely on prefix checking. In general, that is not robust enough.

A real-world example where it fails, is when `Api.createPlatform` is called with a `destination` that is outside of `process.cwd()`. For example a temp dir during a test. This occurred when refactoring E2E tests.

This relies on proper test cleanup as implemented in #1013.

### Description
<!-- Describe your changes in detail -->
Use `is-path-inside` library.


### Testing
<!-- Please describe in detail how you tested your changes. -->
- `Api.createPlatform` now works as expected
- added regression test
  The new test calls `copyFile` with the same arguments as Test#006 and Test#007 with the sole difference that the project dir is relative to the current dir.
