### PR TITLE
fix!: set & use ANDROID_HOME as default

### DIFF
--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -179,15 +179,15 @@ module.exports.check_android = function () {
         function maybeSetAndroidHome (value) {
             if (!hasAndroidHome && fs.existsSync(value)) {
                 hasAndroidHome = true;
-                process.env.ANDROID_SDK_ROOT = value;
+                process.env.ANDROID_HOME = value;
             }
         }
 
         const adbInPath = forgivingWhichSync('adb');
         const avdmanagerInPath = forgivingWhichSync('avdmanager');
 
-        if (process.env.ANDROID_SDK_ROOT) {
-            maybeSetAndroidHome(path.resolve(process.env.ANDROID_SDK_ROOT));
+        if (process.env.ANDROID_HOME) {
+            maybeSetAndroidHome(path.resolve(process.env.ANDROID_HOME));
         }
 
         // First ensure ANDROID_HOME is set
@@ -240,7 +240,7 @@ module.exports.check_android = function () {
         }
 
         if (!hasAndroidHome) {
-            // If we dont have ANDROID_SDK_ROOT, but we do have some tools on the PATH, try to infer from the tooling PATH.
+            // If we dont have ANDROID_HOME, but we do have some tools on the PATH, try to infer from the tooling PATH.
             let parentDir, grandParentDir;
             if (adbInPath) {
                 parentDir = path.dirname(adbInPath);
@@ -248,7 +248,7 @@ module.exports.check_android = function () {
                 if (path.basename(parentDir) === 'platform-tools') {
                     maybeSetAndroidHome(grandParentDir);
                 } else {
-                    throw new CordovaError('Failed to find \'ANDROID_SDK_ROOT\' environment variable. Try setting it manually.\n' +
+                    throw new CordovaError('Failed to find \'ANDROID_HOME\' environment variable. Try setting it manually.\n' +
                         'Detected \'adb\' command at ' + parentDir + ' but no \'platform-tools\' directory found near.\n' +
                         'Try reinstall Android SDK or update your PATH to include valid path to SDK' + path.sep + 'platform-tools directory.');
                 }
@@ -259,26 +259,26 @@ module.exports.check_android = function () {
                 if (path.basename(parentDir) === 'bin' && path.basename(grandParentDir) === 'tools') {
                     maybeSetAndroidHome(path.dirname(grandParentDir));
                 } else {
-                    throw new CordovaError('Failed to find \'ANDROID_SDK_ROOT\' environment variable. Try setting it manually.\n' +
+                    throw new CordovaError('Failed to find \'ANDROID_HOME\' environment variable. Try setting it manually.\n' +
                         'Detected \'avdmanager\' command at ' + parentDir + ' but no \'tools' + path.sep + 'bin\' directory found near.\n' +
                         'Try reinstall Android SDK or update your PATH to include valid path to SDK' + path.sep + 'tools' + path.sep + 'bin directory.');
                 }
             }
         }
-        if (!process.env.ANDROID_SDK_ROOT) {
-            throw new CordovaError('Failed to find \'ANDROID_SDK_ROOT\' environment variable. Try setting it manually.\n' +
+        if (!process.env.ANDROID_HOME) {
+            throw new CordovaError('Failed to find \'ANDROID_HOME\' environment variable. Try setting it manually.\n' +
                 'Failed to find \'android\' command in your \'PATH\'. Try update your \'PATH\' to include path to valid SDK directory.');
         }
-        if (!fs.existsSync(process.env.ANDROID_SDK_ROOT)) {
-            throw new CordovaError('\'ANDROID_SDK_ROOT\' environment variable is set to non-existent path: ' + process.env.ANDROID_SDK_ROOT +
+        if (!fs.existsSync(process.env.ANDROID_HOME)) {
+            throw new CordovaError('\'ANDROID_HOME\' environment variable is set to non-existent path: ' + process.env.ANDROID_SDK_ROOT +
                 '\nTry update it manually to point to valid SDK directory.');
         }
         // Next let's make sure relevant parts of the SDK tooling is in our PATH
         if (hasAndroidHome && !adbInPath) {
-            process.env.PATH += path.delimiter + path.join(process.env.ANDROID_SDK_ROOT, 'platform-tools');
+            process.env.PATH += path.delimiter + path.join(process.env.ANDROID_HOME, 'platform-tools');
         }
         if (hasAndroidHome && !avdmanagerInPath) {
-            process.env.PATH += path.delimiter + path.join(process.env.ANDROID_SDK_ROOT, 'tools', 'bin');
+            process.env.PATH += path.delimiter + path.join(process.env.ANDROID_HOME, 'tools', 'bin');
         }
         return hasAndroidHome;
     });

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -146,7 +146,7 @@ module.exports.get_gradle_wrapper = function () {
 
 // Returns a promise. Called only by build and clean commands.
 module.exports.check_gradle = function () {
-    const sdkDir = process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME;
+    const sdkDir = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
     if (!sdkDir) {
         return Promise.reject(new CordovaError('Could not find gradle wrapper within Android SDK. Could not find Android SDK directory.\n' +
             'Might need to install Android SDK or set up \'ANDROID_SDK_ROOT\' env variable.'));

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -303,7 +303,7 @@ module.exports.check_android_target = function (projectRoot) {
 module.exports.run = function () {
     console.log('Checking Java JDK and Android SDK versions');
     console.log('ANDROID_SDK_ROOT=' + process.env.ANDROID_SDK_ROOT + ' (recommended setting)');
-    console.log('ANDROID_HOME=' + process.env.ANDROID_HOME + ' (DEPRECATED)');
+    console.log('ANDROID_HOME=' + process.env.ANDROID_HOME);
 
     return Promise.all([this.check_java(), this.check_android()]).then(function (values) {
         console.log('Using Android SDK: ' + process.env.ANDROID_SDK_ROOT);

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -302,8 +302,8 @@ module.exports.check_android_target = function (projectRoot) {
 // Returns a promise.
 module.exports.run = function () {
     console.log('Checking Java JDK and Android SDK versions');
-    console.log('ANDROID_SDK_ROOT=' + process.env.ANDROID_SDK_ROOT + ' (recommended setting)');
-    console.log('ANDROID_HOME=' + process.env.ANDROID_HOME);
+    console.log('ANDROID_HOME=' + process.env.ANDROID_HOME + ' (recommended setting)');
+    console.log('ANDROID_SDK_ROOT=' + process.env.ANDROID_SDK_ROOT + ' (DEPRECATED)');
 
     return Promise.all([this.check_java(), this.check_android()]).then(function (values) {
         console.log('Using Android SDK: ' + process.env.ANDROID_SDK_ROOT);

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -68,20 +68,20 @@ describe('check_reqs', function () {
                     spyOn(which, 'sync').and.returnValue(null);
                     spyOn(fs, 'existsSync').and.returnValue(true);
                 });
-                it('it should set ANDROID_SDK_ROOT on Windows', () => {
+                it('it should set ANDROID_HOME on Windows', () => {
                     spyOn(check_reqs, 'isWindows').and.returnValue(true);
                     process.env.LOCALAPPDATA = 'windows-local-app-data';
                     process.env.ProgramFiles = 'windows-program-files';
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_SDK_ROOT).toContain('windows-local-app-data');
+                        expect(process.env.ANDROID_HOME).toContain('windows-local-app-data');
                     });
                 });
-                it('it should set ANDROID_SDK_ROOT on Darwin', () => {
+                it('it should set ANDROID_HOME on Darwin', () => {
                     spyOn(check_reqs, 'isWindows').and.returnValue(false);
                     spyOn(check_reqs, 'isDarwin').and.returnValue(true);
                     process.env.HOME = 'home is where the heart is';
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_SDK_ROOT).toContain('home is where the heart is');
+                        expect(process.env.ANDROID_HOME).toContain('home is where the heart is');
                     });
                 });
             });
@@ -91,7 +91,7 @@ describe('check_reqs', function () {
                         return path;
                     });
                 });
-                it('should set ANDROID_SDK_ROOT based on `adb` command if command exists in a SDK-like directory structure', () => {
+                it('should set ANDROID_HOME based on `adb` command if command exists in a SDK-like directory structure', () => {
                     spyOn(fs, 'existsSync').and.returnValue(true);
                     spyOn(which, 'sync').and.callFake(function (cmd) {
                         if (cmd === 'adb') {
@@ -101,7 +101,7 @@ describe('check_reqs', function () {
                         }
                     });
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_SDK_ROOT).toEqual('/android/sdk');
+                        expect(process.env.ANDROID_HOME).toEqual('/android/sdk');
                     });
                 });
                 it('should error out if `adb` command exists in a non-SDK-like directory structure', () => {
@@ -119,7 +119,7 @@ describe('check_reqs', function () {
                         expect(err.message).toContain('update your PATH to include valid path');
                     });
                 });
-                it('should set ANDROID_SDK_ROOT based on `avdmanager` command if command exists in a SDK-like directory structure', () => {
+                it('should set ANDROID_HOME based on `avdmanager` command if command exists in a SDK-like directory structure', () => {
                     spyOn(fs, 'existsSync').and.returnValue(true);
                     spyOn(which, 'sync').and.callFake(function (cmd) {
                         if (cmd === 'avdmanager') {
@@ -129,7 +129,7 @@ describe('check_reqs', function () {
                         }
                     });
                     return check_reqs.check_android().then(function () {
-                        expect(process.env.ANDROID_SDK_ROOT).toEqual('/android/sdk');
+                        expect(process.env.ANDROID_HOME).toEqual('/android/sdk');
                     });
                 });
                 it('should error out if `avdmanager` command exists in a non-SDK-like directory structure', () => {
@@ -179,7 +179,7 @@ describe('check_reqs', function () {
                 spyOn(fs, 'existsSync').and.returnValue(true);
                 process.env.ANDROID_HOME = '/android/sdk';
                 return check_reqs.check_android().then(() => {
-                    expect(process.env.ANDROID_SDK_ROOT).toContain(expectedAndroidSdkPath);
+                    expect(process.env.ANDROID_HOME).toContain(expectedAndroidSdkPath);
                 });
             });
 
@@ -203,7 +203,7 @@ describe('check_reqs', function () {
         describe('set PATH for various Android binaries if not available', function () {
             beforeEach(function () {
                 spyOn(which, 'sync').and.returnValue(null);
-                process.env.ANDROID_SDK_ROOT = 'let the children play';
+                process.env.ANDROID_HOME = 'let the children play';
                 spyOn(fs, 'existsSync').and.returnValue(true);
             });
             it('should add tools/bin,tools,platform-tools to PATH if `avdmanager`,`android`,`adb` is not found', () => {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #1425

### Description
<!-- Describe your changes in detail -->

* Check `ANDROID_HOME` before `ANDROID_SDK_ROOT`
* Set `ANDROID_HOME` based on paths
* Flag `ANDROID_SDK_ROOT` as deprecate

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
