### PR TITLE
fix: automatic latest build tools finding

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -53,10 +53,13 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
         throw e
     }
 
+    def minBuildToolsVersion = new Version(minBuildToolsVersionString)
+    def maxVersion = new Version((minBuildToolsVersion.getMajor() + 1) + ".0.0")
+
     def highestBuildToolsVersion = buildToolsDirContents
         .collect { new Version(it) }
         // Invalid inputs will be handled as 0.0.0
-        .findAll { it.isHigherThan('0.0.0') }
+        .findAll { it.isHigherThan('0.0.0') && it.isLowerThan(maxVersion) }
         .max()
 
     if (highestBuildToolsVersion == null) {
@@ -68,7 +71,7 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
 
     if (highestBuildToolsVersion.isLowerThan(minBuildToolsVersionString)) {
         throw new RuntimeException("""
-            No usable Android build tools found. Highest installed version is
+            No usable Android build tools found. Highest ${minBuildToolsVersion.getMajor()}.x installed version is
             ${highestBuildToolsVersion.getOriginalString()}; minimum version
             required is ${minBuildToolsVersionString}.
         """.replaceAll(/\s+/, ' ').trim())


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently, android will attempt to pull in the latest build tools version available on the system, regardless of major versions.
This is problematic because we test against a specific major, and future majors may have breaking changes resulting in an inconsistent build.

### Description
<!-- Describe your changes in detail -->

`doFindLatestInstalledBuildTools` will now limit it's scope to the minimum version major. This means that if our minimum required version is `30.0.3`, it will filter everything that is `>= 31.0.0`.

Likewise, in the future when we support v31, if our minimum version was `31.0.0`, it will filter everything `>= 32.0.0`, etc.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran npm test successfully.

Manually tested with:
- build tools v31 installed, 30.0.3 uninstalled, 30.0.2 installed, errors as expected (minimum version is 30.0.3)
- build tools v31 installed, 30.0.3 installed, 30.0.2 installed, rans successfully, using build tools version 30.0.3.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
