### PR TITLE
fix(regression): Cannot read version of undefined caused by Java refactor

### DIFF
--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -135,6 +135,8 @@ module.exports.check_gradle = function () {
 
 /**
  * Checks for the java installation and correct version
+ *
+ * Despite the name, it should return the Java version value, it's used by the Cordova CLI.
  */
 module.exports.check_java = async function () {
     const javaVersion = await java.getVersion();
@@ -145,6 +147,8 @@ module.exports.check_java = async function () {
             'Check your ANDROID_SDK_ROOT / JAVA_HOME / PATH environment variables.'
         );
     }
+
+    return javaVersion;
 };
 
 // Returns a promise.

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -56,6 +56,14 @@ describe('check_reqs', function () {
 
             await expectAsync(check_reqs.check_java()).toBeRejectedWithError(CordovaError, /Requirements check failed for JDK 9999.9999.9999! Detected version: 1.8.0/);
         });
+
+        it('should return the version', async () => {
+            check_reqs.__set__({
+                java: { getVersion: async () => ({ version: '1.8.0' }) }
+            });
+
+            await expectAsync(check_reqs.check_java()).toBeResolvedTo({ version: '1.8.0' });
+        });
     });
 
     describe('check_android', function () {


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/apache/cordova-android/pull/1130#discussion_r563597125 decision caused a regression in the `cordova requirements` command, it turns out, `check_java` method **must** return a value.

Fixes https://github.com/apache/cordova-android/issues/1180

### Description
<!-- Describe your changes in detail -->

Return the java version in `check_java`

### Testing
<!-- Please describe in detail how you tested your changes. -->

Added a unit test to ensure `check_java` returns a value and ensured all unit tests passes.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
