### PR TITLE
refactor: save ProjectBuilder instance in Api instance

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -85,6 +85,8 @@ class Api {
             build: path.join(this.root, 'build'),
             javaSrc: path.join(appMain, 'java')
         };
+
+        this._builder = require('./lib/builders/builders').getBuilder(this.root);
     }
 
     /**
@@ -161,7 +163,7 @@ class Api {
             if (plugin.getFrameworks(this.platform).length === 0) return;
             selfEvents.emit('verbose', 'Updating build files since android plugin contained <framework>');
             // This should pick the correct builder, not just get gradle
-            require('./lib/builders/builders').getBuilder().prepBuildFiles();
+            this._builder.prepBuildFiles();
         }.bind(this))
             // CB-11022 Return truthy value to prevent running prepare after
             .then(() => true);
@@ -193,7 +195,7 @@ class Api {
                 if (plugin.getFrameworks(this.platform).length === 0) return;
 
                 selfEvents.emit('verbose', 'Updating build files since android plugin contained <framework>');
-                require('./lib/builders/builders').getBuilder().prepBuildFiles();
+                this._builder.prepBuildFiles();
             }.bind(this))
             // CB-11022 Return truthy value to prevent running prepare after
             .then(() => true);

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -23,7 +23,6 @@ var nopt = require('nopt');
 
 var Adb = require('./Adb');
 
-var builders = require('./builders/builders');
 var events = require('cordova-common').events;
 const execa = require('execa');
 var CordovaError = require('cordova-common').CordovaError;
@@ -145,7 +144,7 @@ function parseOpts (options, resolvedTarget, projectRoot) {
  */
 module.exports.runClean = function (options) {
     var opts = parseOpts(options, null, this.root);
-    var builder = builders.getBuilder();
+    var builder = this._builder;
 
     return builder.prepEnv(opts).then(function () {
         return builder.clean(opts);
@@ -166,7 +165,7 @@ module.exports.runClean = function (options) {
  */
 module.exports.run = function (options, optResolvedTarget) {
     var opts = parseOpts(options, optResolvedTarget, this.root);
-    var builder = builders.getBuilder();
+    var builder = this._builder;
 
     return builder.prepEnv(opts).then(function () {
         if (opts.prepEnv) {

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -100,7 +100,6 @@ module.exports.run = function (runOptions) {
         });
     }).then(function (resolvedTarget) {
         return new Promise((resolve) => {
-            const builder = require('./builders/builders').getBuilder();
             const buildOptions = require('./build').parseBuildOptions(runOptions, null, self.root);
 
             // Android app bundles cannot be deployed directly to the device
@@ -110,7 +109,7 @@ module.exports.run = function (runOptions) {
                 throw packageTypeErrorMessage;
             }
 
-            resolve(builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));
+            resolve(self._builder.fetchBuildResults(buildOptions.buildType, buildOptions.arch));
         }).then(function (buildResults) {
             if (resolvedTarget && resolvedTarget.isEmulator) {
                 return emulator.wait_for_boot(resolvedTarget.target).then(function () {

--- a/spec/unit/Api.spec.js
+++ b/spec/unit/Api.spec.js
@@ -23,7 +23,6 @@ var common = require('cordova-common');
 var rewire = require('rewire');
 
 var AndroidProject = require('../../bin/templates/cordova/lib/AndroidProject');
-var builders = require('../../bin/templates/cordova/lib/builders/builders');
 
 var PluginInfo = common.PluginInfo;
 
@@ -31,7 +30,7 @@ var FIXTURES = path.join(__dirname, '../e2e/fixtures');
 var FAKE_PROJECT_DIR = path.join(os.tmpdir(), 'plugin-test-project');
 
 describe('addPlugin method', function () {
-    var api, Api, gradleBuilder;
+    var api, Api;
 
     beforeEach(function () {
         Api = rewire('../../bin/templates/cordova/Api');
@@ -49,22 +48,20 @@ describe('addPlugin method', function () {
         Api.__set__('selfEvents.emit', jasmine.createSpy());
 
         api = new Api('android', FAKE_PROJECT_DIR);
-
-        gradleBuilder = jasmine.createSpyObj('gradleBuilder', ['prepBuildFiles']);
-        spyOn(builders, 'getBuilder').and.returnValue(gradleBuilder);
+        spyOn(api._builder, 'prepBuildFiles');
     });
 
     const getPluginFixture = name => new PluginInfo(path.join(FIXTURES, name));
 
     it('Test#001 : should call gradleBuilder.prepBuildFiles for every plugin with frameworks', () => {
         return api.addPlugin(getPluginFixture('cordova-plugin-fake')).then(() => {
-            expect(gradleBuilder.prepBuildFiles).toHaveBeenCalled();
+            expect(api._builder.prepBuildFiles).toHaveBeenCalled();
         });
     });
 
     it('Test#002 : shouldn\'t trigger gradleBuilder.prepBuildFiles for plugins without android frameworks', () => {
         return api.addPlugin(getPluginFixture('cordova-plugin-fake-ios-frameworks')).then(() => {
-            expect(gradleBuilder.prepBuildFiles).not.toHaveBeenCalled();
+            expect(api._builder.prepBuildFiles).not.toHaveBeenCalled();
         });
     });
 });

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -18,6 +18,7 @@
 */
 
 const rewire = require('rewire');
+const builders = require('../../bin/templates/cordova/lib/builders/builders');
 
 describe('run', () => {
     let run;
@@ -58,6 +59,11 @@ describe('run', () => {
                 emulator: emulatorSpyObj,
                 events: eventsSpyObj,
                 getInstallTarget: getInstallTargetSpy
+            });
+
+            // run needs `this` to behave like an Api instance
+            run.run = run.run.bind({
+                _builder: builders.getBuilder('FakeRootPath')
             });
         });
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This reduces dependence on the `builders` module and reduces repetition.

This also facilitates another WIP refactoring I am working on.


### Description
<!-- Describe your changes in detail -->
Create a single `ProjectBuilder` instance during `Api` construction and use that instance everywhere it is accessible.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass.
