### PR TITLE
fix: restore key event handlers when DOM element is fullscreen

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -255,7 +255,12 @@ public class CordovaWebViewImpl implements CordovaWebView {
 
         @Override
         public boolean dispatchKeyEvent(KeyEvent event) {
-            return engine.getView().dispatchKeyEvent(event);
+            boolean ret = engine.getView().dispatchKeyEvent(event);
+            if (! ret) {
+                // If the engine didn't handle the event, handle it normally.
+                ret = super.dispatchKeyEvent(event);
+            }
+            return ret;
         }
     }
 

--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -256,7 +256,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
         @Override
         public boolean dispatchKeyEvent(KeyEvent event) {
             boolean ret = engine.getView().dispatchKeyEvent(event);
-            if (! ret) {
+            if (!ret) {
                 // If the engine didn't handle the event, handle it normally.
                 ret = super.dispatchKeyEvent(event);
             }


### PR DESCRIPTION
Make sure to call dispatchKeyEvent from base class in WrapperView, if the event hasn't been handled by the engine.

Fixes #1156
