### PR TITLE
fix: support installing platfrom from local git clone

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -553,9 +553,17 @@ function updateProjectSplashScreenImage (locations, themeKey, cdvConfigPrefKey, 
     let possiblePreviousDestFilePath = path.join(destPngDir, destFileName + '.png');
 
     // Default Drawable Source File
-    const defaultSrcFilePath = themeKey !== 'windowSplashScreenBrandingImage'
-        ? require.resolve('cordova-android/templates/project/res/drawable/' + destFileNameExt)
-        : null;
+    let defaultSrcFilePath = null;
+
+    if (themeKey !== 'windowSplashScreenBrandingImage') {
+        try {
+            // coming from user project
+            defaultSrcFilePath = require.resolve('cordova-android/templates/project/res/drawable/' + destFileNameExt);
+        } catch (e) {
+            // coming from repo test & coho
+            defaultSrcFilePath = require.resolve('../templates/project/res/drawable/' + destFileNameExt);
+        }
+    }
 
     if (!cdvConfigPrefValue || !fs.existsSync(cdvConfigPrefValue)) {
         let emitType = 'verbose';


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Ability to install platfrom from local git clone

### Description
<!-- Describe your changes in detail -->

If `require.resolve` fails to resolve`cordova-android`, it is coming from local dir..

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`
`cordova build`
`cordova create`
`cordova platform add`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
