### PR TITLE
refactor(utils): reduce number of utils

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -239,7 +239,8 @@ function updateProjectAccordingTo (platformConfig, locations) {
     const javaDirectory = path.join(locations.javaSrc, manifestId.replace(/\./g, '/'));
     const javaPattern = /\.java$/;
     const java_files = utils.scanDirectory(javaDirectory, javaPattern, true).filter(function (f) {
-        return utils.grep(f, /extends\s+CordovaActivity/g) !== null;
+        const contents = fs.readFileSync(f, 'utf-8');
+        return /extends\s+CordovaActivity/.test(contents);
     });
 
     if (java_files.length === 0) {

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -20,6 +20,7 @@
 var fs = require('fs-extra');
 var path = require('path');
 const nopt = require('nopt');
+const glob = require('fast-glob');
 var events = require('cordova-common').events;
 var AndroidManifest = require('./AndroidManifest');
 var checkReqs = require('./check_reqs');
@@ -237,8 +238,7 @@ function updateProjectAccordingTo (platformConfig, locations) {
 
     // Java file paths shouldn't be hard coded
     const javaDirectory = path.join(locations.javaSrc, manifestId.replace(/\./g, '/'));
-    const javaPattern = /\.java$/;
-    const java_files = utils.scanDirectory(javaDirectory, javaPattern, true).filter(function (f) {
+    const java_files = glob.sync('**/*.java', { cwd: javaDirectory, absolute: true }).filter(f => {
         const contents = fs.readFileSync(f, 'utf-8');
         return /extends\s+CordovaActivity/.test(contents);
     });
@@ -665,9 +665,8 @@ function cleanIcons (projectRoot, projectConfig, platformResourcesDir) {
  */
 function mapImageResources (rootDir, subDir, type, resourceName) {
     const pathMap = {};
-    const pattern = new RegExp(type + '-.+');
-    utils.scanDirectory(path.join(rootDir, subDir), pattern).forEach(function (drawableFolder) {
-        const imagePath = path.join(subDir, path.basename(drawableFolder), resourceName);
+    glob.sync(type + '-*', { cwd: path.join(rootDir, subDir) }).forEach(drawableFolder => {
+        const imagePath = path.join(subDir, drawableFolder, resourceName);
         pathMap[imagePath] = null;
     });
     return pathMap;

--- a/bin/templates/cordova/lib/utils.js
+++ b/bin/templates/cordova/lib/utils.js
@@ -24,7 +24,6 @@
 // TODO: Perhaps this should live in cordova-common?
 
 const fs = require('fs-extra');
-const path = require('path');
 
 /**
  * Reads, searches, and replaces the found occurences with replacementString and then writes the file back out.
@@ -39,41 +38,4 @@ exports.replaceFileContents = function (file, searchRegex, replacementString) {
     let contents = fs.readFileSync(file).toString();
     contents = contents.replace(searchRegex, replacementString);
     fs.writeFileSync(file, contents);
-};
-
-/**
- * Scans directories and outputs a list of found paths that matches the regex
- *
- * @param {string} directory The starting directory
- * @param {RegExp} regex The search regex
- * @param {boolean} recursive Enables recursion
- * @returns Array<string>
- */
-exports.scanDirectory = function (directory, regex, recursive) {
-    let output = [];
-
-    if (fs.existsSync(directory)) {
-        const items = fs.readdirSync(directory);
-
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            const itemPath = path.join(directory, item);
-            const stats = fs.statSync(itemPath);
-
-            if (regex.test(itemPath)) {
-                output.push(itemPath);
-            }
-
-            if (stats.isDirectory()) {
-                if (recursive) {
-                    output = output.concat(exports.scanDirectory(itemPath, regex, recursive));
-                } else {
-                    // Move onto the next item
-                    continue;
-                }
-            }
-        }
-    }
-
-    return output;
 };

--- a/bin/templates/cordova/lib/utils.js
+++ b/bin/templates/cordova/lib/utils.js
@@ -42,24 +42,6 @@ exports.replaceFileContents = function (file, searchRegex, replacementString) {
 };
 
 /**
- * Reads a file and scans for regex. Returns the line of the first occurence or null if no occurences are found.
- *
- * @param {string} file A file path
- * @param {RegExp} regex A search regex
- * @returns string|null
- */
-exports.grep = function (file, regex) {
-    const contents = fs.readFileSync(file).toString().replace(/\\r/g, '').split('\n');
-    for (let i = 0; i < contents.length; i++) {
-        const line = contents[i];
-        if (regex.test(line)) {
-            return line;
-        }
-    }
-    return null;
-};
-
-/**
  * Scans directories and outputs a list of found paths that matches the regex
  *
  * @param {string} directory The starting directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1325,9 +1325,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "android-versions": "^1.5.0",
     "cordova-common": "^4.0.1",
     "execa": "^4.0.2",
+    "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.1",
     "is-path-inside": "^3.0.2",
     "nopt": "^4.0.3",


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reduce amount of code to maintain.


### Description
<!-- Describe your changes in detail -->
- Inlined `utils.grep` at only point of usage
- Replaced `utils.scanDirectory` with `fast-glob`


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass
