### PR TITLE
chore: display warning on deprecated <splash> tag usage

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -63,6 +63,7 @@ module.exports.prepare = function (cordovaProject, options) {
 
     // Update own www dir with project's www assets and plugins' assets and js-files
     return Promise.resolve(updateWww(cordovaProject, this.locations))
+        .then(() => warnForDeprecatedSplashScreen(cordovaProject))
         .then(() => updateProjectAccordingTo(self._config, self.locations))
         .then(function () {
             updateIcons(cordovaProject, path.relative(cordovaProject.root, self.locations.res));
@@ -351,6 +352,16 @@ function updateProjectStrings (platformConfig, locations) {
 
     fs.writeFileSync(locations.strings, strings.write({ indent: 4 }), 'utf-8');
     events.emit('verbose', 'Wrote out android application name "' + name + '" to ' + locations.strings);
+}
+
+function warnForDeprecatedSplashScreen (cordovaProject) {
+    const hasOldSplashTags = (
+        cordovaProject.projectConfig.doc.findall('./platform[@name="android"]/splash') || []
+    ).length > 0;
+
+    if (hasOldSplashTags) {
+        events.emit('warn', 'The "<splash>" tags were detected and are no longer supported. Please migrate to the "preference" tag "AndroidWindowSplashScreenAnimatedIcon".');
+    }
 }
 
 /**

--- a/spec/unit/prepare.spec.js
+++ b/spec/unit/prepare.spec.js
@@ -766,6 +766,8 @@ describe('prepare', () => {
             prepare.__set__('updateWww', jasmine.createSpy());
             prepare.__set__('updateProjectAccordingTo', jasmine.createSpy('updateProjectAccordingTo')
                 .and.returnValue(Promise.resolve()));
+            prepare.__set__('warnForDeprecatedSplashScreen', jasmine.createSpy('warnForDeprecatedSplashScreen')
+                .and.returnValue(Promise.resolve()));
             prepare.__set__('updateIcons', jasmine.createSpy('updateIcons').and.returnValue(Promise.resolve()));
             prepare.__set__('updateFileResources', jasmine.createSpy('updateFileResources').and.returnValue(Promise.resolve()));
             prepare.__set__('updateConfigFilesFrom',
@@ -859,6 +861,8 @@ describe('prepare', () => {
             prepare.__set__('updateWww', jasmine.createSpy('updateWww'));
             prepare.__set__('updateIcons', jasmine.createSpy('updateIcons').and.returnValue(Promise.resolve()));
             prepare.__set__('updateProjectSplashScreen', jasmine.createSpy('updateProjectSplashScreen'));
+            prepare.__set__('warnForDeprecatedSplashScreen', jasmine.createSpy('warnForDeprecatedSplashScreen')
+                .and.returnValue(Promise.resolve()));
             prepare.__set__('updateFileResources', jasmine.createSpy('updateFileResources').and.returnValue(Promise.resolve()));
             prepare.__set__('updateConfigFilesFrom',
                 jasmine.createSpy('updateConfigFilesFrom')


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Users may still use old tag.

### Description
<!-- Describe your changes in detail -->

Display a warning to migate to the new preference tag when `<splash>` tag is used.

This only checks for slash tags in `platform[name="android` as global tags could still be used in other platforms.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`cordova build`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
