### PR TITLE
refactor: Stop suppressing unnecessarily TruelyRandom lints

### DIFF
--- a/framework/src/org/apache/cordova/CordovaBridge.java
+++ b/framework/src/org/apache/cordova/CordovaBridge.java
@@ -114,7 +114,6 @@ public class CordovaBridge {
     /** Called by cordova.js to initialize the bridge. */
     //On old Androids SecureRandom isn't really secure, this is the least of your problems if
     //you're running Android 4.3 and below in 2017
-    @SuppressLint("TrulyRandom")
     int generateBridgeSecret() {
         SecureRandom randGen = new SecureRandom();
         expectedBridgeSecret = randGen.nextInt(Integer.MAX_VALUE);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #638


### Description
<!-- Describe your changes in detail -->
The issue is an older issue that pointed out that `SecureRandom` isn't actually secure on android devices pre 4.4. As it's been not supported for such time, it's safe to remove the `@suppressLint TruelyRandom`, which will provide us insurance that this method is not modified in an insecure manner in the future.


### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
