### PR TITLE
fix: add WebViewAssetloader to default allow list

### DIFF
--- a/framework/src/org/apache/cordova/AllowListPlugin.java
+++ b/framework/src/org/apache/cordova/AllowListPlugin.java
@@ -84,7 +84,9 @@ public class AllowListPlugin extends CordovaPlugin {
                 allowedNavigations.addAllowListEntry(startPage, false);
 
                 // Allow origin for WebViewAssetLoader
-                allowedNavigations.addAllowListEntry("https://" + this.prefs.getString("hostname", "localhost") + "/" + startPage, false);
+                if (!this.prefs.getBoolean("AndroidInsecureFileModeEnabled", false)) {
+                    allowedNavigations.addAllowListEntry("https://" + this.prefs.getString("hostname", "localhost"), false);
+                }
             } else if (strNode.equals("allow-navigation")) {
                 String origin = xml.getAttributeValue(null, "href");
                 if ("*".equals(origin)) {

--- a/framework/src/org/apache/cordova/AllowListPlugin.java
+++ b/framework/src/org/apache/cordova/AllowListPlugin.java
@@ -23,6 +23,7 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.ConfigXmlParser;
 import org.apache.cordova.LOG;
 import org.apache.cordova.AllowList;
+import org.apache.cordova.CordovaPreferences;
 import org.xmlpull.v1.XmlPullParser;
 
 import android.content.Context;
@@ -73,12 +74,17 @@ public class AllowListPlugin extends CordovaPlugin {
     }
 
     private class CustomConfigXmlParser extends ConfigXmlParser {
+        private CordovaPreferences prefs = new CordovaPreferences();
+
         @Override
         public void handleStartTag(XmlPullParser xml) {
             String strNode = xml.getName();
             if (strNode.equals("content")) {
                 String startPage = xml.getAttributeValue(null, "src");
                 allowedNavigations.addAllowListEntry(startPage, false);
+
+                // Allow origin for WebViewAssetLoader
+                allowedNavigations.addAllowListEntry("https://" + this.prefs.getString("hostname", "localhost") + "/" + startPage, false);
             } else if (strNode.equals("allow-navigation")) {
                 String origin = xml.getAttributeValue(null, "href");
                 if ("*".equals(origin)) {


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Addresses issues in #1217 

Closes #1217


### Description
<!-- Describe your changes in detail -->

With the introduction of the WebViewAssetloader #1137 and the Allow List Plugin #1138 we need to add the origin / href the app is running to the allowlist.


### Testing
<!-- Please describe in detail how you tested your changes. -->

Create a blank new app with one plugin

```
cordova create test
cd test
cordova platform add https://github.com/apache/cordova-android#webviewassetloader-allowlist
cordova plugin add cordova-plugin-file
cordova run android
```

These steps will produce the hello world cordova app that should show "deviceready" with this pr. See issue.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
