### PR TITLE
feat: add backwards compatibility mode for WebViewAssetLoader

### DIFF
--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -46,9 +46,14 @@ public class ConfigXmlParser {
     }
 
     public String getLaunchUrl() {
-        if (launchUrl == null) { 
+        if (launchUrl == null) {
             launchUrl = "https://" +  this.prefs.getString("hostname", "localhost");
         }
+
+        if (this.prefs.getBoolean("InsecureFileMode", false)) {
+            launchUrl = "file:///android_asset/www/index.html";
+        }
+
         return launchUrl;
     }
 

--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -147,7 +147,11 @@ public class ConfigXmlParser {
             if (src.charAt(0) == '/') {
                 src = src.substring(1);
             }
-            launchUrl = "https://" +  this.prefs.getString("hostname", "localhost") + "/" + src;
+            if (this.prefs.getBoolean("AndroidInsecureFileModeEnabled", false)) {
+                launchUrl = "file:///android_asset/www/" + src;
+            } else {
+                launchUrl = "https://" +  this.prefs.getString("hostname", "localhost") + "/" + src;
+            }
         }
     }
 }

--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -50,7 +50,7 @@ public class ConfigXmlParser {
             launchUrl = "https://" +  this.prefs.getString("hostname", "localhost");
         }
 
-        if (this.prefs.getBoolean("InsecureFileMode", false)) {
+        if (this.prefs.getBoolean("AndroidInsecureFileModeEnabled", false)) {
             launchUrl = "file:///android_asset/www/index.html";
         }
 

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -159,7 +159,7 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         settings.setSaveFormData(false);
         settings.setSavePassword(false);
 
-        if (preferences.getBoolean("InsecureFileMode", false)) {
+        if (preferences.getBoolean("AndroidInsecureFileModeEnabled", false)) {
             //These settings are deprecated and loading content via file:// URLs is generally discouraged,
             //but we allow this for compatibility reasons
             LOG.d(TAG, "Enabled insecure file access");

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -159,6 +159,14 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         settings.setSaveFormData(false);
         settings.setSavePassword(false);
 
+        if (preferences.getBoolean("InsecureFileMode", false)) {
+            //These settings are deprecated and loading content via file:// URLs is generally discouraged,
+            //but we allow this for compatibility reasons
+            LOG.d(TAG, "Enabled insecure file access");
+            settings.setAllowFileAccess(true);
+            settings.setAllowUniversalAccessFromFileURLs(true);
+        }
+
         settings.setMediaPlaybackRequiresUserGesture(false);
 
         // Enable database


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As we discussed on the list we might need a fallback for the new changes in #1137 

With this PR you can fall back to using files instead of https://localhost with this preference:
`
<preference name="AndroidInsecureFileModeEnabled" value="true" />
`

Documentation: https://github.com/apache/cordova-docs/pull/1172


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
