### PR TITLE
feat: Deprecated onRequestPermissionResult in favour for onRequestPermissionsResult for consistency

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -414,8 +414,23 @@ public class CordovaPlugin {
      * @param requestCode
      * @param permissions
      * @param grantResults
+     * 
+     * @deprecated Use {@link #onRequestPermissionsResult} instead.
      */
+    @Deprecated
     public void onRequestPermissionResult(int requestCode, String[] permissions,
+                                          int[] grantResults) throws JSONException {
+
+    }
+
+    /**
+     * Called by the system when the user grants permissions
+     *
+     * @param requestCode
+     * @param permissions
+     * @param grantResults
+     */
+    public void onRequestPermissionsResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException {
 
     }

--- a/framework/src/org/apache/cordova/PermissionHelper.java
+++ b/framework/src/org/apache/cordova/PermissionHelper.java
@@ -79,7 +79,9 @@ public class PermissionHelper {
         Arrays.fill(requestResults, PackageManager.PERMISSION_GRANTED);
 
         try {
+            // This one is deprecated - see https://github.com/apache/cordova-android/issues/592
             plugin.onRequestPermissionResult(requestCode, permissions, requestResults);
+            plugin.onRequestPermissionsResult(requestCode, permissions, requestResults);
         } catch (JSONException e) {
             LOG.e(LOG_TAG, "JSONException when delivering permissions results", e);
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #592 

### Description
<!-- Describe your changes in detail -->
Deprecates `onRequestPermissionResult` for `onRequestPermissionsResult` for consistency with the [Android API](https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback)

This change is not breaking, but will signal a breaking change some time in the future.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`
Also did a live manual test with the geolocation plugin, both with it using the deprecated method and the new method.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
