### PR TITLE
fix(android): allow file access for existing behavior

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -152,6 +152,15 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         settings.setJavaScriptCanOpenWindowsAutomatically(true);
         settings.setLayoutAlgorithm(LayoutAlgorithm.NORMAL);
 
+        /**
+         * https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean)
+         * 
+         * SDK >= 30 has recently set this value to false by default.
+         * It is recommended to turn off this settings To prevent possible security issues targeting Build.VERSION_CODES.Q and earlier.
+         * For existing functionality, this setting is set to true. In a future release, this should be defaulted to false.
+         */
+        settings.setAllowFileAccess(true);
+
         String manufacturer = android.os.Build.MANUFACTURER;
         LOG.d(TAG, "CordovaWebView is running on device made by: " + manufacturer);
 


### PR DESCRIPTION
### Motivation, Context & Description

Fixes SDK 30 related issues

Loading `file://` resources is failing in SDK API 30 because the `setAllowFileAccess` is now defaulted to `false`.

To keep existing behavior, we should set this to `true`, but in future releases we should default it to `false` and have the files loaded not though file. 

### Testing

With the camera plugin, took a photo and loaded the `FILE_URI` in `<img>` tag.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
