### PR TITLE
chore!: drop node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rewire": "^5.0.0"
   },
   "engines": {
-    "node": ">=10.10.0"
+    "node": ">=12.0.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
### Motivation, Context & Description

* Drop Node 10 Support from GH Actions Workflow
* Bump required Node engine to `>= 12.0.0`

Node 10 has been deprecated and no longer supported by the nodejs team.

Other packages has dropped node 10 and require node 12 and up.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I've updated the documentation if necessary
