### PR TITLE
feat!: release build defaults to aab package type

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -130,7 +130,11 @@ function parseOpts (options, resolvedTarget, projectRoot) {
             ret.packageType = packageArgs.packageType;
         }
     } else {
-        ret.packageType = PackageType.APK;
+        if(ret.buildType === 'release') {
+            ret.packageType = PackageType.BUNDLE;
+        } else {
+            ret.packageType = PackageType.APK;
+        }
     }
 
     return ret;

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -130,7 +130,7 @@ function parseOpts (options, resolvedTarget, projectRoot) {
             ret.packageType = packageArgs.packageType;
         }
     } else {
-        if(ret.buildType === 'release') {
+        if (ret.buildType === 'release') {
             ret.packageType = PackageType.BUNDLE;
         } else {
             ret.packageType = PackageType.APK;


### PR DESCRIPTION
### Motivation, Context & Description

This PR changes the default package type of the release builds to be `aab` (Android App Bundle). In August, AAB format is required for all new apps.

https://developer.android.com/distribute/play-policies#RequirementForNewApps

Exisiting apps can continue to release APK packages till November. To continue to build release APK, append the `--buildType=apk` flag to the build command.

### Testing

- `npm t`
- Android build with command line

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I've updated the documentation if necessary
