### PR TITLE
refactor(lib/run): simplify code to determine install/run target

### DIFF
--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -36,22 +36,7 @@ function getInstallTarget (runOptions) {
     return install_target;
 }
 
-/**
- * Runs the application on a device if available. If no device is found, it will
- *   use a started emulator. If no started emulators are found it will attempt
- *   to start an avd. If no avds are found it will error out.
- *
- * @param   {Object}  runOptions  various run/build options. See Api.js build/run
- *   methods for reference.
- *
- * @return  {Promise}
- */
-module.exports.run = function (runOptions) {
-    runOptions = runOptions || {};
-
-    var self = this;
-    var install_target = getInstallTarget(runOptions);
-
+function resolveInstallTarget (install_target) {
     return Promise.resolve().then(function () {
         if (!install_target) {
             // no target given, deploy to device if available, otherwise use the emulator.
@@ -98,7 +83,26 @@ module.exports.run = function (runOptions) {
                 });
             });
         });
-    }).then(function (resolvedTarget) {
+    });
+}
+
+/**
+ * Runs the application on a device if available. If no device is found, it will
+ *   use a started emulator. If no started emulators are found it will attempt
+ *   to start an avd. If no avds are found it will error out.
+ *
+ * @param   {Object}  runOptions  various run/build options. See Api.js build/run
+ *   methods for reference.
+ *
+ * @return  {Promise}
+ */
+module.exports.run = function (runOptions) {
+    runOptions = runOptions || {};
+
+    var self = this;
+    var install_target = getInstallTarget(runOptions);
+
+    return resolveInstallTarget(install_target).then(function (resolvedTarget) {
         return new Promise((resolve) => {
             const buildOptions = require('./build').parseBuildOptions(runOptions, null, self.root);
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change simplifies the code that determines on which target (device or emulator) the app should be installed and run on.

This refactoring was triggered during a bigger refactoring (still WIP) that has the goal of doing something similar to https://github.com/apache/cordova-electron/pull/142 here.

### Description
<!-- Describe your changes in detail -->
The changes made here should not change the observable behavior of the code beyond changing what is logged to the console. The changes included are:

- factor out `resolveInstallTarget` from `lib/run.run`
- improve unit tests for the `lib/run` module
- convert `resolveInstallTarget` to async/await
- DRY logic in `resolveInstallTarget`

The logic for selecting a install/run target is unchanged. Targets are tried to resolve in this order:

- A connected device matching the given ID (if target ID given)
- Any connected device (if `--emulator` option was not given)
- A started emulator matching the given ID (if target ID given)
- An existing emulator matching the given ID (will be started) (if target ID given)
- An existing emulator that best matches the app's target API (will be started) (if `--device` option was not given)

### Testing
<!-- Please describe in detail how you tested your changes. -->
The unit tests for this module still pass.


