### PR TITLE
fix!: changed the method called due to deprecation

### DIFF
--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -219,7 +219,7 @@ public class CordovaInterfaceImpl implements CordovaInterface {
                                           int[] grantResults) throws JSONException {
         Pair<CordovaPlugin, Integer> callback = permissionResultCallbacks.getAndRemoveCallback(requestCode);
         if(callback != null) {
-            callback.first.onRequestPermissionResult(callback.second, permissions, grantResults);
+            callback.first.onRequestPermissionsResult(callback.second, permissions, grantResults);
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`CordovaInterfaceImpl` is calling a deprecated method of `CordovaPlugin`.

Fixes https://github.com/apache/cordova-android/issues/1388

### Description
<!-- Describe your changes in detail -->

Simply replaces the `onRequestPermissionResult` by `onRequestPermissionsResult`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Created a new Cordova android app with a plugin that requests camera permission.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
