### PR TITLE
fix!: ANDROID_HOME is the new default, to check first and give advice

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -83,9 +83,9 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
 String getAndroidSdkDir() {
     def rootDir = project.rootDir
     def androidSdkDir = null
-    String envVar = System.getenv("ANDROID_SDK_ROOT")
+    String envVar = System.getenv("ANDROID_HOME")
     if (envVar == null) {
-        envVar = System.getenv("ANDROID_HOME")
+        envVar = System.getenv("ANDROID_SDK_ROOT")
     }
 
     def localProperties = new File(rootDir, 'local.properties')

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -149,7 +149,7 @@ module.exports.check_gradle = function () {
     const sdkDir = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
     if (!sdkDir) {
         return Promise.reject(new CordovaError('Could not find gradle wrapper within Android SDK. Could not find Android SDK directory.\n' +
-            'Might need to install Android SDK or set up \'ANDROID_SDK_ROOT\' env variable.'));
+            'Might need to install Android SDK or set up \'ANDROID_HOME\' env variable.'));
     }
 
     const gradlePath = module.exports.get_gradle_wrapper();
@@ -270,7 +270,7 @@ module.exports.check_android = function () {
                 'Failed to find \'android\' command in your \'PATH\'. Try update your \'PATH\' to include path to valid SDK directory.');
         }
         if (!fs.existsSync(process.env.ANDROID_HOME)) {
-            throw new CordovaError('\'ANDROID_HOME\' environment variable is set to non-existent path: ' + process.env.ANDROID_SDK_ROOT +
+            throw new CordovaError('\'ANDROID_HOME\' environment variable is set to non-existent path: ' + process.env.ANDROID_HOME +
                 '\nTry update it manually to point to valid SDK directory.');
         }
         // Next let's make sure relevant parts of the SDK tooling is in our PATH
@@ -306,7 +306,7 @@ module.exports.run = function () {
     console.log('ANDROID_SDK_ROOT=' + process.env.ANDROID_SDK_ROOT + ' (DEPRECATED)');
 
     return Promise.all([this.check_java(), this.check_android()]).then(function (values) {
-        console.log('Using Android SDK: ' + process.env.ANDROID_SDK_ROOT);
+        console.log('Using Android SDK: ' + (process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT));
 
         if (!values[1]) {
             throw new CordovaError('Requirements check failed for Android SDK! Android SDK was not detected.');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
cordova-android 11.0.0 (since #1444) reports about `Android SDK: undefined` while `ANDROID_HOME` is set and `ANDROID_SDK_ROOT` is not.


### Description
<!-- Describe your changes in detail -->
```
cordova create hello com.example.hello HelloWorld
cd hello/
cordova platform add android@11.0.0
cordova build
```
with environment variables set for Java (`JAVA_HOME`) and Android (`ANDROID_HOME`, and no more `ANDROID_SDK_ROOT`)

results in a successful build but with wrong reporting during the first steps:
```
Checking Java JDK and Android SDK versions
ANDROID_HOME=C:\my\path\to\android-sdk (recommended setting)
ANDROID_SDK_ROOT=undefined (DEPRECATED)
Using Android SDK: undefined
```

### Testing
<!-- Please describe in detail how you tested your changes. -->
- creating and building a blank project using local clone of my fork of cordova-android
- `npm run test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
