### PR TITLE
feat: allow appcompat version to be configurable

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -61,6 +61,7 @@ module.exports.prepare = function (cordovaProject, options) {
     const targetSdkVersion = this._config.getPreference('android-targetSdkVersion', 'android');
     const isGradlePluginKotlinEnabled = this._config.getPreference('GradlePluginKotlinEnabled', 'android');
     const gradlePluginKotlinCodeStyle = this._config.getPreference('GradlePluginKotlinCodeStyle', 'android');
+    const androidXAppCompatVersion = this._config.getPreference('AndroidXAppCompatVersion', 'android');
 
     const gradlePropertiesUserConfig = {};
     if (minSdkVersion) gradlePropertiesUserConfig.cdvMinSdkVersion = minSdkVersion;
@@ -69,6 +70,10 @@ module.exports.prepare = function (cordovaProject, options) {
     if (args.jvmargs) gradlePropertiesUserConfig['org.gradle.jvmargs'] = args.jvmargs;
     if (isGradlePluginKotlinEnabled) {
         gradlePropertiesUserConfig['kotlin.code.style'] = gradlePluginKotlinCodeStyle || 'official';
+    }
+
+    if (androidXAppCompatVersion) {
+        gradlePropertiesUserConfig.cdvAndroidXAppCompatVersion = androidXAppCompatVersion;
     }
 
     const gradlePropertiesParser = new GradlePropertiesParser(this.locations.root);

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -137,6 +137,11 @@ ext {
         cdvBuildArch = null
     }
 
+    // Sets the default cdvAndroidXAppCompatVersion to the given value.
+    if (!project.hasProperty('cdvAndroidXAppCompatVersion')) {
+        cdvAndroidXAppCompatVersion = null
+    }
+
     // Plugin gradle extensions can append to this to have code run at the end.
     cdvPluginPostBuildExtras = []
 }
@@ -185,6 +190,8 @@ ext.cdvTargetSdkVersion = cdvTargetSdkVersion == null ? defaultTargetSdkVersion 
 
 ext.cdvVersionCode = cdvVersionCode == null ? null : Integer.parseInt('' + cdvVersionCode)
 
+ext.cdvAndroidXAppCompatVersion = cdvAndroidXAppCompatVersion == null ? defaultAndroidXAppCompatVersion : cdvAndroidXAppCompatVersion
+
 def computeBuildTargetName(debugBuild) {
     def ret = 'assemble'
     if (cdvBuildMultipleApks && cdvBuildArch) {
@@ -219,6 +226,7 @@ task cdvPrintProps {
         println('cdvDebugSigningPropertiesFile=' + cdvDebugSigningPropertiesFile)
         println('cdvBuildArch=' + cdvBuildArch)
         println('computedVersionCode=' + android.defaultConfig.versionCode)
+        println('cdvAndroidXAppCompatVersion=' + cdvAndroidXAppCompatVersion)
         android.productFlavors.each { flavor ->
             println('computed' + flavor.name.capitalize() + 'VersionCode=' + flavor.versionCode)
         }
@@ -339,7 +347,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "androidx.appcompat:appcompat:$cdvAndroidXAppCompatVersion"
 
     if (cdvHelpers.getConfigPreference('GradlePluginKotlinEnabled', 'false').toBoolean()) {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -40,6 +40,7 @@ allprojects {
       defaultMinSdkVersion=22 //Integer - Minimum requirement is Android 5.1
       defaultTargetSdkVersion=30 //Integer - We ALWAYS target the latest by default
       defaultCompileSdkVersion=30 //Integer - We ALWAYS compile with the latest by default
+      defaultAndroidXAppCompatVersion="1.2.0" //String - We ALWAYS compile with the latest stable by default
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -26,6 +26,13 @@ ext {
     } else {
         cdvMinSdkVersion = 22; // current Cordova's default
     }
+
+    if (project.hasProperty('cdvAndroidXAppCompatVersion')) {
+        cdvAndroidXAppCompatVersion = cdvAndroidXAppCompatVersion
+        println '[Cordova] cdvAndroidXAppCompatVersion is overridden, try it at your own risk.'
+    } else {
+        cdvAndroidXAppCompatVersion = "1.2.0"; // current Cordova's default
+    }
 }
 
 buildscript {
@@ -123,7 +130,7 @@ task sourcesJar(type: Jar) {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "androidx.appcompat:appcompat:$cdvAndroidXAppCompatVersion"
 }
 
 artifacts {


### PR DESCRIPTION
### Motivation and Context

Allow the AndroidX AppCompat library version to be configurable.

### Description

Added a `config.xml` preference to allow users to override the default version at their own risk.

**Example Config:**

```xml
<platform name="android">
    <preference name="AndroidXAppCompatVersion" value="1.3.0-rc01" />
</platform>
```

### Testing

- npm t
- `cordova build android` with no change
- `cordova build android` with changes using the example config above that sets the version to `1.3.0-rc01`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Will update the documentation here (https://github.com/apache/cordova-docs/issues/1169)
