### PR TITLE
test(java): fix, improve and move clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   ],
   "scripts": {
     "test": "npm run lint && npm run cover && npm run java-unit-tests",
+    "lint": "eslint . \"bin/**/!(*.*|gitignore)\"",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
     "cover": "nyc jasmine --config=spec/coverage.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",
     "java-unit-tests": "node test/run_java_unit_tests.js",
-    "lint": "eslint . \"bin/**/!(*.*|gitignore)\"",
-    "clean-tests": "node bin/clean_test.js"
+    "clean:java-unit-tests": "node test/clean.js"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",

--- a/test/clean.js
+++ b/test/clean.js
@@ -17,12 +17,16 @@
        under the License.
 */
 
-const fs = require('fs');
+const fs = require('fs-extra');
+const path = require('path');
 
-if (fs.existsSync('./test/gradlew')) {
-    fs.unlinkSync('./test/gradlew');
-}
+/**
+ * This script is to be run manually (e.g. by npm run clean:java-unit-tests) if
+ * you want to upgrade gradlew or test its proper generation.
+ */
 
-if (fs.existsSync('./test/gradlew.bat')) {
-    fs.unlinkSync('./test/gradlew.bat');
+for (const variant of ['android', 'androidx']) {
+    for (const file of ['gradlew', 'gradlew.bat']) {
+        fs.removeSync(path.join(__dirname, variant, file));
+    }
 }


### PR DESCRIPTION
This includes the following changes:

- move this developer-only script to test/ where it conceptually belongs
  - this also prevents it from being distributed with this package
- fix paths for `android` and `androidx` variants
- make paths relative to the script, not to CWD
- use `removeSync` instead of `existsSync` and `existsSync`
- rename npm script to `clean:java-unit-tests` to clarify scope