### PR TITLE
feat: allow webkit version override

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -98,6 +98,7 @@ function getUserGradleConfig (configXml) {
         { xmlKey: 'AndroidGradlePluginVersion', gradleKey: 'AGP_VERSION', type: String },
         { xmlKey: 'GradlePluginKotlinVersion', gradleKey: 'KOTLIN_VERSION', type: String },
         { xmlKey: 'AndroidXAppCompatVersion', gradleKey: 'ANDROIDX_APP_COMPAT_VERSION', type: String },
+        { xmlKey: 'AndroidXWebKitVersion', gradleKey: 'ANDROIDX_WEBKIT_VERSION', type: String },
         { xmlKey: 'GradlePluginGoogleServicesVersion', gradleKey: 'GRADLE_PLUGIN_GOOGLE_SERVICES_VERSION', type: String },
         { xmlKey: 'GradlePluginGoogleServicesEnabled', gradleKey: 'IS_GRADLE_PLUGIN_GOOGLE_SERVICES_ENABLED', type: Boolean },
         { xmlKey: 'GradlePluginKotlinEnabled', gradleKey: 'IS_GRADLE_PLUGIN_KOTLIN_ENABLED', type: Boolean }

--- a/bin/templates/project/app/build.gradle
+++ b/bin/templates/project/app/build.gradle
@@ -165,6 +165,7 @@ task cdvPrintProps {
         println('cdvBuildArch=' + cdvBuildArch)
         println('computedVersionCode=' + android.defaultConfig.versionCode)
         println('cdvAndroidXAppCompatVersion=' + cdvAndroidXAppCompatVersion)
+        println('cdvAndroidXWebKitVersion=' + cdvAndroidXWebKitVersion)
         android.productFlavors.each { flavor ->
             println('computed' + flavor.name.capitalize() + 'VersionCode=' + flavor.versionCode)
         }

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -167,6 +167,9 @@ def doApplyCordovaConfigCustomization() {
     if (project.hasProperty('cdvAndroidXAppCompatVersion')) {
         cordovaConfig.ANDROIDX_APP_COMPAT_VERSION = cdvAndroidXAppCompatVersion
     }
+    if (project.hasProperty('cdvAndroidXWebKitVersion')) {
+        cordovaConfig.ANDROIDX_WEBKIT_VERSION = cdvAndroidXWebKitVersion
+    }
 
     // Ensure the latest installed build tools is selected, with or without defined override
     cordovaConfig.LATEST_INSTALLED_BUILD_TOOLS = doFindLatestInstalledBuildTools(


### PR DESCRIPTION
### Motivation, Context & Description

Allow `androidx.webkit` version overrides.

~~Forked of #1253. Requires parent PR merged in first.~~

### Testing

- `npm t`
- build
- changing of versions

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I've updated the documentation if necessary
