### PR TITLE
fix(GH-1391): Reword minimum build tools version error message

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -64,16 +64,16 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
 
     if (highestBuildToolsVersion == null) {
         throw new RuntimeException("""
-            No installed build tools found. Install the Android build tools
-            version ${minBuildToolsVersionString} or higher.
+            No installed build tools found. Please install the Android build tools
+            version ${minBuildToolsVersionString}.
         """.replaceAll(/\s+/, ' ').trim())
     }
 
     if (highestBuildToolsVersion.isLowerThan(minBuildToolsVersionString)) {
         throw new RuntimeException("""
             No usable Android build tools found. Highest ${minBuildToolsVersion.getMajor()}.x installed version is
-            ${highestBuildToolsVersion.getOriginalString()}; minimum version
-            required is ${minBuildToolsVersionString}.
+            ${highestBuildToolsVersion.getOriginalString()}; Recommended version
+            is ${minBuildToolsVersionString}.
         """.replaceAll(/\s+/, ' ').trim())
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Solves confusion as the current error message suggest they can install any newer version when that is often not the case.
Fixes #1391 

### Description
<!-- Describe your changes in detail -->

Removes text such as "or higher" / "or later" which suggest that the user can install any version later. Instead of attempting to explain that they need a specific major version, I reworded the text to suggest/recommend installing the default build tools version in which Cordova is tested against. Advanced users can still install alternate versions if they know what they are doing and the risks involved.


### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran npm test and manually tested by uninstalling build tools and trying to build.
Note: npm test will fail due to the lack of build tools version installed.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
