### PR TITLE
breaking: remove deprecated AppCache settings

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -194,12 +194,6 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         // Enable built-in geolocation
         settings.setGeolocationEnabled(true);
 
-        // Enable AppCache
-        // Fix for CB-2282
-        settings.setAppCacheMaxSize(5 * 1048576);
-        settings.setAppCachePath(databasePath);
-        settings.setAppCacheEnabled(true);
-
         // Fix for CB-1405
         // Google issue 4641
         String defaultUserAgent = settings.getUserAgentString();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The App Cache API will soon be removed: https://web.dev/appcache-removal/

The app cache methods for  `WebSettings` are another thing that get deprecated for API level 30: https://developer.android.com/reference/android/webkit/WebSettings#setAppCacheEnabled(boolean)

### Description
<!-- Describe your changes in detail -->

The app cache web API is considered deprecated and will get removed from Chrome/the Android webview around April 2021. Service workers are considered an alternative.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Unit tests


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
