### PR TITLE
feat!: bump gradle@7.1.1

### DIFF
--- a/framework/cdv-gradle-config-defaults.json
+++ b/framework/cdv-gradle-config-defaults.json
@@ -1,7 +1,7 @@
 {
     "MIN_SDK_VERSION": 22,
     "SDK_VERSION": 30,
-    "GRADLE_VERSION": "6.8.3",
+    "GRADLE_VERSION": "7.1.1",
     "BUILD_TOOLS_VERSION": "30.0.3",
     "AGP_VERSION": "4.2.1",
     "KOTLIN_VERSION": "1.4.32",

--- a/spec/fixtures/android_studio_project/gradle/wrapper/gradle-wrapper.properties
+++ b/spec/fixtures/android_studio_project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip


### PR DESCRIPTION
### Motivation, Context & Description

Bump Gradle to `7.1.1`. Using the new centralized configuration defaults.

Also updated test fixtures.

After some discussion and seeing that Gradle's website declares that they have tested with the current released AGP means there most likely wont be any issues in upgrading this, eventhough Google Android docs does not define it in the supported range.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
