### PR TITLE
fix: remove forced default gradle.daemon setting

### DIFF
--- a/lib/config/GradlePropertiesParser.js
+++ b/lib/config/GradlePropertiesParser.js
@@ -30,9 +30,6 @@ class GradlePropertiesParser {
     */
     constructor (platformDir) {
         this._defaults = {
-            // 10 seconds -> 6 seconds
-            'org.gradle.daemon': 'true',
-
             // to allow dex in process
             'org.gradle.jvmargs': '-Xmx2048m',
 


### PR DESCRIPTION
### Motivation, Context & Description

- Remove the forced default `org.gradle.daemon` setting.
- Per [Gradle Docs](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon):

> The Gradle Daemon is enabled by default, and we recommend always enabling it. You can disable the long-lived Gradle daemon via the --no-daemon command-line option, or by adding org.gradle.daemon=false to your gradle.properties file.

Since the `Gradle Daemon` is enabled by default, this default setting value is no longer needed.

### Additional Notes

Changes were cherry-picked from https://github.com/apache/cordova-android/pull/983.

This PR is based on the users master branch and is out-dated. To avoid rebasing his PR, I decided to create a new PR.

closes: #983
fixes: #982

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
