### PR TITLE
chore: bump version 10.1.0-dev

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -31,7 +31,7 @@ import android.webkit.WebChromeClient.CustomViewCallback;
  * are not expected to implement it.
  */
 public interface CordovaWebView {
-    public static final String CORDOVA_VERSION = "10.0.2-dev";
+    public static final String CORDOVA_VERSION = "10.1.0-dev";
 
     void init(CordovaInterface cordova, List<PluginEntry> pluginEntries, CordovaPreferences preferences);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-android",
-  "version": "10.0.2-dev",
+  "version": "10.1.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-android",
-  "version": "10.0.2-dev",
+  "version": "10.1.0-dev",
   "description": "cordova-android release",
   "main": "lib/Api.js",
   "repository": "github:apache/cordova-android",


### PR DESCRIPTION
### Motivation and Context

Prepare for minor release `10.1.0`

### Description

Bump version in:
- package.json
- package-lock.json
- CordovaWebView.java

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
