### PR TITLE
fix(prepare): delete splash screens if none are used

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -334,7 +334,7 @@ function updateSplashes (cordovaProject, platformResourcesDir) {
         // We must not return here!
         // If the user defines no splash screens, the cleanup map will cause any
         // existing splash screen images (e.g. the defaults that we copy into a
-        // new app) to be removed the app folder, which is what we want.
+        // new app) to be removed from the app folder, which is what we want.
     }
 
     // Build an initial resource map that deletes all existing splash screens

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -328,10 +328,13 @@ function makeSplashCleanupMap (projectRoot, resourcesDir) {
 function updateSplashes (cordovaProject, platformResourcesDir) {
     var resources = cordovaProject.projectConfig.getSplashScreens('android');
 
-    // if there are "splash" elements in config.xml
+    // if there are no "splash" elements in config.xml
     if (resources.length === 0) {
         events.emit('verbose', 'This app does not have splash screens defined');
-        return;
+        // We must not return here!
+        // If the user defines no splash screens, the cleanup map will cause any
+        // existing splash screen images (e.g. the defaults that we copy into a
+        // new app) to be removed the app folder, which is what we want.
     }
 
     // Build an initial resource map that deletes all existing splash screens


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We copy default splash screens to the platform folder during platform creation. But then we do not delete them when the user uses no splash screens at all. This causes #1226 and what is described in #689.

Fixes #1226


### Description
<!-- Describe your changes in detail -->
The new implementation does not return early when updating splashes and none are defined. Instead, we let the cleanup map we create initially take care of deleting all unused splash screens. This also deletes the default splashes during the first prepare after platform creation.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing on a default app.
A regression test would be great but I'm on a tight schedule. Feel free to add one if you feel like it.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
