### PR TITLE
refactor(Api)!: use version from package.json

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -17,15 +17,6 @@
     under the License.
 */
 
-/**
- * @todo update coho to update this line.
- * @todo use `package.json` instead but first
- *  figure out how this fit in with the platform-centered workflow structure.
- *  This workflow would not have the `package.json` file.
- */
-// Coho updates this line
-const VERSION = '10.0.0-dev';
-
 var path = require('path');
 
 var AndroidProject = require('./AndroidProject');
@@ -37,6 +28,7 @@ var ConfigParser = require('cordova-common').ConfigParser;
 const prepare = require('./prepare').prepare;
 
 var PLATFORM = 'android';
+const VERSION = require('../package').version;
 
 function setupEvents (externalEventEmitter) {
     if (externalEventEmitter) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Have `Api.version` return the version from `package.json`, reducing the need for `coho` usage. There are still other places where the version is hardcoded, but that's beyond the scope of this PR.