### PR TITLE
remove jcenter from gradles

### DIFF
--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -21,7 +21,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -47,7 +47,8 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven {url 'https://plugins.gradle.org/m2/' }
+        // org.jetbrains.trove4j:trove4j:20160824.
+        maven { url 'https://repo.appspace.com/list/plugins-release/' }
     }
 
     dependencies {

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -45,9 +45,9 @@ buildscript {
     }
 
     repositories {
-        mavenCentral()
         google()
-        jcenter()
+        mavenCentral()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -84,7 +84,7 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 }
 

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -22,7 +22,8 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        // org.jetbrains.trove4j:trove4j:20160824.
+        maven { url 'https://repo.appspace.com/list/plugins-release/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -35,7 +35,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
     }
 
     //This replaces project.properties w.r.t. build settings

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,7 +31,7 @@ ext {
 buildscript {
     repositories {
         google()
-        jcenter()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -46,7 +46,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 }
 

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -196,7 +196,8 @@ ext {
 
 buildscript {
     repositories {
-        jcenter()
+        // com.g00fy2:versioncompare:1.3.4@jar.
+        maven { url 'https://repo.appspace.com/list/plugins-release/' }
     }
 
     dependencies {

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -16,7 +16,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 }
 

--- a/test/android/app/build.gradle
+++ b/test/android/app/build.gradle
@@ -57,5 +57,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
-    jcenter()
+    mavenCentral()
+    maven {url 'https://plugins.gradle.org/m2/' }
 }

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -38,7 +38,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 }
 

--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -56,5 +56,6 @@ dependencies {
     })
 }
 repositories {
-    jcenter()
+    mavenCentral()
+    maven {url 'https://plugins.gradle.org/m2/' }
 }

--- a/test/androidx/build.gradle
+++ b/test/androidx/build.gradle
@@ -21,7 +21,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -35,7 +35,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven {url 'https://plugins.gradle.org/m2/' }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
JFrog will sunset Bintray, JCenter, GoCenter, and ChartCenter on May 1st 2021 and it will affect cordova-android project. 
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
This PR removes jcenter repository from all gradles and replace it with maven. 


### Testing
<!-- Please describe in detail how you tested your changes. -->
Create the android project and check if there is no jcenter in gradle files and it is built successfully.
```
npx cordova create SampleApp com.sample.app SampleApp
cd SampleApp/
npx cordova platform add android
```
### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
