### PR TITLE
fix(AllowListPlugin): Safely handle default allow navigation policy in allow request

### DIFF
--- a/framework/src/org/apache/cordova/AllowListPlugin.java
+++ b/framework/src/org/apache/cordova/AllowListPlugin.java
@@ -127,7 +127,7 @@ public class AllowListPlugin extends CordovaPlugin {
 
     @Override
     public Boolean shouldAllowRequest(String url) {
-        return (this.shouldAllowNavigation(url) || this.allowedRequests.isUrlAllowListed(url))
+        return (Boolean.TRUE.equals(this.shouldAllowNavigation(url)) || this.allowedRequests.isUrlAllowListed(url))
             ? true
             : null; // default policy
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes: https://github.com/apache/cordova-android/issues/1322

### Description

`shouldAllowRequest` will throw an exception for all URLS that are not in the navigation allowed list.  This change safely tests the result of `shouldAllowNavigation`, avoiding the exception and allowing for the execution to continue to see if the URL is in the request allowed list.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Incorporating this change into our project successfully allows expected network requests that previously were allowed with the whitelist plugin.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
