### PR TITLE
fix: detect JAVA_HOME with Java 11

### DIFF
--- a/lib/env/java.js
+++ b/lib/env/java.js
@@ -99,7 +99,8 @@ const java = {
                 } else {
                     // See if we can derive it from javac's location.
                     var maybeJavaHome = path.dirname(path.dirname(javacPath));
-                    if (fs.existsSync(path.join(maybeJavaHome, 'lib', 'tools.jar'))) {
+                    if (fs.existsSync(path.join(maybeJavaHome, 'bin', 'java')) ||
+                            fs.existsSync(path.join(maybeJavaHome, 'bin', 'java.exe'))) {
                         environment.JAVA_HOME = maybeJavaHome;
                     } else {
                         throw new CordovaError(default_java_error_msg);


### PR DESCRIPTION
### Platforms affected

Linux and Windows

### Motivation and Context

Starting with Java 9 the JRE and JDK no longer include `tools.jar` as described in [JEP 220](https://openjdk.java.net/jeps/220). As a result the `check_java` function is unable to detect a Java 11 installation unless the `JAVA_HOME` environment variable is set manually:

https://github.com/apache/cordova-android/blob/6d3ce211dd813cc39517a4173068168f7fe2b95e/lib/env/java.js#L101-L102

The check for `tools.jar` appears to have been added in commit 7133576fe9ca8e8a3c91938eba524a843ccf8365.

### Description

This change instead checks for the presence of `${maybeJavaHome}/bin/java` or `${maybeJavaHome}/bin/java.exe`. This is similar to the checks performed by [`gradlew`](https://github.com/gradle/gradle/blob/master/gradlew#L126-L128) and [`gradlew.bat`](https://github.com/gradle/gradle/blob/master/gradlew.bat#L55-L57).

### Testing

On Debian 11:
```
$ readlink -f $(which javac)
/usr/lib/jvm/java-11-openjdk-amd64/bin/javac
$ ls /usr/lib/jvm/java-11-openjdk-amd64/lib/tools.jar
ls: cannot access '/usr/lib/jvm/java-11-openjdk-amd64/lib/tools.jar': No such file or directory
$ ls /usr/lib/jvm/java-11-openjdk-amd64/bin/java
/usr/lib/jvm/java-11-openjdk-amd64/bin/java
```

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
