### PR TITLE
fix: gradle ignore properties

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -330,7 +330,7 @@ class ProjectBuilder {
         var wrapper = path.join(this.root, 'gradlew');
         var args = this.getArgs(opts.buildType === 'debug' ? 'debug' : 'release', opts);
 
-        return execa(wrapper, args, { stdio: 'inherit' })
+        return execa(wrapper, args, { stdio: 'inherit', cwd: path.resolve(this.root) })
             .catch(function (error) {
                 if (error.toString().indexOf('failed to find target with hash string') >= 0) {
                     return check_reqs.check_android_target(error).then(function () {
@@ -346,7 +346,7 @@ class ProjectBuilder {
     clean (opts) {
         const wrapper = path.join(this.root, 'gradlew');
         const args = this.getArgs('clean', opts);
-        return execa(wrapper, args, { stdio: 'inherit' })
+        return execa(wrapper, args, { stdio: 'inherit', cwd: path.resolve(this.root) })
             .then(() => {
                 fs.removeSync(path.join(this.root, 'out'));
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A regression was made during the refactor of `shelljs` to `execa`. The current working directory was the cordova project root, which caused the gradle properties file in the android project folder to be ignored.
fixes #1011 


### Description
<!-- Describe your changes in detail -->

I've specified the cwd in the execa settings in every place that looked appropriate, to be the android project directory (`platforms/android`).

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`
Manually tested my fork.

Easiest way to test is by running `cordova build android`, wait until gradle starts... then run `ps -aux | grep 'Xmx'`

The expected output of the java processes should be something like `/usr/lib/jvm/java-8-openjdk-amd64/bin/java -Xmx2048m`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
