### PR TITLE
fix: accept file cookies only if AndroidInsecureFileModeEnabled

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemCookieManager.java
+++ b/framework/src/org/apache/cordova/engine/SystemCookieManager.java
@@ -19,8 +19,6 @@
 
 package org.apache.cordova.engine;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.CookieManager;
 import android.webkit.WebView;
 
@@ -35,8 +33,12 @@ class SystemCookieManager implements ICordovaCookieManager {
         webView = webview;
         cookieManager = CookieManager.getInstance();
 
-        cookieManager.setAcceptFileSchemeCookies(true);
         cookieManager.setAcceptThirdPartyCookies(webView, true);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void setAcceptFileSchemeCookies() {
+        cookieManager.setAcceptFileSchemeCookies(true);
     }
 
     public void setCookiesEnabled(boolean accept) {

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -165,6 +165,7 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
             LOG.d(TAG, "Enabled insecure file access");
             settings.setAllowFileAccess(true);
             settings.setAllowUniversalAccessFromFileURLs(true);
+            cookieManager.setAcceptFileSchemeCookies();
         }
 
         settings.setMediaPlaybackRequiresUserGesture(false);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

we are enabling file cookies even if AndroidInsecureFileModeEnabled is not enabled

### Description
<!-- Describe your changes in detail -->
accept file cookies only if AndroidInsecureFileModeEnabled is true
also suppress the warning caused by using that method 

removes two unused imports
closes https://github.com/apache/cordova-android/issues/1080


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
