### PR TITLE
feat(Adb): list devices _and_ emulators in one go

### DIFF
--- a/bin/templates/cordova/lib/device.js
+++ b/bin/templates/cordova/lib/device.js
@@ -27,8 +27,9 @@ var events = require('cordova-common').events;
 /**
  * Returns a promise for the list of the device ID's found
  */
-module.exports.list = function () {
-    return Adb.devices();
+module.exports.list = async () => {
+    return (await Adb.devices())
+        .filter(id => !id.startsWith('emulator-'));
 };
 
 module.exports.resolveTarget = function (target) {

--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -214,9 +214,9 @@ module.exports.best_image = function () {
     });
 };
 
-// Returns a promise.
-module.exports.list_started = function () {
-    return Adb.devices({ emulators: true });
+exports.list_started = async () => {
+    return (await Adb.devices())
+        .filter(id => id.startsWith('emulator-'));
 };
 
 /*

--- a/spec/unit/device.spec.js
+++ b/spec/unit/device.spec.js
@@ -33,11 +33,11 @@ describe('device', () => {
     });
 
     describe('list', () => {
-        it('should return the list from adb devices', () => {
-            AdbSpy.devices.and.returnValue(Promise.resolve(DEVICE_LIST));
+        it('should return a list of all connected devices', () => {
+            AdbSpy.devices.and.resolveTo(['emulator-5556', '123a76565509e124']);
 
             return device.list().then(list => {
-                expect(list).toEqual(DEVICE_LIST);
+                expect(list).toEqual(['123a76565509e124']);
             });
         });
     });

--- a/spec/unit/emulator.spec.js
+++ b/spec/unit/emulator.spec.js
@@ -205,13 +205,13 @@ describe('emulator', () => {
     });
 
     describe('list_started', () => {
-        it('should call adb devices with the emulators flag', () => {
+        it('should return a list of all online emulators', () => {
             const AdbSpy = jasmine.createSpyObj('Adb', ['devices']);
-            AdbSpy.devices.and.returnValue(Promise.resolve());
+            AdbSpy.devices.and.resolveTo(['emulator-5556', '123a76565509e124']);
             emu.__set__('Adb', AdbSpy);
 
-            return emu.list_started().then(() => {
-                expect(AdbSpy.devices).toHaveBeenCalledWith({ emulators: true });
+            return emu.list_started().then(emus => {
+                expect(emus).toEqual(['emulator-5556']);
             });
         });
     });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Previously `Adb.devices` returned _either_ emulators _or_ devices. This change allows one to get a list of devices _and_ emulators in one go. This enables refactors that improve performance & stability.

This PR is a dependency of #1101.

### Description
<!-- Describe your changes in detail -->
- `Adb.devices` now returns the IDs of _all_ targets in the state `device`
- `device.list` and `emulator.list_started` implement the respective filtering (in a simpler manner than `Adb.devices` did)
- Adapted the unit tests accordingly


### Testing
<!-- Please describe in detail how you tested your changes. -->
- Automated unit tests
- Manual testing
