### PR TITLE
fix(PluginManager): AllowNavigation default policy to handle scheme & hostname

### DIFF
--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -455,7 +455,7 @@ public class PluginManager {
         }
 
         // Default policy:
-        return url.startsWith("file://") || url.startsWith("about:blank");
+        return url.startsWith(getLaunchUrlPrefix()) || url.startsWith("about:blank");
     }
 
 


### PR DESCRIPTION
### Motivation and Context

Allow Navigation should also handle the default policy for scheme & hostname 

### Testing

- `npm t`
- `cordova build`
- `cordova run`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
