### PR TITLE
fix: restore checkReqs in prepare.js

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -32,7 +32,7 @@ const PlatformMunger = require('cordova-common').ConfigChanges.PlatformMunger;
 const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const utils = require('./utils');
 const gradleConfigDefaults = require('./gradle-config-defaults');
-
+const checkReqs = require('./check_reqs');
 const GradlePropertiesParser = require('./config/GradlePropertiesParser');
 
 function parseArguments (argv) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Restore `checkReqs` in `prepare.js`

### Description
<!-- Describe your changes in detail -->

In PR #1431, additional usage of `checkReqs` was added to `prepare.js`.
In PR #1154, the only usage of `checkReqs` was removed so the requirement was deleted.

Because of #1154 was merged first and #1431 was merged second, with no conflict, the test ended up failing on master. 

This PR just adds back the `require` statement.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
