### PR TITLE
fix: add not null checks to prevent running on destroyed activity

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -176,22 +176,24 @@ public class CordovaWebViewImpl implements CordovaWebView {
                     e.printStackTrace();
                 }
 
-                // If timeout, then stop loading and handle error
-                if (loadUrlTimeout == currentLoadUrlTimeout) {
+                // If timeout, then stop loading and handle error (if activity still exists)
+                if (loadUrlTimeout == currentLoadUrlTimeout && cordova.getActivity() != null) {
                     cordova.getActivity().runOnUiThread(loadError);
                 }
             }
         };
 
-        final boolean _recreatePlugins = recreatePlugins;
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            public void run() {
-                if (loadUrlTimeoutValue > 0) {
-                    cordova.getThreadPool().execute(timeoutCheck);
+        if (cordova.getActivity() != null) {
+            final boolean _recreatePlugins = recreatePlugins;
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                public void run() {
+                    if (loadUrlTimeoutValue > 0) {
+                        cordova.getThreadPool().execute(timeoutCheck);
+                    }
+                    engine.loadUrl(url, _recreatePlugins);
                 }
-                engine.loadUrl(url, _recreatePlugins);
-            }
-        });
+            });
+        }
     }
 
 
@@ -238,7 +240,9 @@ public class CordovaWebViewImpl implements CordovaWebView {
             } else {
                 intent.setData(uri);
             }
-            cordova.getActivity().startActivity(intent);
+            if (cordova.getActivity() != null) {
+                cordova.getActivity().startActivity(intent);
+            }
         } catch (android.content.ActivityNotFoundException e) {
             LOG.e(TAG, "Error loading url " + url, e);
         }
@@ -553,11 +557,13 @@ public class CordovaWebViewImpl implements CordovaWebView {
                     public void run() {
                         try {
                             Thread.sleep(2000);
-                            cordova.getActivity().runOnUiThread(new Runnable() {
-                                public void run() {
-                                    pluginManager.postMessage("spinner", "stop");
-                                }
-                            });
+                            if (cordova.getActivity() != null) {
+                                cordova.getActivity().runOnUiThread(new Runnable() {
+                                    public void run() {
+                                        pluginManager.postMessage("spinner", "stop");
+                                    }
+                                });
+                            }
                         } catch (InterruptedException e) {
                         }
                     }

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -179,6 +179,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
                 // If timeout, then stop loading and handle error (if activity still exists)
                 if (loadUrlTimeout == currentLoadUrlTimeout && cordova.getActivity() != null) {
                     cordova.getActivity().runOnUiThread(loadError);
+                } else if (cordova.getActivity() == null) {
+                    LOG.d(TAG, "Cordova activity does not exist.");
                 }
             }
         };
@@ -193,6 +195,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
                     engine.loadUrl(url, _recreatePlugins);
                 }
             });
+        } else {
+            LOG.d(TAG, "Cordova activity does not exist.");
         }
     }
 
@@ -242,6 +246,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
             }
             if (cordova.getActivity() != null) {
                 cordova.getActivity().startActivity(intent);
+            } else {
+                LOG.d(TAG, "Cordova activity does not exist.");
             }
         } catch (android.content.ActivityNotFoundException e) {
             LOG.e(TAG, "Error loading url " + url, e);
@@ -563,6 +569,8 @@ public class CordovaWebViewImpl implements CordovaWebView {
                                         pluginManager.postMessage("spinner", "stop");
                                     }
                                 });
+                            } else {
+                                LOG.d(TAG, "Cordova activity does not exist.");
                             }
                         } catch (InterruptedException e) {
                         }


### PR DESCRIPTION
### Platforms affected
Android 

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See issue and sample MVP/Videos in : https://github.com/apache/cordova-android/issues/1002
Fixes #1002 

### Description
<!-- Describe your changes in detail -->
Added null pointer checks around ```cordova.getActivity()```, to check if the activity hosting Cordova is still alive.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Updated MVP (see issue #1002 ) locally with these changes (also updated gradle but is not pushed in this PR).


### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
