### PR TITLE
feat!: drop abandoned com.github.dcendents:android-maven-gradle-plugin

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -96,7 +96,7 @@ publishing {
                 licenses {
                     license {
                         name = 'Apache License, Version 2.0'
-                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txts'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -87,6 +87,7 @@ publishing {
             version = '10.0.0-dev'
 
             artifact(sourcesJar)
+            artifact("$buildDir/outputs/aar/framework-release.aar")
 
             pom {
                 name = 'Cordova'

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -29,9 +29,6 @@ buildscript {
     dependencies {
         // Android Gradle Plugin (AGP) Build Tools
         classpath "com.android.tools.build:gradle:${cordovaConfig.AGP_VERSION}"
-
-        // @todo remove this abandoned plugin. maven-publish-plugin is now supported by Android Gradle plugin 3.6.0 and higher
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 
@@ -41,12 +38,7 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-
-// @todo remove this abandoned plugin. maven-publish-plugin is now supported by Android Gradle plugin 3.6.0 and higher
-apply plugin: 'com.github.dcendents.android-maven'
-
-group = 'org.apache.cordova'
-version = '10.0.0-dev'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion cordovaConfig.SDK_VERSION
@@ -82,48 +74,56 @@ android {
     }
 }
 
-// @todo after removing abandoned plugin "com.github.dcendents.android-maven". figure out what to do with this.
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'Cordova'
-                url 'https://cordova.apache.org'
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+publishing {
+    publications {
+        Cordova(MavenPublication) {
+            groupId = 'org.apache.cordova'
+            artifactId = 'framework'
+            version = '10.0.0-dev'
+
+            artifact(sourcesJar)
+
+            pom {
+                name = 'Cordova'
+                description = 'A library to build Cordova-based projects for the Android platform.'
+                url = 'https://cordova.apache.org'
+
                 licenses {
                     license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = 'Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txts'
                     }
                 }
+
                 developers {
                     developer {
-                        id 'stevengill'
-                        name 'Steve Gill'
+                        id = 'stevengill'
+                        name = 'Steve Gill'
+                    }
+                    developer {
+                        id = 'erisu'
+                        name = 'Bryan Ellis'
+                        email = 'erisu@apache.org'
                     }
                 }
-                scm {
-                    connection 'scm:git:https://github.com/apache/cordova-android.git'
-                    developerConnection 'scm:git:git@github.com:apache/cordova-android.git'
-                    url 'https://github.com/apache/cordova-android'
 
+                scm {
+                    connection = 'scm:git:https://github.com/apache/cordova-android.git'
+                    developerConnection = 'scm:git:git@github.com:apache/cordova-android.git'
+                    url = 'https://github.com/apache/cordova-android'
                 }
             }
         }
     }
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
 dependencies {
     implementation "androidx.appcompat:appcompat:${cordovaConfig.ANDROIDX_APP_COMPAT_VERSION}"
-}
-
-artifacts {
-    archives sourcesJar
 }
 
 dependencies {

--- a/framework/gradle.properties
+++ b/framework/gradle.properties
@@ -1,0 +1,19 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx1536m
+android.useAndroidX=true
+android.enableJetifier=true
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true


### PR DESCRIPTION
### Motivation, Context & Description

- Drop `.github.dcendents:android-maven-gradle-plugin` which has been abandonded because maven-publish-plugin is supported by the Android Gradle Plugin 3.6.0 and higher
- Update the publishing definition to support publishing to maven
- Fixed the `gradle build` failure due to missing `useAndroidX` flag. The build is needed to create an `aar` release artifact that is bundled with the publish.

This PR requires #1251 to be merged in first.

You can see commit: https://github.com/apache/cordova-android/commit/2338bc6975fe592922f2070767be011f6b2aab13
If you want to see only the changes of this PR.

### Testing

-  [x] `npm t`
-  [ ] Publishing package has not been tested yet.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
