### PR TITLE
Enabling minify to generate ReTrace mapping file

### DIFF
--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -321,6 +321,8 @@ android {
         buildTypes {
             release {
                 signingConfig signingConfigs.release
+                minifyEnabled true
+                proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             }
         }
         addSigningProps(cdvReleaseSigningPropertiesFile, signingConfigs.release)


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/apache/cordova-android/issues/1008


### Description
<!-- Describe your changes in detail -->
New Google Console show warning if your upload file app not contain ReTrace (mapping.txt).

This will help to avoid warning message from new Console Version.

If the user build the app using `bundle` type then the `mapping.txt` file will included, but if the user build the app using `apk` then the `mapping.txt` file should uploaded with `apk`.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
