### PR TITLE
chore: Remove unneeded deprecated annotation

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -51,7 +51,6 @@ class SystemCookieManager implements ICordovaCookieManager {
         return cookieManager.getCookie(url);
     }
 
-    @SuppressWarnings("deprecation")
     public void clearCookies() {
         cookieManager.removeAllCookies(null);
     }


### PR DESCRIPTION
The `@SuppressWarnings("deprecation")` was added because there was some deprecated code for SDK <= 21, but it was removed some time ago, so it's no longer needed to suppress the deprecation warning.