### PR TITLE
feat: unify `create` default values & stop project name transform

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -219,7 +219,7 @@ exports.create = function (project_path, config, options, events) {
 
     var package_name = config.android_packageName() || config.packageName() || 'my.cordova.project';
     var project_name = config.name()
-        ? config.name().replace(/[^\w.]/g, '_') : 'CordovaExample';
+        ? config.name().replace(/[^\w.]/g, '_') : 'Hello Cordova';
 
     var safe_activity_name = config.android_activityName() || options.activityName || 'MainActivity';
     var target_api = check_reqs.get_target(project_path);

--- a/lib/create.js
+++ b/lib/create.js
@@ -228,7 +228,7 @@ exports.create = function (project_path, config, options, events) {
         .then(function () {
             return exports.validateProjectName(project_name);
         }).then(function () {
-        // Log the given values for the project
+            // Log the given values for the project
             events.emit('log', 'Creating Cordova project for the Android platform:');
             events.emit('log', '\tPath: ' + project_path);
             events.emit('log', '\tPackage: ' + package_name);

--- a/lib/create.js
+++ b/lib/create.js
@@ -211,7 +211,7 @@ exports.create = function (project_path, config, options, events) {
     options = options || {};
 
     // Set default values for path, package and name
-    project_path = path.relative(process.cwd(), (project_path || 'CordovaExample'));
+    project_path = path.relative(process.cwd(), project_path);
     // Check if project already exists
     if (fs.existsSync(project_path)) {
         return Promise.reject(new CordovaError('Project already exists! Delete and recreate'));

--- a/lib/create.js
+++ b/lib/create.js
@@ -218,8 +218,7 @@ exports.create = function (project_path, config, options, events) {
     }
 
     var package_name = config.android_packageName() || config.packageName() || 'io.cordova.helloCordova';
-    var project_name = config.name()
-        ? config.name().replace(/[^\w.]/g, '_') : 'Hello Cordova';
+    var project_name = config.name() || 'Hello Cordova';
 
     var safe_activity_name = config.android_activityName() || options.activityName || 'MainActivity';
     var target_api = check_reqs.get_target(project_path);

--- a/lib/create.js
+++ b/lib/create.js
@@ -217,7 +217,7 @@ exports.create = function (project_path, config, options, events) {
         return Promise.reject(new CordovaError('Project already exists! Delete and recreate'));
     }
 
-    var package_name = config.android_packageName() || config.packageName() || 'my.cordova.project';
+    var package_name = config.android_packageName() || config.packageName() || 'io.cordova.helloCordova';
     var project_name = config.name()
         ? config.name().replace(/[^\w.]/g, '_') : 'Hello Cordova';
 

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -176,10 +176,10 @@ describe('create', function () {
                 });
             });
 
-            it('should replace any non-word characters (including unicode and spaces) in the ConfigParser-provided project name with underscores', () => {
+            it('should keep non-word characters (including unicode and spaces) in the ConfigParser-provided project name', () => {
                 config_mock.name.and.returnValue('応応応応 hello 用用用用');
                 return create.create(project_path, config_mock, {}, events_mock).then(() => {
-                    expect(create.validateProjectName).toHaveBeenCalledWith('_____hello_____');
+                    expect(create.validateProjectName).toHaveBeenCalledWith('応応応応 hello 用用用用');
                 });
             });
 

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -162,10 +162,10 @@ describe('create', function () {
                 });
             });
 
-            it('should have a default project name of CordovaExample', () => {
+            it('should have a default project name of Hello Cordova', () => {
                 config_mock.name.and.returnValue(undefined);
                 return create.create(project_path, config_mock, {}, events_mock).then(() => {
-                    expect(create.validateProjectName).toHaveBeenCalledWith('CordovaExample');
+                    expect(create.validateProjectName).toHaveBeenCalledWith('Hello Cordova');
                 });
             });
 

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -148,10 +148,10 @@ describe('create', function () {
         });
 
         describe('parameter values and defaults', function () {
-            it('should have a default package name of my.cordova.project', () => {
+            it('should have a default package name of io.cordova.helloCordova', () => {
                 config_mock.packageName.and.returnValue(undefined);
                 return create.create(project_path, config_mock, {}, events_mock).then(() => {
-                    expect(create.validatePackageName).toHaveBeenCalledWith('my.cordova.project');
+                    expect(create.validatePackageName).toHaveBeenCalledWith('io.cordova.helloCordova');
                 });
             });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Mixed default values for `create` between cli doc, cordova-android and cordova-ios.

And wrong project name if with spaces and accents:

fixes #1210


### Description
<!-- Describe your changes in detail -->
Package ids were mostly correct but not all, and same for project name. Suggested proper defaults:
- **id** / package name: `io.cordova.helloCordova`
- **name** / project name: `Hello Cordova`

See linked PRs: apache/cordova-cli#554, apache/cordova-ios#1100

And
- Fix #1210: project name not transformed anymore (was replacing non-word characters with underscores), because there is no known limitation with it, project creation and all still work fine, and cordova-ios does it the same way
- small update on main Readme to update/add details for use and test

_(see each commit for detail on my steps)_


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` success + project creation, open and run from IDE into emulator

Fine on 10.0.0-dev and same for 9.2.0-dev 👍 (would be nice to backport this into a 9.x fix release)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
