### PR TITLE
refactor(check_reqs): cleanup default Java location detection on Windows

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -193,9 +193,7 @@ module.exports.check_java = function () {
                 }
 
                 if (jdkDir) {
-                    if (!javacPath) {
-                        process.env.PATH += path.delimiter + path.join(jdkDir, 'bin');
-                    }
+                    process.env.PATH += path.delimiter + path.join(jdkDir, 'bin');
                     process.env.JAVA_HOME = path.normalize(jdkDir);
                 }
             }

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -176,24 +176,18 @@ module.exports.check_java = function () {
                     }
                 }
             } else if (module.exports.isWindows()) {
-                const dirs = [
-                    process.env.ProgramFiles,
-                    process.env['ProgramFiles(x86)']
-                ];
+                const { env } = process;
+                const baseDirs = [env.ProgramFiles, env['ProgramFiles(x86)']];
+                const globOpts = { absolute: true, onlyDirectories: true };
+                const flatMap = (arr, f) => [].concat(...arr.map(f));
 
-                let jdkDir;
-                for (const dir of dirs) {
-                    jdkDir = glob.sync('java/jdk*', {
-                        cwd: dir,
-                        absolute: true,
-                        onlyDirectories: true
-                    })[0];
-                    if (jdkDir) break;
-                }
+                const jdkDir = flatMap(baseDirs, cwd =>
+                    glob.sync('java/jdk*', { cwd, ...globOpts })
+                )[0];
 
                 if (jdkDir) {
-                    process.env.PATH += path.delimiter + path.join(jdkDir, 'bin');
-                    process.env.JAVA_HOME = path.normalize(jdkDir);
+                    env.PATH += path.delimiter + path.join(jdkDir, 'bin');
+                    env.JAVA_HOME = path.normalize(jdkDir);
                 }
             }
         }

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -178,8 +178,7 @@ module.exports.check_java = function () {
             } else if (module.exports.isWindows()) {
                 const dirs = [
                     process.env.ProgramFiles,
-                    'C:/Program Files',
-                    'C:/Program Files (x86)'
+                    process.env['ProgramFiles(x86)']
                 ];
 
                 let jdkDir;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I was thrown off by [the regex introduced in #842](https://github.com/apache/cordova-android/pull/842/files#diff-0d1afa0d5c88bdb18fbc6ab9ef7fc4bbe10f7047d387bb2964932dbb6eb8c4b7R47) to match JDK folders. While it matches what we want, it is somehow misleading ("does the dir start with an arbitrary long sequence of `jdk` strings followed by any single character?").


### Description
<!-- Describe your changes in detail -->
- use `fast-glob` to change the implementation back to the more straightforward "give me all directories that start with `jdk`"
- add a unit test for that feature
- remove a useless `if`
- use `ProgramFiles(x86)` env var to cover all bases


### Testing
<!-- Please describe in detail how you tested your changes. -->
New unit test passes
