### PR TITLE
Bugfix/java checks

### DIFF
--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -79,10 +79,6 @@ const java = {
             throw new CordovaError(msg);
         }
 
-        // This parses out additional lines that
-        // the Java executable may print out
-        version = /^javac? .+$/im.exec(version)[0];
-
         return semver.coerce(version);
     },
 
@@ -97,7 +93,6 @@ const java = {
             return;
         }
 
-        const javacPath = utils.forgivingWhichSync('javac');
         const javaHome = environment.CORDOVA_JAVA_HOME || environment.JAVA_HOME;
         if (javaHome) {
             // Ensure that CORDOVA_JAVA_HOME overrides
@@ -106,6 +101,7 @@ const java = {
             // to cover cases where different Java versions is in the PATH
             environment.PATH = path.join(environment.JAVA_HOME, 'bin') + path.delimiter + environment.PATH;
         } else {
+            const javacPath = utils.forgivingWhichSync('javac');
             if (javacPath) {
                 // OS X has a command for finding JAVA_HOME.
                 const find_java = '/usr/libexec/java_home';

--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -102,10 +102,9 @@ const java = {
         if (javaHome) {
             // Ensure that CORDOVA_JAVA_HOME overrides
             environment.JAVA_HOME = javaHome;
-            // Windows java installer doesn't add javac to PATH, nor set JAVA_HOME (ugh).
-            if (!javacPath) {
-                environment.PATH += path.delimiter + path.join(environment.JAVA_HOME, 'bin');
-            }
+            // Ensure that the JAVA_HOME bin path is before anything else
+            // to cover cases where different Java versions is in the PATH
+            environment.PATH = path.join(environment.JAVA_HOME, 'bin') + path.delimiter + environment.PATH;
         } else {
             if (javacPath) {
                 // OS X has a command for finding JAVA_HOME.

--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -79,6 +79,10 @@ const java = {
             throw new CordovaError(msg);
         }
 
+        // This parses out additional lines that
+        // the Java executable may print out
+        version = /^javac? .+$/im.exec(version)[0];
+
         return semver.coerce(version);
     },
 

--- a/spec/unit/java.spec.js
+++ b/spec/unit/java.spec.js
@@ -47,9 +47,19 @@ describe('Java', () => {
                 all: 'javac 1.8.0_275'
             }));
 
-            console.log('BEFORE', process.env.JAVA_HOME);
             const result = await Java.getVersion();
-            console.log('AFTER', process.env.JAVA_HOME);
+            expect(result.major).toBe(1);
+            expect(result.minor).toBe(8);
+            expect(result.patch).toBe(0);
+            expect(result.version).toBe('1.8.0');
+        });
+
+        it('detects JDK when additional details are printed', async () => {
+            Java.__set__('execa', () => Promise.resolve({
+                all: 'Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8\njavac 1.8.0_275'
+            }));
+
+            const result = await Java.getVersion();
             expect(result.major).toBe(1);
             expect(result.minor).toBe(8);
             expect(result.patch).toBe(0);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/apache/cordova-android/issues/1221
~Fixes https://github.com/apache/cordova-android/issues/1203~ (Addressed by https://github.com/apache/cordova-android/pull/1220)


### Description
<!-- Describe your changes in detail -->

This addresses two flaws in Java checking.

1. ~If some Java options are present, `javac -version` will print out additional lines of information. A regex is used to find the `java(c) x.x.x` line for proper version checking.~ Addressed by https://github.com/apache/cordova-android/pull/1220
2. If `JAVA_HOME` is set, we would only set the path if `javac` wasn't findable, and when we do, we set the path at the end of the `PATH` chain. To be smarter, if `JAVA_HOME` is set, we **always** want to set the `JAVA_HOME` bin path to the front of the `PATH` chain so that we can guarantee the proper java executable to be used.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Added new test for the `javac -version` issue. All existing tests passes. Manual testing for the `JAVA_HOME` issue.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
