### PR TITLE
fix: fall back to project root repositories.gradle

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -29,7 +29,13 @@ buildscript {
 }
 
 allprojects {
-    apply from: 'repositories.gradle'
+    def hasRepositoriesGradle = file('repositories.gradle').exists()
+    if (hasRepositoriesGradle) {
+        apply from: 'repositories.gradle'
+    } else {
+        apply from: "${project.rootDir}/repositories.gradle"
+    }
+
     repositories repos
 }
 

--- a/templates/project/app/build.gradle
+++ b/templates/project/app/build.gradle
@@ -60,7 +60,13 @@ buildscript {
 
 // Allow plugins to declare Maven dependencies via build-extras.gradle.
 allprojects {
-    apply from: 'repositories.gradle'
+    def hasRepositoriesGradle = file('repositories.gradle').exists()
+    if (hasRepositoriesGradle) {
+        apply from: 'repositories.gradle'
+    } else {
+        apply from: "${project.rootDir}/repositories.gradle"
+    }
+
     repositories repos
 }
 

--- a/templates/project/build.gradle
+++ b/templates/project/build.gradle
@@ -30,7 +30,13 @@ buildscript {
 }
 
 allprojects {
-    apply from: 'repositories.gradle'
+    def hasRepositoriesGradle = file('repositories.gradle').exists()
+    if (hasRepositoriesGradle) {
+        apply from: 'repositories.gradle'
+    } else {
+        apply from: "${project.rootDir}/repositories.gradle"
+    }
+
     repositories repos
 }
 


### PR DESCRIPTION
### Motivation and Context

Not all subprojects will have the `repositories.gradle` so therefore trying to apply `repositories.gradle` will fail.

### Description

This PR updates the logic to check if the `repositories.gradle` exists and if it does not, fallback and use the `repositories.gradle` that is in the project root directory.

### Testing

- `npm t`
- `cordova build android` with a plugin that has a subproject.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
