### PR TITLE
refactor(check_reqs): drop originalError param from check_android_target

### DIFF
--- a/bin/templates/cordova/lib/builders/ProjectBuilder.js
+++ b/bin/templates/cordova/lib/builders/ProjectBuilder.js
@@ -300,21 +300,23 @@ class ProjectBuilder {
     * Builds the project with gradle.
     * Returns a promise.
     */
-    build (opts) {
+    async build (opts) {
         var wrapper = path.join(this.root, 'gradlew');
         var args = this.getArgs(opts.buildType === 'debug' ? 'debug' : 'release', opts);
 
-        return execa(wrapper, args, { stdio: 'inherit', cwd: path.resolve(this.root) })
-            .catch(function (error) {
-                if (error.toString().indexOf('failed to find target with hash string') >= 0) {
-                    return check_reqs.check_android_target(error).then(function () {
-                        // If due to some odd reason - check_android_target succeeds
-                        // we should still fail here.
-                        throw error;
-                    });
+        try {
+            return await execa(wrapper, args, { stdio: 'inherit', cwd: path.resolve(this.root) });
+        } catch (error) {
+            if (error.toString().includes('failed to find target with hash string')) {
+                // Add hint from check_android_target to error message
+                try {
+                    await check_reqs.check_android_target();
+                } catch (checkAndroidTargetError) {
+                    error.message += '\n' + checkAndroidTargetError.message;
                 }
-                throw error;
-            });
+            }
+            throw error;
+        }
     }
 
     clean (opts) {

--- a/bin/templates/cordova/lib/check_reqs.js
+++ b/bin/templates/cordova/lib/check_reqs.js
@@ -246,7 +246,7 @@ module.exports.check_android = function () {
     });
 };
 
-module.exports.check_android_target = function (originalError) {
+module.exports.check_android_target = function () {
     // valid_target can look like:
     //   android-19
     //   android-L
@@ -257,11 +257,7 @@ module.exports.check_android_target = function (originalError) {
         if (targets.indexOf(desired_api_level) >= 0) {
             return targets;
         }
-        var msg = `Please install the Android SDK Platform "platforms;${desired_api_level}"`;
-        if (originalError) {
-            msg = originalError + '\n' + msg;
-        }
-        throw new CordovaError(msg);
+        throw new CordovaError(`Please install the Android SDK Platform "platforms;${desired_api_level}"`);
     });
 };
 

--- a/spec/unit/builders/ProjectBuilder.spec.js
+++ b/spec/unit/builders/ProjectBuilder.spec.js
@@ -224,7 +224,7 @@ describe('ProjectBuilder', () => {
             return builder.build({}).then(
                 () => fail('Unexpectedly resolved'),
                 error => {
-                    expect(checkReqsSpy.check_android_target).toHaveBeenCalledWith(testError);
+                    expect(checkReqsSpy.check_android_target).toHaveBeenCalled();
                     expect(error).toBe(testError);
                 }
             );


### PR DESCRIPTION
This refactor removes a strange optional parameter from `check_reqs.check_android_target` in favor of having the sole user of that parameter handle the related logic itself.