### PR TITLE
fix: missing super.onRequestPermissionsResult error (MissingSuperCall)

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -513,6 +513,8 @@ public class CordovaActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, String permissions[],
                                            int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
         try
         {
             cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);


### PR DESCRIPTION
### Motivation, Context & Description

Fix missing super call error for the `onRequestPermissionsResult` override.

### Testing

- `npm t`
- `cordova build android`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
