### PR TITLE
fix: optional arch parameter

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -55,7 +55,7 @@ const outputFileComparator = compareByAll([
  * @param {'debug' | 'release'} buildType
  * @param {{arch?: string}} options
  */
-function findOutputFiles (bundleType, buildType, { arch }) {
+function findOutputFiles (bundleType, buildType, { arch } = {}) {
     let files = glob.sync(`**/*.${bundleType}`, {
         absolute: true,
         cwd: path.resolve(this[`${bundleType}Dir`], buildType)


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Building bundles broke at some point between 9.0.0 and nightly.

Fixes https://github.com/apache/cordova-android/issues/1151

### Description
<!-- Describe your changes in detail -->

When building bundles, the `arch` setting is not supplied. This is provided through an options parameter, but you cannot deconstruct a object that doesn't exists. Therefore, I made the options parameter default to `{}`. The `arch` option remains optional.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
