### PR TITLE
cleanup!: remove deprecated settings & add todo comments

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -155,7 +155,8 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         String manufacturer = android.os.Build.MANUFACTURER;
         LOG.d(TAG, "CordovaWebView is running on device made by: " + manufacturer);
 
-        //We don't save any form data in the application
+        // We don't save any form data in the application
+        // @todo remove when Cordova drop API level 26 support
         settings.setSaveFormData(false);
         settings.setSavePassword(false);
 

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -173,8 +173,6 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         // We keep this disabled because we use or shim to get around DOM_EXCEPTION_ERROR_16
         String databasePath = webView.getContext().getApplicationContext().getDir("database", Context.MODE_PRIVATE).getPath();
         settings.setDatabaseEnabled(true);
-        settings.setDatabasePath(databasePath);
-
 
         //Determine whether we're in debug or release mode, and turn on Debugging!
         ApplicationInfo appInfo = webView.getContext().getApplicationContext().getApplicationInfo();

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -180,6 +180,7 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
             enableRemoteDebugging();
         }
 
+        // @todo remove when Cordova drop API level 24 support
         settings.setGeolocationDatabasePath(databasePath);
 
         // Enable DOM storage

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -158,7 +158,6 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         // We don't save any form data in the application
         // @todo remove when Cordova drop API level 26 support
         settings.setSaveFormData(false);
-        settings.setSavePassword(false);
 
         if (preferences.getBoolean("AndroidInsecureFileModeEnabled", false)) {
             //These settings are deprecated and loading content via file:// URLs is generally discouraged,


### PR DESCRIPTION
### Motivation, Context & Description

#### Added Todo Comment [`setSaveFormData`](https://developer.android.com/reference/android/webkit/WebSettings#setSaveFormData(boolean))

Remove this setting once Cordova drops support for API Level 26.

> This method was deprecated in API level 26.
> In Android O and afterwards, this function does not have any effect, the form data will be saved to platform's autofill service if applicable.

#### Remove [`setSavePassword`](https://developer.android.com/reference/android/webkit/WebSettings#setSavePassword(boolean))

> This method was deprecated in API level 18.
> Saving passwords in WebView will not be supported in future versions.

#### Remove [`setDatabasePath`](https://developer.android.com/reference/android/webkit/WebSettings#setDatabasePath(java.lang.String))

> This method was deprecated in API level 19.
> Database paths are managed by the implementation and calling this method will have no effect.

#### Added Todo Comment: [`setGeolocationDatabasePath`](https://developer.android.com/reference/android/webkit/WebSettings#setGeolocationDatabasePath(java.lang.String))

Remove this setting once Cordova drops support for API Level 24.

> This method was deprecated in API level 24.
> Geolocation database are managed by the implementation and calling this method will have no effect.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
