### PR TITLE
[Android] Added support for BoM imports

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -140,7 +140,8 @@ class ProjectBuilder {
         return {
             libs: findAllUniq(data, /^\s*android\.library\.reference\.\d+=(.*)(?:\s|$)/mg),
             gradleIncludes: findAllUniq(data, /^\s*cordova\.gradle\.include\.\d+=(.*)(?:\s|$)/mg),
-            systemLibs: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=(.*)(?:\s|$)/mg)
+            systemLibs: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=((?!.*\().*)(?:\s|$)/mg),
+            bomPlatforms: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=platform\((?:'|")(.*)(?:'|")\)/mg),
         };
     }
 
@@ -226,11 +227,24 @@ class ProjectBuilder {
             [/^\/?google\/google_play_services\/libproject\/google-play-services_lib\/?$/, 'com.google.android.gms:play-services:+']
         ];
 
+        propertiesObj.bomPlatforms.forEach(function (p) {
+            if (!/:.*:/.exec(p)) {
+                throw new CordovaError('Malformed BoM platform: ' + p);
+            }
+
+            // Add bom platform
+            depsList += '    implementation platform("' + p + '")\n';
+        });
+
         propertiesObj.systemLibs.forEach(function (p) {
             var mavenRef;
             // It's already in gradle form if it has two ':'s
             if (/:.*:/.exec(p)) {
                 mavenRef = p;
+            } else if (/:.*/.exec(p)) {
+                // Support BoM imports
+				mavenRef = p;
+				events.emit('warn', 'Library expects a BoM package: ' + p);
             } else {
                 for (var i = 0; i < SYSTEM_LIBRARY_MAPPINGS.length; ++i) {
                     var pair = SYSTEM_LIBRARY_MAPPINGS[i];

--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -141,7 +141,7 @@ class ProjectBuilder {
             libs: findAllUniq(data, /^\s*android\.library\.reference\.\d+=(.*)(?:\s|$)/mg),
             gradleIncludes: findAllUniq(data, /^\s*cordova\.gradle\.include\.\d+=(.*)(?:\s|$)/mg),
             systemLibs: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=((?!.*\().*)(?:\s|$)/mg),
-            bomPlatforms: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=platform\((?:'|")(.*)(?:'|")\)/mg),
+            bomPlatforms: findAllUniq(data, /^\s*cordova\.system\.library\.\d+=platform\((?:'|")(.*)(?:'|")\)/mg)
         };
     }
 
@@ -243,8 +243,8 @@ class ProjectBuilder {
                 mavenRef = p;
             } else if (/:.*/.exec(p)) {
                 // Support BoM imports
-				mavenRef = p;
-				events.emit('warn', 'Library expects a BoM package: ' + p);
+                mavenRef = p;
+                events.emit('warn', 'Library expects a BoM package: ' + p);
             } else {
                 for (var i = 0; i < SYSTEM_LIBRARY_MAPPINGS.length; ++i) {
                     var pair = SYSTEM_LIBRARY_MAPPINGS[i];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Bill of Material (BoM) pattern simplifies the management of dependency versions (when there are multiple packages with shared dependencies).
https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import

A cordova plugin may want to use BoM to manage the versions of it's dependencies.

Currently there is no way to implement this:

- Package import can not be defined without a version defined
- No ability to import BoM platform

Example using Firebase BoM
https://firebase.google.com/docs/android/learn-more#bom

### Description
<!-- Describe your changes in detail -->

- `propertiesObj.systemLibs` regex - exclude any imports that contains `(` in it's package name
- Added `propertiesObj.bomPlatforms` - any value package which matches `platform("...")`
- Allow package to be imported without version. This will generate a warning in the console

### Testing
<!-- Please describe in detail how you tested your changes. -->

I was able to compile my project (with custom plugin) which uses Firebase BoM

### Checklist

- [ x ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ x ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
