### PR TITLE
feat: overload PluginEntry constructor to set onload property

### DIFF
--- a/framework/src/org/apache/cordova/PluginEntry.java
+++ b/framework/src/org/apache/cordova/PluginEntry.java
@@ -47,11 +47,19 @@ public final class PluginEntry {
 
     /**
      * Constructs with a CordovaPlugin already instantiated.
+     *
+     * @param service               The name of the service
+     * @param pluginClass           The plugin class name
      */
     public PluginEntry(String service, CordovaPlugin plugin) {
         this(service, plugin.getClass().getName(), true, plugin);
     }
 
+    /**
+     * @param service               The name of the service
+     * @param plugin                The CordovaPlugin already instantiated
+     * @param onload                Create plugin object when HTML page is loaded
+     */
     public PluginEntry(String service, CordovaPlugin plugin, boolean onload) {
         this(service, plugin.getClass().getName(), onload, plugin);
     }
@@ -65,6 +73,12 @@ public final class PluginEntry {
         this(service, pluginClass, onload, null);
     }
 
+    /**
+     * @param service               The name of the service
+     * @param pluginClass           The plugin class name
+     * @param onload                Create plugin object when HTML page is loaded
+     * @param plugin                The CordovaPlugin already instantiated
+     */
     private PluginEntry(String service, String pluginClass, boolean onload, CordovaPlugin plugin) {
         this.service = service;
         this.pluginClass = pluginClass;

--- a/framework/src/org/apache/cordova/PluginEntry.java
+++ b/framework/src/org/apache/cordova/PluginEntry.java
@@ -52,6 +52,10 @@ public final class PluginEntry {
         this(service, plugin.getClass().getName(), true, plugin);
     }
 
+    public PluginEntry(String service, CordovaPlugin plugin, boolean onload) {
+        this(service, plugin.getClass().getName(), onload, plugin);
+    }
+
     /**
      * @param service               The name of the service
      * @param pluginClass           The plugin class name


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
resolves https://github.com/apache/cordova-android/issues/1164
This will allow to specify already instantiated PluginEntries with `onload = false`. 
Which will stop Cordova from initialising them multiple time and fix issue on AGP 4.1.2 that enables all asserts in debug 

Is setting onLoad false valid option here?

### Testing
have a look at test exposing issue:
https://github.com/jblejder/cordova-android/pull/1


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
