### PR TITLE
fix: force hostname to lowercase

### DIFF
--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -154,7 +154,7 @@ public class ConfigXmlParser {
             return "file:///android_asset/www/";
         } else {
             String scheme = prefs.getString("scheme", SCHEME_HTTPS).toLowerCase();
-            String hostname = prefs.getString("hostname", DEFAULT_HOSTNAME);
+            String hostname = prefs.getString("hostname", DEFAULT_HOSTNAME).toLowerCase();
 
             if (!scheme.contentEquals(SCHEME_HTTP) && !scheme.contentEquals(SCHEME_HTTPS)) {
                 LOG.d(TAG, "The provided scheme \"" + scheme + "\" is not valid. " +

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -383,7 +383,7 @@ public class PluginManager {
     private String getLaunchUrlPrefix() {
         if (!app.getPreferences().getBoolean("AndroidInsecureFileModeEnabled", false)) {
             String scheme = app.getPreferences().getString("scheme", SCHEME_HTTPS).toLowerCase();
-            String hostname = app.getPreferences().getString("hostname", DEFAULT_HOSTNAME);
+            String hostname = app.getPreferences().getString("hostname", DEFAULT_HOSTNAME).toLowerCase();
             return scheme + "://" + hostname + '/';
         }
 

--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -71,7 +71,7 @@ public class SystemWebViewClient extends WebViewClient {
         this.parentEngine = parentEngine;
 
         WebViewAssetLoader.Builder assetLoaderBuilder = new WebViewAssetLoader.Builder()
-                .setDomain(parentEngine.preferences.getString("hostname", "localhost"))
+                .setDomain(parentEngine.preferences.getString("hostname", "localhost").toLowerCase())
                 .setHttpAllowed(true);
 
         assetLoaderBuilder.addPathHandler("/", path -> {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1426

Per comment https://github.com/apache/cordova-android/issues/1426#issuecomment-1111661474

There might be an underlining issue within the Android WebView and how it is not honouring the domain name incase sensitive specification.

### Description
<!-- Describe your changes in detail -->

As workaround, this PR will force the user defined `hostname` to lowercase with the `.toLowerCase()` method.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `cordova build`
- `cordova run`

Also tested use cases where upper-case string could have been provided while we force lowercase.

**Html**
```
<a href="https://ABCDEFG/another-page.html">ANOTHER PAGE</a>
```
**Javascript**
```
window.location = "https://ABCDEFG/another-page.html";
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
