### PR TITLE
#1002: Add Null Pointer Checks to prevent Cordova from running on a destroyed activity

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -177,21 +177,23 @@ public class CordovaWebViewImpl implements CordovaWebView {
                 }
 
                 // If timeout, then stop loading and handle error
-                if (loadUrlTimeout == currentLoadUrlTimeout) {
+                if (loadUrlTimeout == currentLoadUrlTimeout && cordova.getActivity() != null) {
                     cordova.getActivity().runOnUiThread(loadError);
                 }
             }
         };
 
         final boolean _recreatePlugins = recreatePlugins;
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            public void run() {
-                if (loadUrlTimeoutValue > 0) {
-                    cordova.getThreadPool().execute(timeoutCheck);
+        if (cordova.getActivity() != null) {
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                public void run() {
+                    if (loadUrlTimeoutValue > 0) {
+                        cordova.getThreadPool().execute(timeoutCheck);
+                    }
+                    engine.loadUrl(url, _recreatePlugins);
                 }
-                engine.loadUrl(url, _recreatePlugins);
-            }
-        });
+            });
+        }
     }
 
 
@@ -238,7 +240,9 @@ public class CordovaWebViewImpl implements CordovaWebView {
             } else {
                 intent.setData(uri);
             }
-            cordova.getActivity().startActivity(intent);
+            if (cordova.getActivity() != null) {
+                cordova.getActivity().startActivity(intent);
+            }
         } catch (android.content.ActivityNotFoundException e) {
             LOG.e(TAG, "Error loading url " + url, e);
         }
@@ -535,11 +539,13 @@ public class CordovaWebViewImpl implements CordovaWebView {
                     public void run() {
                         try {
                             Thread.sleep(2000);
-                            cordova.getActivity().runOnUiThread(new Runnable() {
-                                public void run() {
-                                    pluginManager.postMessage("spinner", "stop");
-                                }
-                            });
+                            if (cordova.getActivity() != null) {
+                                cordova.getActivity().runOnUiThread(new Runnable() {
+                                    public void run() {
+                                        pluginManager.postMessage("spinner", "stop");
+                                    }
+                                });
+                            }
                         } catch (InterruptedException e) {
                         }
                     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See issue and sample MVP/Videos in : https://github.com/apache/cordova-android/issues/1002
Fixes #1002 


### Description
<!-- Describe your changes in detail -->
Added null pointer checks around ```cordova.getActivity()```, to check if the activity hosting Cordova is still alive.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Updated MVP (see issue #1002 ) locally with these changes (also updated gradle but is not pushed in this PR).


### Checklist

- [] I've run the tests to see all new and existing tests pass
-- Wasn't able to
- [] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
