### PR TITLE
feat: CORDOVA_JAVA_HOME env variable

### DIFF
--- a/bin/templates/cordova/lib/env/java.js
+++ b/bin/templates/cordova/lib/env/java.js
@@ -73,8 +73,10 @@ const java = {
         }
 
         const javacPath = utils.forgivingWhichSync('javac');
-        const hasJavaHome = !!environment.JAVA_HOME;
-        if (hasJavaHome) {
+        const javaHome = environment.CORDOVA_JAVA_HOME || environment.JAVA_HOME;
+        if (javaHome) {
+            // Ensure that CORDOVA_JAVA_HOME overrides
+            environment.JAVA_HOME = javaHome;
             // Windows java installer doesn't add javac to PATH, nor set JAVA_HOME (ugh).
             if (!javacPath) {
                 environment.PATH += path.delimiter + path.join(environment.JAVA_HOME, 'bin');

--- a/spec/unit/java.spec.js
+++ b/spec/unit/java.spec.js
@@ -76,6 +76,19 @@ describe('Java', () => {
             Java.__set__('javaIsEnsured', false);
         });
 
+        it('CORDOVA_JAVA_HOME overrides JAVA_HOME', async () => {
+            spyOn(utils, 'forgivingWhichSync').and.returnValue('');
+
+            const env = {
+                CORDOVA_JAVA_HOME: '/tmp/jdk'
+            };
+
+            await Java._ensure(env);
+
+            expect(env.PATH.split(path.delimiter))
+                .toContain(path.join(env.JAVA_HOME, 'bin'));
+        });
+
         it('with JAVA_HOME / without javac', async () => {
             spyOn(utils, 'forgivingWhichSync').and.returnValue('');
 

--- a/spec/unit/java.spec.js
+++ b/spec/unit/java.spec.js
@@ -85,8 +85,8 @@ describe('Java', () => {
 
             await Java._ensure(env);
 
-            expect(env.PATH.split(path.delimiter))
-                .toContain(path.join(env.JAVA_HOME, 'bin'));
+            expect(env.JAVA_HOME).toBe('/tmp/jdk');
+            expect(env.PATH.split(path.delimiter)).toContain('/tmp/jdk/bin');
         });
 
         it('with JAVA_HOME / without javac', async () => {

--- a/spec/unit/java.spec.js
+++ b/spec/unit/java.spec.js
@@ -86,7 +86,7 @@ describe('Java', () => {
             await Java._ensure(env);
 
             expect(env.JAVA_HOME).toBe('/tmp/jdk');
-            expect(env.PATH.split(path.delimiter)).toContain('/tmp/jdk/bin');
+            expect(env.PATH.split(path.delimiter)).toContain(['', 'tmp', 'jdk', 'bin'].join(path.sep));
         });
 
         it('with JAVA_HOME / without javac', async () => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It's been a requested feature (not formally, but in variety of bug tickets of people trying to use java >8) because often times, we are stuck on using older Java versions
due to the Android SDK. This will make it easier for users to have multiple java versions installed.

### Description
<!-- Describe your changes in detail -->

If `CORDOVA_JAVA_HOME` is present, it will override `JAVA_HOME` environment variable for the execution context of Cordova.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Unit test added. All existing tests passes. Manual testing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
