### PR TITLE
chore(pkg): remove deprecated no-op field "engineStrict"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "engines": {
     "node": ">=10.0.0"
   },
-  "engineStrict": true,
   "nyc": {
     "include": [
       "bin/lib/**",


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#enginestrict

Related to https://github.com/apache/cordova/issues/55
