### PR TITLE
Revert "feat: upgrade gradle@6.8.3"

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -268,7 +268,7 @@ class ProjectBuilder {
                 // update/set the distributionUrl in the gradle-wrapper.properties
                 const gradleWrapperPropertiesPath = path.join(self.root, 'gradle/wrapper/gradle-wrapper.properties');
                 const gradleWrapperProperties = createEditor(gradleWrapperPropertiesPath);
-                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.8.3-all.zip';
+                const distributionUrl = process.env.CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL || 'https://services.gradle.org/distributions/gradle-6.6.1-all.zip';
                 gradleWrapperProperties.set('distributionUrl', distributionUrl);
                 gradleWrapperProperties.save();
 

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -84,7 +84,7 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '6.8.3'
+    gradleVersion = '6.6.1'
 }
 
 // Configuration properties. Set these via environment variables, build-extras.gradle, or gradle.properties.

--- a/test/android/wrapper.gradle
+++ b/test/android/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '6.6.1'
 }

--- a/test/androidx/wrapper.gradle
+++ b/test/androidx/wrapper.gradle
@@ -17,5 +17,5 @@
 */
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '6.6.1'
 }


### PR DESCRIPTION
Reverts apache/cordova-android#1174

Sorry, it seems some people do not trust that this follows semver and feels it may not fit a minor release.
We will revert this PR and would like it resubmitted for the major release.