### PR TITLE
feat(android-studio): display app name as project name

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -206,7 +206,7 @@ function validateProjectName (project_name) {
  * https://github.com/apache/cordova-android/issues/1172
  */
 function writeNameForAndroidStudio (project_path, project_name) {
-    var ideaPath = path.join(project_path, '.idea');
+    const ideaPath = path.join(project_path, '.idea');
     fs.ensureDirSync(ideaPath);
     fs.writeFileSync(path.join(ideaPath, '.name'), project_name);
 }

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -205,7 +205,7 @@ function validateProjectName (project_name) {
  *
  * https://github.com/apache/cordova-android/issues/1172
  */
-function writeNameForAndroidStudio(project_path, project_name) {
+function writeNameForAndroidStudio (project_path, project_name) {
     var ideaPath = path.join(project_path, '.idea');
     fs.ensureDirSync(ideaPath);
     fs.writeFileSync(path.join(ideaPath, '.name'), project_name);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -36,6 +36,7 @@ exports.copyScripts = copyScripts;
 exports.copyBuildRules = copyBuildRules;
 exports.writeProjectProperties = writeProjectProperties;
 exports.prepBuildFiles = prepBuildFiles;
+exports.writeNameForAndroidStudio = writeNameForAndroidStudio;
 
 function getFrameworkDir (projectPath, shared) {
     return shared ? path.join(ROOT, 'framework') : path.join(projectPath, 'CordovaLib');
@@ -198,6 +199,19 @@ function validateProjectName (project_name) {
 }
 
 /**
+ * Write the name of the app in "platforms/android/.idea/.name" so that Android Studio can show that name in the
+ * project listing. This is helpful to quickly look in the Android Studio listing if there are so many projects in
+ * Android Studio.
+ *
+ * https://github.com/apache/cordova-android/issues/1172
+ */
+function writeNameForAndroidStudio(project_path, project_name) {
+    var ideaPath = path.join(project_path, '.idea');
+    fs.ensureDirSync(ideaPath);
+    fs.writeFileSync(path.join(ideaPath, '.name'), project_name);
+}
+
+/**
  * Creates an android application with the given options.
  *
  * @param   {String}  project_path  Path to the new Cordova android project.
@@ -294,6 +308,7 @@ exports.create = function (project_path, config, options, events) {
             // Link it to local android install.
             exports.writeProjectProperties(project_path, target_api);
             exports.prepBuildFiles(project_path);
+            exports.writeNameForAndroidStudio(project_path, project_name);
             events.emit('log', generateDoneMessage('create', options.link));
         }).then(() => project_path);
 };

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -132,6 +132,7 @@ describe('create', function () {
             spyOn(create, 'copyBuildRules');
             spyOn(create, 'writeProjectProperties');
             spyOn(create, 'prepBuildFiles');
+            spyOn(create, 'writeNameForAndroidStudio');
             revert_manifest_mock = create.__set__('AndroidManifest', Manifest_mock);
             spyOn(fs, 'existsSync').and.returnValue(false);
             spyOn(fs, 'copySync');
@@ -298,6 +299,25 @@ describe('create', function () {
                     expect(create.prepBuildFiles).toHaveBeenCalledWith(project_path);
                 });
             });
+        });
+    });
+
+    describe('writeNameForAndroidStudio', () => {
+        var project_path = path.join('some', 'path');
+
+        it('should call ensureDirSync with path', () => {
+            spyOn(fs, 'ensureDirSync');
+            spyOn(fs, 'writeFileSync');
+            create.writeNameForAndroidStudio(project_path, 'Test Android');
+            expect(fs.ensureDirSync).toHaveBeenCalledWith(path.join(project_path, '.idea'));
+        });
+
+        it('should call writeFileSync with content', () => {
+            var appName = 'Test Cordova';
+            spyOn(fs, 'ensureDirSync');
+            spyOn(fs, 'writeFileSync');
+            create.writeNameForAndroidStudio(project_path, appName);
+            expect(fs.writeFileSync).toHaveBeenCalledWith(path.join(project_path, '.idea', '.name'), appName);
         });
     });
 });

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -303,19 +303,20 @@ describe('create', function () {
     });
 
     describe('writeNameForAndroidStudio', () => {
-        var project_path = path.join('some', 'path');
+        const project_path = path.join('some', 'path');
+        const appName = 'Test Cordova';
 
-        it('should call ensureDirSync with path', () => {
+        beforeEach(function () {
             spyOn(fs, 'ensureDirSync');
             spyOn(fs, 'writeFileSync');
-            create.writeNameForAndroidStudio(project_path, 'Test Android');
+        });
+
+        it('should call ensureDirSync with path', () => {
+            create.writeNameForAndroidStudio(project_path, appName);
             expect(fs.ensureDirSync).toHaveBeenCalledWith(path.join(project_path, '.idea'));
         });
 
         it('should call writeFileSync with content', () => {
-            var appName = 'Test Cordova';
-            spyOn(fs, 'ensureDirSync');
-            spyOn(fs, 'writeFileSync');
             create.writeNameForAndroidStudio(project_path, appName);
             expect(fs.writeFileSync).toHaveBeenCalledWith(path.join(project_path, '.idea', '.name'), appName);
         });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context

Closes #1172 


### Testing

Tried locally but couldn't run (probably I have to read it more carefully).


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
