### PR TITLE
fix(requirements check): use regex to get java version from javac output

### DIFF
--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -43,9 +43,9 @@ const java = {
         // Java <= 8 writes version info to stderr, Java >= 9 to stdout
         let version = null;
         try {
-            javacOutput = (await execa('javac', ['-version'], { all: true })).all;
+            const javacOutput = (await execa('javac', ['-version'], { all: true })).all;
 
-            /*  
+            /*
             A regex match for the java version looks like the following:
 
             version: [
@@ -54,7 +54,7 @@ const java = {
                 index: 45,
                 input: 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271',
                 groups: undefined
-            ] 
+            ]
 
             We have to use a regular expression to get the java version, because on some environments
             (e.g. macOS Big Sur) javac prints _JAVA_OPTIONS before printing the version and semver.coerce()

--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -43,7 +43,25 @@ const java = {
         // Java <= 8 writes version info to stderr, Java >= 9 to stdout
         let version = null;
         try {
-            version = (await execa('javac', ['-version'], { all: true })).all;
+            javacOutput = (await execa('javac', ['-version'], { all: true })).all;
+
+            /*  
+            A regex match for the java version looks like the following:
+
+            version: [
+                'javac 1.8.0',
+                '1.8.0',
+                index: 45,
+                input: 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271',
+                groups: undefined
+            ] 
+
+            We have to use a regular expression to get the java version, because on some environments
+            (e.g. macOS Big Sur) javac prints _JAVA_OPTIONS before printing the version and semver.coerce()
+            will fail to get the correct version from the output.
+            */
+
+            version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
         } catch (ex) {
             events.emit('verbose', ex.shortMessage);
 

--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -61,7 +61,10 @@ const java = {
             will fail to get the correct version from the output.
             */
 
-            version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
+            const match = /javac\s+([\d.]+)/i.exec(javacOutput);
+            if (match && match[1]) {
+                version = match[1];
+            }
         } catch (ex) {
             events.emit('verbose', ex.shortMessage);
 

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -64,6 +64,19 @@ describe('check_reqs', function () {
 
             await expectAsync(check_reqs.check_java()).toBeResolvedTo({ version: '1.8.0' });
         });
+
+        it('should return the correct version if javac prints _JAVA_OPTIONS', async () => {
+            check_reqs.__set__({
+                java: { getVersion: async () => {
+                    javacOutput = 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271';
+                    version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
+
+                    return { version };
+                } }
+            });
+
+            await expectAsync(check_reqs.check_java()).toBeResolvedTo({ version: '1.8.0' });
+        });
     });
 
     describe('check_android', function () {

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -69,8 +69,12 @@ describe('check_reqs', function () {
             check_reqs.__set__({
                 java: {
                     getVersion: async () => {
+                        let version = null;
                         const javacOutput = 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271';
-                        const version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
+                        const match = /javac\s+([\d.]+)/i.exec(javacOutput);
+                        if (match && match[1]) {
+                            version = match[1];
+                        }
 
                         return { version };
                     }

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -67,12 +67,14 @@ describe('check_reqs', function () {
 
         it('should return the correct version if javac prints _JAVA_OPTIONS', async () => {
             check_reqs.__set__({
-                java: { getVersion: async () => {
-                    javacOutput = 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271';
-                    version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
+                java: {
+                    getVersion: async () => {
+                        const javacOutput = 'Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271';
+                        const version = /javac\s+([\d.]+)/i.exec(javacOutput)?.[1];
 
-                    return { version };
-                } }
+                        return { version };
+                    }
+                }
             });
 
             await expectAsync(check_reqs.check_java()).toBeResolvedTo({ version: '1.8.0' });


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Fixes getting the java version from the `javac -version` output on macOS devices when custom `_JAVA_OPTIONS` are set. A detailed description of the issue can be found im my comment [here](https://github.com/apache/cordova-android/pull/1130#issuecomment-824749304).

Fixes https://github.com/apache/cordova-android/issues/1203

### Description
Use a regex to get just the version string from the `javac` output. Fixes #1130.

Previously `semver.coerce()` would get a wrong version from a string like the following:

```js
Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271
```

With the change in this PR, the following regex is used to get the version string (`1.8.0`) from the output:

```js
/javac\s+([\d.]+)/i
```

I also tried removing `_JAVA_OPTIONS` from the version check by adding `env: {}, extendEnv: false` to the options of the `javac` command like suggested [here](https://github.com/apache/cordova-android/pull/1130#issuecomment-826084254):

```js
execa('javac', ['-version'], { all: true, env: {}, extendEnv: false })
```

This changed the output from:

```js
Picked up _JAVA_OPTIONS: -Xms1024M -Xmx2048M\njavac 1.8.0_271
```

to:

```js
javac 12.0.2
```

which subsequently let the requirements check fail again (no idea where `12.0.2` comes from). So I just went with the regex solution.

### Testing
- Add android platform with fix on macOS, run `cordova build android`, check if requirements check succeeds
- Add android platform with fix on Windows, run `cordova build android`, check if requirements check succeeds
- Add unit test for `javac -version` output with `_JAVA_OPTIONS`, run unit tests

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
