### PR TITLE
fix: add missing release notes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -312,6 +312,12 @@
 * [CB-13830](https://issues.apache.org/jira/browse/CB-13830) Add handlers for plugins that use non-Java source files, such as Camera
 * [CB-13923](https://issues.apache.org/jira/browse/CB-13923) Fix -1 length for compressed files
 
+### 7.1.4 (Nov 22, 2018)
+
+* Update android-versions to `1.4.0`, with added support for Android Pie ([#573](https://github.com/apache/cordova-android/pull/573))
+* Output current package name if package name can't be validated ([#567](https://github.com/apache/cordova-android/pull/567))
+* Resolve issue with plugin `target-dir="*app*"` subdirs ([#572](https://github.com/apache/cordova-android/pull/572))
+
 ### 7.1.3 (Nov 19, 2018)
 
 * [GH-495](https://github.com/apache/cordova-android/pull/495) Incorrect default sdk version issue fix

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -312,6 +312,15 @@
 * [CB-13830](https://issues.apache.org/jira/browse/CB-13830) Add handlers for plugins that use non-Java source files, such as Camera
 * [CB-13923](https://issues.apache.org/jira/browse/CB-13923) Fix -1 length for compressed files
 
+### 7.1.1 (Jul 11, 2018)
+* Fix unsafe property access in run.js (#445)
+* Emit log event instead of logging directly (#452)
+* [CB-14101](https://issues.apache.org/jira/browse/CB-14101) Fix Java version check for Java >= 9 (#446)
+* [CB-14127](https://issues.apache.org/jira/browse/CB-14127) (android) Move google maven repo ahead of jcenter
+* [CB-13923](https://issues.apache.org/jira/browse/CB-13923) (android) fix -1 length for compressed files
+* [CB-14145](https://issues.apache.org/jira/browse/CB-14145) use cordova-common@2.2.5 and update other dependencies to resolve `npm audit` warnings
+* [CB-9366](https://issues.apache.org/jira/browse/CB-9366) log error.stack in cordova.js
+
 ### 7.1.0 (Feb 20, 2018)
 * [CB-13879](https://issues.apache.org/jira/browse/CB-13879) updated gradle tools dependency to 3.0.1 for project template
 * [CB-13831](https://issues.apache.org/jira/browse/CB-13831) Update `android-versions` to 1.3.0 to support SDK 27.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -312,6 +312,13 @@
 * [CB-13830](https://issues.apache.org/jira/browse/CB-13830) Add handlers for plugins that use non-Java source files, such as Camera
 * [CB-13923](https://issues.apache.org/jira/browse/CB-13923) Fix -1 length for compressed files
 
+### 7.1.2 (Nov 08, 2018)
+* [CB-14127](https://issues.apache.org/jira/browse/CB-14127): Always put the Google repo above jcenter
+* [CB-14165](https://issues.apache.org/jira/browse/CB-14165): Emulator: handle "device still connecting" error (#457)
+* [CB-14125](https://issues.apache.org/jira/browse/CB-14125): Increase old plugin compatibility
+* [CB-13830](https://issues.apache.org/jira/browse/CB-13830): Add handlers for plugins that use non-Java source files, such as Camera
+* [CB-14038](https://issues.apache.org/jira/browse/CB-14038): fix false positive detecting project type
+
 ### 7.1.1 (Jul 11, 2018)
 * Fix unsafe property access in run.js (#445)
 * Emit log event instead of logging directly (#452)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -312,6 +312,16 @@
 * [CB-13830](https://issues.apache.org/jira/browse/CB-13830) Add handlers for plugins that use non-Java source files, such as Camera
 * [CB-13923](https://issues.apache.org/jira/browse/CB-13923) Fix -1 length for compressed files
 
+### 7.1.3 (Nov 19, 2018)
+
+* [GH-495](https://github.com/apache/cordova-android/pull/495) Incorrect default sdk version issue fix
+* [GH-496](https://github.com/apache/cordova-android/pull/496) update comments in `build.gradle`
+* [GH-539](https://github.com/apache/cordova-android/pull/539) Fix dest overwrite, in case of of plugin `source-file` element with `target-dir` that does not need remapping
+* [GH-540](https://github.com/apache/cordova-android/issues/540) support plugin `source-file` element with any app `target-dir` value
+* [GH-547](https://github.com/apache/cordova-android/issues/547) Compatibility of old plugins with non-Java `source-file` entries (individual files)
+* [GH-551](https://github.com/apache/cordova-android/pull/551) add missing cast for cdvMinSdkVersion to `build.gradle`
+* [GH-552](https://github.com/apache/cordova-android/issues/552) check for `build-extras.gradle` in the parent app directory
+
 ### 7.1.2 (Nov 08, 2018)
 * [CB-14127](https://issues.apache.org/jira/browse/CB-14127): Always put the Google repo above jcenter
 * [CB-14165](https://issues.apache.org/jira/browse/CB-14165): Emulator: handle "device still connecting" error (#457)


### PR DESCRIPTION
### Motivation and Context

Add missing old release notes.

resolves: #639 

### Description

Cherry-picked the missing release notes to main branch.
