### PR TITLE
fix: display project name in Android Studio

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -197,7 +197,9 @@ class ProjectBuilder {
 
         fs.writeFileSync(path.join(this.root, 'settings.gradle'),
             '// GENERATED FILE - DO NOT EDIT\n' +
-            'include ":"\n' + settingsGradlePaths.join(''));
+            'apply from: "cdv-gradle-name.gradle"\n' +
+            'include ":"\n' +
+            settingsGradlePaths.join(''));
 
         // Update dependencies within build.gradle.
         var buildGradle = fs.readFileSync(path.join(this.root, 'app', 'build.gradle'), 'utf8');

--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -183,13 +183,13 @@ class ProjectBuilder {
                 checkAndCopy(subProjects[i], this.root);
             }
         }
-        var name = this.extractRealProjectNameFromManifest();
+        var projectName = this.extractRealProjectNameFromManifest();
         // Remove the proj.id/name- prefix from projects: https://issues.apache.org/jira/browse/CB-9149
         var settingsGradlePaths = subProjects.map(function (p) {
             var realDir = p.replace(/[/\\]/g, ':');
-            var libName = realDir.replace(name + '-', '');
+            var libName = realDir.replace(projectName + '-', '');
             var str = 'include ":' + libName + '"\n';
-            if (realDir.indexOf(name + '-') !== -1) {
+            if (realDir.indexOf(projectName + '-') !== -1) {
                 str += 'project(":' + libName + '").projectDir = new File("' + p + '")\n';
             }
             return str;
@@ -214,7 +214,7 @@ class ProjectBuilder {
         };
         subProjects.forEach(function (p) {
             events.emit('log', 'Subproject Path: ' + p);
-            var libName = p.replace(/[/\\]/g, ':').replace(name + '-', '');
+            var libName = p.replace(/[/\\]/g, ':').replace(projectName + '-', '');
             if (libName !== 'app') {
                 depsList += '    implementation(project(path: ":' + libName + '"))';
                 insertExclude(p);

--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -195,11 +195,17 @@ class ProjectBuilder {
             return str;
         });
 
+        // Update subprojects within settings.gradle.
         fs.writeFileSync(path.join(this.root, 'settings.gradle'),
             '// GENERATED FILE - DO NOT EDIT\n' +
             'apply from: "cdv-gradle-name.gradle"\n' +
             'include ":"\n' +
             settingsGradlePaths.join(''));
+
+        // Touch empty cdv-gradle-name.gradle file if missing.
+        if (!fs.pathExistsSync(path.join(this.root, 'cdv-gradle-name.gradle'))) {
+            fs.writeFileSync(path.join(this.root, 'cdv-gradle-name.gradle'), '');
+        }
 
         // Update dependencies within build.gradle.
         var buildGradle = fs.readFileSync(path.join(this.root, 'app', 'build.gradle'), 'utf8');

--- a/lib/create.js
+++ b/lib/create.js
@@ -37,7 +37,6 @@ exports.copyScripts = copyScripts;
 exports.copyBuildRules = copyBuildRules;
 exports.writeProjectProperties = writeProjectProperties;
 exports.prepBuildFiles = prepBuildFiles;
-exports.writeNameForAndroidStudio = writeNameForAndroidStudio;
 
 function getFrameworkDir (projectPath, shared) {
     return shared ? path.join(ROOT, 'framework') : path.join(projectPath, 'CordovaLib');
@@ -177,19 +176,6 @@ function validateProjectName (project_name) {
 }
 
 /**
- * Write the name of the app in "platforms/android/.idea/.name" so that Android Studio can show that name in the
- * project listing. This is helpful to quickly look in the Android Studio listing if there are so many projects in
- * Android Studio.
- *
- * https://github.com/apache/cordova-android/issues/1172
- */
-function writeNameForAndroidStudio (project_path, project_name) {
-    const ideaPath = path.join(project_path, '.idea');
-    fs.ensureDirSync(ideaPath);
-    fs.writeFileSync(path.join(ideaPath, '.name'), project_name);
-}
-
-/**
  * Creates an android application with the given options.
  *
  * @param   {String}  project_path  Path to the new Cordova android project.
@@ -286,7 +272,6 @@ exports.create = function (project_path, config, options, events) {
             // Link it to local android install.
             exports.writeProjectProperties(project_path, target_api);
             exports.prepBuildFiles(project_path);
-            exports.writeNameForAndroidStudio(project_path, project_name);
             events.emit('log', generateDoneMessage('create', options.link));
         }).then(() => project_path);
 };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -276,7 +276,7 @@ function updateProjectAccordingTo (platformConfig, locations) {
     // Update app name for gradle project
     fs.writeFileSync(path.join(locations.root, 'cdv-gradle-name.gradle'),
         '// GENERATED FILE - DO NOT EDIT\n' +
-        'rootProject.name = "' + name + '"\n');
+        'rootProject.name = "' + name.replace(/[/\\:<>"?*|]/g, '_') + '"\n');
 
     // Java packages cannot support dashes
     var androidPkgName = (platformConfig.android_packageName() || platformConfig.packageName()).replace(/-/g, '_');

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -273,6 +273,11 @@ function updateProjectAccordingTo (platformConfig, locations) {
     fs.writeFileSync(locations.strings, strings.write({ indent: 4 }), 'utf-8');
     events.emit('verbose', 'Wrote out android application name "' + name + '" to ' + locations.strings);
 
+    // Update app name for gradle project
+    fs.writeFileSync(path.join(locations.root, 'cdv-gradle-name.gradle'),
+        '// GENERATED FILE - DO NOT EDIT\n' +
+        'rootProject.name = "' + name + '"\n');
+
     // Java packages cannot support dashes
     var androidPkgName = (platformConfig.android_packageName() || platformConfig.packageName()).replace(/-/g, '_');
 

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -132,7 +132,6 @@ describe('create', function () {
             spyOn(create, 'copyBuildRules');
             spyOn(create, 'writeProjectProperties');
             spyOn(create, 'prepBuildFiles');
-            spyOn(create, 'writeNameForAndroidStudio');
             revert_manifest_mock = create.__set__('AndroidManifest', Manifest_mock);
             spyOn(fs, 'existsSync').and.returnValue(false);
             spyOn(fs, 'copySync');
@@ -299,26 +298,6 @@ describe('create', function () {
                     expect(create.prepBuildFiles).toHaveBeenCalledWith(project_path);
                 });
             });
-        });
-    });
-
-    describe('writeNameForAndroidStudio', () => {
-        const project_path = path.join('some', 'path');
-        const appName = 'Test Cordova';
-
-        beforeEach(function () {
-            spyOn(fs, 'ensureDirSync');
-            spyOn(fs, 'writeFileSync');
-        });
-
-        it('should call ensureDirSync with path', () => {
-            create.writeNameForAndroidStudio(project_path, appName);
-            expect(fs.ensureDirSync).toHaveBeenCalledWith(path.join(project_path, '.idea'));
-        });
-
-        it('should call writeFileSync with content', () => {
-            create.writeNameForAndroidStudio(project_path, appName);
-            expect(fs.writeFileSync).toHaveBeenCalledWith(path.join(project_path, '.idea', '.name'), appName);
         });
     });
 });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes #1209

(Android Studio resets project name on Gradle reload)

### Description
<!-- Describe your changes in detail -->
Add `rootProject.name = "Hello World"` inside **settings.gradle** at root.

Remove _.idea/.name_ file previously added with #1173 and [v9.1.0](https://github.com/apache/cordova-android/blob/master/RELEASENOTES.md#910-apr-09-2021)


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` success + project creation, open and run from IDE into emulator

Fine on 10.0.0-dev and same for 9.2.0-dev 👍 (would be nice to backport this into a 9.x fix release)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
