### PR TITLE
feat(AndroidManifest): explicitly define the activity attribute android:exported

### DIFF
--- a/templates/project/AndroidManifest.xml
+++ b/templates/project/AndroidManifest.xml
@@ -37,7 +37,8 @@
                 android:launchMode="singleTop"
                 android:theme="@style/Theme.AppCompat.NoActionBar"
                 android:windowSoftInputMode="adjustResize"
-                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode">
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+                android:exported="true">
             <intent-filter android:label="@string/launcher_name">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
### Motivation and Context

Explicitly define the `android:exported` attribute on the Activty within the AndroidManifest.

Previously, this attribute did not need to be explicitly defined but start in Android 12 it will need to be.

> Warning: If an activity, service, or broadcast receiver uses intent filters and doesn't have an explicitly-declared value for android:exported, your app can't be installed on a device that runs Android 12 or higher.

It is safe to add this to the current major as it does not introduce a breaking change.

### Description

Adds the `android:exported="true"` to the activity attribute

### Testing

- build test with build-tools 30.0.3
- build test with build-tools 31.0.0

### Checklist

- [x] I've run the tests to see all new and existing tests pass
