### PR TITLE
fix: dirty fix SystemWebViewEngine by using history.back instead of g…

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -29,6 +29,7 @@ import android.content.pm.ApplicationInfo;
 import android.os.Build;
 import android.view.View;
 import android.webkit.ValueCallback;
+import android.webkit.WebBackForwardList;
 import android.webkit.WebSettings;
 import android.webkit.WebSettings.LayoutAlgorithm;
 import android.webkit.WebView;
@@ -278,11 +279,20 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
     public boolean goBack() {
         // Check webview first to see if there is a history
         // This is needed to support curPage#diffLink, since they are added to parentEngine's history, but not our history url array (JQMobile behavior)
-        if (webView.canGoBack()) {
-            webView.goBack();
-            return true;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WebBackForwardList list = webView.copyBackForwardList();
+            if (list.getCurrentIndex() > 0) {
+                parentWebView.sendJavascript("history.back();");
+                return true;
+            }
+            return false;
+        } else {
+            if (webView.canGoBack()) {
+                webView.goBack();
+                return true;
+            }
+            return false;
         }
-        return false;
     }
 
     @Override


### PR DESCRIPTION

### Platforms affected
android


### Motivation and Context
To pass the BackButtonMultipageTest.testViaHref() on Android 11 (SDK30) .

i.e. This PR fix the following error
```
junit.framework.AssertionFailedError
	at junit.framework.Assert.fail(Assert.java:48)
	at junit.framework.Assert.assertTrue(Assert.java:20)
	at junit.framework.Assert.assertTrue(Assert.java:27)
	at org.apache.cordova.unittests.BackButtonMultipageTest$3.run(BackButtonMultipageTest.java:85)
```
in BackButtonMultipageTest.

### Description
if we use the `window.location = new_url` in javascript and make a page transition,
SDK29 or before => we can go back to previous page by `webView.goBack()`.
SDK30 => we cannot go back to previous page by `webView.goBack()`.

I don't know this is a bug or specification in SDK 30.
Anyway I used `history.back()` in javascript instead on SDK 30. 

### Testing
Open the project `test/androidx` by AndroidStudio,
and execute the BackButtonMultipageTest on Pixel 3 API 30 and API 29 in my local environment.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
