### PR TITLE
fix: backbutton test code

### DIFF
--- a/test/androidx/app/src/androidTest/java/org/apache/cordova/unittests/BackButtonMultipageTest.java
+++ b/test/androidx/app/src/androidTest/java/org/apache/cordova/unittests/BackButtonMultipageTest.java
@@ -158,7 +158,7 @@ public class BackButtonMultipageTest {
         assertEquals(START_URL, mActivity.onPageFinishedUrl.take());
     }
 
-    private void assertPageSample(String url) {
+    private void assertPageSample(String url) throws Throwable {
         assertEquals(url, mActivity.onPageFinishedUrl.take());
     }
 }


### PR DESCRIPTION

### Platforms affected
android


### Motivation and Context
Fix the issue of `BackButtonMultipageTest`.

### Description
Adding `throws Throwable` in the `assertPageSample` methods
in order to fix the test error.

### Testing
Do 
```
% npm run java-tests
```
in my local environment (mac).


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
