### PR TITLE
fix: Google Services Gradle Plugin version check failure

### DIFF
--- a/templates/project/app/build.gradle
+++ b/templates/project/app/build.gradle
@@ -46,7 +46,7 @@ buildscript {
 
         if(cordovaConfig.IS_GRADLE_PLUGIN_GOOGLE_SERVICES_ENABLED) {
             // Checks if the kotlin version format is valid.
-            if(!cdvHelpers.isVersionValid(gradlePluginGoogleServicesVersion)) {
+            if(!cdvHelpers.isVersionValid(cordovaConfig.GRADLE_PLUGIN_GOOGLE_SERVICES_VERSION)) {
                 throw new GradleException("The defined Google Services plugin version (${cordovaConfig.GRADLE_PLUGIN_GOOGLE_SERVICES_VERSION}) does not appear to be a valid version.")
             }
 


### PR DESCRIPTION
### Motivation and Context

fixes: #1284

Build failure when Google Services Gradle Plugin is enabled. It fails because the version checking is calling a variable that was refactored and forgotten.

### Description

Changed old variable name `gradlePluginGoogleServicesVersion` to new variable name `cordovaConfig.GRADLE_PLUGIN_GOOGLE_SERVICES_VERSION`

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
