### PR TITLE
fix(prepare): mapImageResources always returning []

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -665,7 +665,8 @@ function cleanIcons (projectRoot, projectConfig, platformResourcesDir) {
  */
 function mapImageResources (rootDir, subDir, type, resourceName) {
     const pathMap = {};
-    glob.sync(type + '-*', { cwd: path.join(rootDir, subDir) }).forEach(drawableFolder => {
+    const globOptions = { cwd: path.join(rootDir, subDir), onlyDirectories: true };
+    glob.sync(type + '-*', globOptions).forEach(drawableFolder => {
         const imagePath = path.join(subDir, drawableFolder, resourceName);
         pathMap[imagePath] = null;
     });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I broke `mapImageResources` when refactoring it to use globbing in #1085. The problem is, that `fast-glob` will only match files by default while we are looking for directories here.


### Description
<!-- Describe your changes in detail -->
Pass `onlyDirectories` option to `fast-glob`.
