### PR TITLE
fix: unit-test failure

### DIFF
--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -255,20 +255,20 @@ describe('check_reqs', function () {
                 });
             });
 
-            it('with ANDROID_SDK_ROOT / without ANDROID_HOME', () => {
+            it('with ANDROID_SDK_ROOT / without ANDROID_HOME', async () => {
                 process.env.ANDROID_SDK_ROOT = '/android/sdk/root';
-                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
+                await expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
             });
 
-            it('with ANDROID_SDK_ROOT / with ANDROID_HOME', () => {
+            it('with ANDROID_SDK_ROOT / with ANDROID_HOME', async () => {
                 process.env.ANDROID_SDK_ROOT = '/android/sdk/root';
                 process.env.ANDROID_HOME = '/android/sdk/home';
-                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
+                await expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/root/bin/gradle');
             });
 
-            it('without ANDROID_SDK_ROOT / with ANDROID_HOME', () => {
+            it('without ANDROID_SDK_ROOT / with ANDROID_HOME', async () => {
                 process.env.ANDROID_HOME = '/android/sdk/home';
-                expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/home/bin/gradle');
+                await expectAsync(check_reqs.check_gradle()).toBeResolvedTo('/android/sdk/home/bin/gradle');
             });
 
             it('without ANDROID_SDK_ROOT / without ANDROID_HOME', () => {

--- a/spec/unit/prepare.spec.js
+++ b/spec/unit/prepare.spec.js
@@ -826,17 +826,17 @@ describe('prepare', () => {
             api = new Api();
         });
 
-        it('runs without arguments', () => {
-            expectAsync(
+        it('runs without arguments', async () => {
+            await expectAsync(
                 api.prepare(cordovaProject, options).then(() => {
                     expect(gradlePropertiesParserSpy).toHaveBeenCalledWith({});
                 })
             ).toBeResolved();
         });
 
-        it('runs with jvmargs', () => {
+        it('runs with jvmargs', async () => {
             options.options.argv = ['--jvmargs=-Xmx=4096m'];
-            expectAsync(
+            await expectAsync(
                 api.prepare(cordovaProject, options).then(() => {
                     expect(gradlePropertiesParserSpy).toHaveBeenCalledWith({
                         'org.gradle.jvmargs': '-Xmx=4096m'


### PR DESCRIPTION
### Motivation and Context

`expectAsync` need `await`. With out await, tests can fail.

### Description

- Added `await` & `async` where needed.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
