### PR TITLE
fix: escape strings.xml app name

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -255,7 +255,7 @@ exports.create = function (project_path, config, options, events) {
             fs.ensureDirSync(activity_dir);
             fs.copySync(path.join(project_template_dir, 'Activity.java'), activity_path);
             utils.replaceFileContents(activity_path, /__ACTIVITY__/, safe_activity_name);
-            utils.replaceFileContents(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, project_name);
+            utils.replaceFileContents(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, utils.escape(project_name));
             utils.replaceFileContents(activity_path, /__ID__/, package_name);
 
             var manifest = new AndroidManifest(path.join(project_template_dir, 'AndroidManifest.xml'));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,3 +66,21 @@ exports.forgivingWhichSync = (cmd) => {
 
 exports.isWindows = () => os.platform() === 'win32';
 exports.isDarwin = () => os.platform() === 'darwin';
+
+const UNESCAPED_REGEX = /[&<>"']/g;
+
+const escapes = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+
+/**
+ * Converts the characters "&", "<", ">", '"' and "'" in the given string to
+ * their corresponding escaped value
+ * @param {string} str the string to be escaped
+ * @returns the escaped string
+ */
+exports.escape = (str) => UNESCAPED_REGEX.test(str) ? str.replace(UNESCAPED_REGEX, (key) => escapes[key]) : str;

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -275,6 +275,13 @@ describe('create', function () {
                 });
             });
 
+            it('should interpolate the escaped project name into strings.xml', () => {
+                config_mock.name.and.returnValue('<Incredible&App>');
+                return create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, '&lt;Incredible&amp;App&gt;');
+                });
+            });
+
             it('should copy template scripts into generated project', () => {
                 return create.create(project_path, config_mock, {}, events_mock).then(() => {
                     expect(create.copyScripts).toHaveBeenCalledWith(project_path);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Error on `cordova platform add` when the Cordova app name contains the character `&`. The issue occurs when parsing the `strings.xml` file. The issue was introduced on cordova-android 10.1.0

<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/apache/cordova-android/issues/1380

### Description
<!-- Describe your changes in detail -->
Simply replaces the `&` characters in the project name (if present) by an `_`. 


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` and project creation successful


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
