### PR TITLE
[Frequent Updates] Gradle 6.6.1 & Android Gradle Plugin 4.0.1 & com.jfrog.bintray.gradle 1.8.5

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -303,7 +303,7 @@ class ProjectBuilder {
                 // update/set the distributionUrl in the gradle-wrapper.properties
                 const gradleWrapperPropertiesPath = path.join(self.root, 'gradle/wrapper/gradle-wrapper.properties');
                 const gradleWrapperProperties = createEditor(gradleWrapperPropertiesPath);
-                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.6.1-all.zip';
+                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.5-all.zip';
                 gradleWrapperProperties.set('distributionUrl', distributionUrl);
                 gradleWrapperProperties.save();
 

--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -303,7 +303,7 @@ class ProjectBuilder {
                 // update/set the distributionUrl in the gradle-wrapper.properties
                 const gradleWrapperPropertiesPath = path.join(self.root, 'gradle/wrapper/gradle-wrapper.properties');
                 const gradleWrapperProperties = createEditor(gradleWrapperPropertiesPath);
-                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.5-all.zip';
+                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.6.1-all.zip';
                 gradleWrapperProperties.set('distributionUrl', distributionUrl);
                 gradleWrapperProperties.save();
 

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -53,7 +53,7 @@ buildscript {
     dependencies {
         apply from: '../CordovaLib/cordova.gradle'
 
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         if (cdvHelpers.getConfigPreference('GradlePluginKotlinEnabled', 'false').toBoolean()) {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -89,7 +89,7 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '6.5'
+    gradleVersion = '6.6.1'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -19,7 +19,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -19,13 +19,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,9 +31,9 @@ buildscript {
     dependencies {
         // The gradle plugin and the maven plugin have to be updated after each version of Android
         // studio comes out
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -19,7 +19,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.3.50'
 
     repositories {
         google()

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -19,7 +19,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.10'
 
     repositories {
         google()
@@ -30,7 +30,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/test/android/wrapper.gradle
+++ b/test/android/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.5'
+    gradleVersion = '6.6.1'
 }

--- a/test/androidx/build.gradle
+++ b/test/androidx/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -19,4 +19,3 @@
 wrapper {
     gradleVersion = '6.6.1'
 }
-

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -19,3 +19,4 @@
 wrapper {
     gradleVersion = '6.6.1'
 }
+

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.5'
+    gradleVersion = '6.6.1'
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[To keep Android projects sync with latest Gradle versions and anything related to Gradle]

As Android Gradle plugin release notes https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
Related to Gradle version and Android Gradle Plugin.

Here what the latest versions:

Updates:

- Gradle version to 6.6.1
- Android Gradle Plugin version to 4.0.1
- com.jfrog.bintray.gradle to 1.8.5


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
