### PR TITLE
fix(PluginManager): AllowBridgeAccess default policy to handle scheme & hostname

### DIFF
--- a/framework/src/org/apache/cordova/AllowListPlugin.java
+++ b/framework/src/org/apache/cordova/AllowListPlugin.java
@@ -32,11 +32,6 @@ public class AllowListPlugin extends CordovaPlugin {
     public static final String PLUGIN_NAME = "CordovaAllowListPlugin";
     protected static final String LOG_TAG = "CordovaAllowListPlugin";
 
-    // @todo same as ConfigXmlParser. Research centralizing ideas, maybe create CordovaConstants
-    private static String SCHEME_HTTPS = "https";
-    // @todo same as ConfigXmlParser. Research centralizing ideas, maybe create CordovaConstants
-    private static String DEFAULT_HOSTNAME = "localhost";
-
     private AllowList allowedNavigations;
     private AllowList allowedIntents;
     private AllowList allowedRequests;
@@ -74,17 +69,7 @@ public class AllowListPlugin extends CordovaPlugin {
             this.allowedIntents = new AllowList();
             this.allowedRequests = new AllowList();
 
-            ConfigXmlParser pref = new CustomConfigXmlParser();
-            pref.parse(webView.getContext());
-
-            if (!this.preferences.getBoolean("AndroidInsecureFileModeEnabled", false)) {
-                String scheme = this.preferences.getString("scheme", SCHEME_HTTPS).toLowerCase();
-                String hostname = this.preferences.getString("hostname", DEFAULT_HOSTNAME);
-                String origin = scheme + "://" + hostname + "/*";
-
-                LOG.d(LOG_TAG, "Adding to Allowed Navigation: " + origin);
-                this.allowedNavigations.addAllowListEntry(origin, false);
-            }
+            new CustomConfigXmlParser().parse(webView.getContext());
         }
     }
 


### PR DESCRIPTION
### Motivation and Context

fixes: #1328
fixes: https://github.com/apache/cordova-plugin-device/issues/118

### Description

Update how the PluginManager handles the default policy.

* If `AndroidInsecureFileModeEnabled` is `true`, then the default policy is `file://`
* If `AndroidInsecureFileModeEnabled` is `false`, then the default policy is the combination of the `scheme` & `hostname`.
  * The default scheme is: `https`
  * The default hostname is: `localhost`
  * If the user changes any of these values, it will be used.

### Testing

* Creating Project
* Adding Platform
* Adding Device Plugin
* Changing `scheme` to `http`
* Changing `hostname` to `apache.org`
* Setting `AndroidInsecureFileModeEnabled` to `true`

### Additional Notes

I also tested a solution that added the fix to the `AllowListPlugin` class. https://github.com/apache/cordova-android/commit/fa5b228bb9cefca36d92df3c80bb6bbc42672377

This is where @NiklasMerz originally the code. The issue is that is was written in the config parser step. The config parser has not fully parse everything, e.g. the preferences, and therefore always picked the default values.

If we wanted to keep the login inside the `AllowListPlugin` file, we would have to move it to the `pluginInitialize` method, after the config parser has been completed.

The question really comes down to, where it should reside?

* The `PluginManager`, is where the default policy is defined.
* The `AllowListPlugin` is where we parse the user's custom-defined `allow-navigation`, `allow-intent`, `access`, and `content`.

IMO the `PluginManager` sounded better. Previously the default policy was `file://` but since `WebViewAssetLoader` was added and default should now be `https://localhost`. But also, since users can change the launch URL to either file or default/custom scheme+hostname, it seems maybe the default policy should be a bit flexible.
### Checklist

- [x] I've run the tests to see all new and existing tests pass
