### PR TITLE
fix(prepare): fix pattern used to collect image resources

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -664,7 +664,7 @@ function cleanIcons (projectRoot, projectConfig, platformResourcesDir) {
  */
 function mapImageResources (rootDir, subDir, type, resourceName) {
     const pathMap = {};
-    const pattern = new RegExp(type + '+-.+');
+    const pattern = new RegExp(type + '-.+');
     utils.scanDirectory(path.join(rootDir, subDir), pattern).forEach(function (drawableFolder) {
         const imagePath = path.join(subDir, path.basename(drawableFolder), resourceName);
         pathMap[imagePath] = null;


### PR DESCRIPTION
The pattern contained an additional plus that slipped in during the refactoring done in #842. See [the diff][1] for details.

It's unlikely that this bug actually affects anyone.

[1]: https://github.com/apache/cordova-android/pull/842/commits/09e8248d1f0bbf5c833765e71dbf2343c38cc6bf#diff-26c51bfaa44eff1e46fd61ec3225ec13L640-R650