### PR TITLE
fix: copy repositories.gradle to project on create

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -72,6 +72,7 @@ function copyJsAndLibrary (projectPath, shared, projectName, isLegacy) {
         fs.copySync(path.join(ROOT, 'framework', 'project.properties'), path.join(nestedCordovaLibPath, 'project.properties'));
         fs.copySync(path.join(ROOT, 'framework', 'build.gradle'), path.join(nestedCordovaLibPath, 'build.gradle'));
         fs.copySync(path.join(ROOT, 'framework', 'cordova.gradle'), path.join(nestedCordovaLibPath, 'cordova.gradle'));
+        fs.copySync(path.join(ROOT, 'framework', 'repositories.gradle'), path.join(nestedCordovaLibPath, 'repositories.gradle'));
         fs.copySync(path.join(ROOT, 'framework', 'src'), path.join(nestedCordovaLibPath, 'src'));
     }
 }
@@ -126,6 +127,8 @@ function copyBuildRules (projectPath, isLegacy) {
     } else {
         fs.copySync(path.join(srcDir, 'build.gradle'), path.join(projectPath, 'build.gradle'));
         fs.copySync(path.join(srcDir, 'app', 'build.gradle'), path.join(projectPath, 'app', 'build.gradle'));
+        fs.copySync(path.join(srcDir, 'app', 'repositories.gradle'), path.join(projectPath, 'app', 'repositories.gradle'));
+        fs.copySync(path.join(srcDir, 'repositories.gradle'), path.join(projectPath, 'repositories.gradle'));
         fs.copySync(path.join(srcDir, 'wrapper.gradle'), path.join(projectPath, 'wrapper.gradle'));
     }
 }


### PR DESCRIPTION
### Motivation, Context & Description

Build fails because the `repositories.gradle` files are not copied into the project during the initial project creation.

### Testing

- `cordova build android`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
