### PR TITLE
breaking: drop jcenter/bintray & update dependencies

### DIFF
--- a/bin/templates/cordova/lib/plugin-build.gradle
+++ b/bin/templates/cordova/lib/plugin-build.gradle
@@ -21,7 +21,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the

--- a/bin/templates/project/app/repositories.gradle
+++ b/bin/templates/project/app/repositories.gradle
@@ -17,7 +17,6 @@
 */
 
 ext.repos = {
-    mavenCentral()
     google()
-    jcenter()
+    mavenCentral()
 }

--- a/bin/templates/project/repositories.gradle
+++ b/bin/templates/project/repositories.gradle
@@ -18,5 +18,5 @@
 
 ext.repos = {
     google()
-    jcenter()
+    mavenCentral()
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -40,11 +40,11 @@ buildscript {
     repositories repos
 
     dependencies {
-        // The gradle plugin and the maven plugin have to be updated after each version of Android
-        // studio comes out
+        // Android Gradle Plugin (AGP) Build Tools
         classpath 'com.android.tools.build:gradle:4.2.1'
+
+        // @todo remove this abandoned plugin. maven-publish-plugin is now supported by Android Gradle plugin 3.6.0 and higher
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 
@@ -54,8 +54,9 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
+
+// @todo remove this abandoned plugin. maven-publish-plugin is now supported by Android Gradle plugin 3.6.0 and higher
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 group = 'org.apache.cordova'
 version = '10.0.0-dev'
@@ -94,6 +95,7 @@ android {
     }
 }
 
+// @todo after removing abandoned plugin "com.github.dcendents.android-maven". figure out what to do with this.
 install {
     repositories.mavenInstaller {
         pom {
@@ -135,29 +137,6 @@ dependencies {
 
 artifacts {
     archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'maven'
-        name = 'cordova-android'
-        userOrg = 'cordova'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/apache/cordova-android'
-        websiteUrl = 'https://cordova.apache.org'
-        issueTrackerUrl = 'https://github.com/apache/cordova-android/issues'
-        publicDownloadNumbers = true
-        licenses = ['Apache-2.0']
-        labels = ['android', 'cordova', 'phonegap']
-        version {
-            name = '10.0.0-dev'
-            released = new Date()
-            vcsTag = '10.0.0-dev'
-        }
-    }
 }
 
 dependencies {

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -19,7 +19,7 @@
 
 import java.util.regex.Pattern
 import groovy.swing.SwingBuilder
-import com.g00fy2.versioncompare.Version
+import io.github.g00fy2.versioncompare.Version
 
 String doEnsureValueExists(filePath, props, key) {
     if (props.get(key) == null) {
@@ -171,10 +171,11 @@ ext {
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.g00fy2:versioncompare:1.3.4@jar'
+        classpath 'io.github.g00fy2:versioncompare:1.4.1@jar'
     }
 }

--- a/framework/repositories.gradle
+++ b/framework/repositories.gradle
@@ -18,5 +18,5 @@
 
 ext.repos = {
     google()
-    jcenter()
+    mavenCentral()
 }

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -56,5 +56,6 @@ dependencies {
     })
 }
 repositories {
-    jcenter()
+    google()
+    mavenCentral()
 }

--- a/test/androidx/build.gradle
+++ b/test/androidx/build.gradle
@@ -21,7 +21,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -35,7 +35,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
### Motivation, Context & Description

- Remove JCenter usage
- Remove Bintray usage
- Replace & Upgrade `com.g00fy2:versioncompare:1.3.4` with `io.github.g00fy2:versioncompare:1.4.1`
- Update all `repositories` definitions with:

```
repositories {
    google()
    mavenCentral()
}
```

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
