### PR TITLE
WIP: fix: password prompt

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -134,6 +134,7 @@ def doExtractStringFromManifest(name) {
 def doPromptForPassword(msg) {
     if (System.console() == null) {
         def ret = null
+        System.setProperty('java.awt.headless', 'false')
         new SwingBuilder().edt {
             dialog(modal: true, title: 'Enter password', alwaysOnTop: true, resizable: false, locationRelativeTo: null, pack: true, show: true) {
                 vbox {
@@ -146,6 +147,7 @@ def doPromptForPassword(msg) {
                 }
             }
         }
+        System.setProperty('java.awt.headless', 'true')
         if (!ret) {
             throw new GradleException('User canceled build')
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Password prompt when building release builds is broken and crashes with an exception.
Fixes #1021 

### Description
<!-- Describe your changes in detail -->

Adds `System.setProperty("java.awt.headless", "false")` just before building the Swing UI, and resets the property back to true afterwards.

This is required when gradle is set in daemon mode. This [blog](https://www.timroes.de/using-password-prompts-with-gradle-build-files#problem-2--we-dont-have-a-console) explains why.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing and `npm test`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
