### PR TITLE
fix: Add android prefix to windowSplashScreenBrandingImage

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -382,14 +382,10 @@ function updateProjectSplashScreen (platformConfig, locations) {
         'windowSplashScreenIconBackgroundColor',
         'postSplashScreenTheme'
     ].forEach(themeKey => {
-        let index = 0;
-        if (themeKey.indexOf(':') !== -1) {
-            index = themeKey.indexOf(':') + 1;
-        }
+        let index = themeKey.indexOf(':') + 1;
         const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
         const cdvConfigPrefValue = platformConfig.getPreference(cdvConfigPrefKey, this.platform);
         let themeTargetNode = splashScreenTheme.find(`item[@name="${themeKey}"]`);
-        console.log('hola', cdvConfigPrefKey);
         switch (themeKey) {
         case 'windowSplashScreenBackground':
             // use the user defined value for "colors.xml"

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -378,14 +378,18 @@ function updateProjectSplashScreen (platformConfig, locations) {
         'windowSplashScreenAnimatedIcon',
         'windowSplashScreenAnimationDuration',
         'windowSplashScreenBackground',
-        'windowSplashScreenBrandingImage',
+        'android:windowSplashScreenBrandingImage',
         'windowSplashScreenIconBackgroundColor',
         'postSplashScreenTheme'
     ].forEach(themeKey => {
-        const cdvConfigPrefKey = 'Android' + themeKey.charAt(0).toUpperCase() + themeKey.slice(1);
+        let index = 0;
+        if (themeKey.indexOf(':') !== -1) {
+            index = themeKey.indexOf(':') + 1;
+        }
+        const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
         const cdvConfigPrefValue = platformConfig.getPreference(cdvConfigPrefKey, this.platform);
         let themeTargetNode = splashScreenTheme.find(`item[@name="${themeKey}"]`);
-
+        console.log('hola', cdvConfigPrefKey);
         switch (themeKey) {
         case 'windowSplashScreenBackground':
             // use the user defined value for "colors.xml"
@@ -411,7 +415,7 @@ function updateProjectSplashScreen (platformConfig, locations) {
             updateProjectSplashScreenImage(locations, themeKey, cdvConfigPrefKey, cdvConfigPrefValue);
             break;
 
-        case 'windowSplashScreenBrandingImage':
+        case 'android:windowSplashScreenBrandingImage':
             // display warning only when set.
             if (cdvConfigPrefValue) {
                 events.emit('warn', `"${themeKey}" is currently not supported by the splash screen compatibility library. https://issuetracker.google.com/issues/194301890`);
@@ -537,7 +541,7 @@ function cleanupAndSetProjectSplashScreenImage (srcFile, destFilePath, possibleP
 function updateProjectSplashScreenImage (locations, themeKey, cdvConfigPrefKey, cdvConfigPrefValue = '') {
     const SPLASH_SCREEN_IMAGE_BY_THEME_KEY = {
         windowSplashScreenAnimatedIcon: 'ic_cdv_splashscreen',
-        windowSplashScreenBrandingImage: 'ic_cdv_splashscreen_branding'
+        'android:windowSplashScreenBrandingImage': 'ic_cdv_splashscreen_branding'
     };
 
     const destFileName = SPLASH_SCREEN_IMAGE_BY_THEME_KEY[themeKey] || null;
@@ -555,7 +559,7 @@ function updateProjectSplashScreenImage (locations, themeKey, cdvConfigPrefKey, 
     // Default Drawable Source File
     let defaultSrcFilePath = null;
 
-    if (themeKey !== 'windowSplashScreenBrandingImage') {
+    if (themeKey !== 'android:windowSplashScreenBrandingImage') {
         try {
             // coming from user project
             defaultSrcFilePath = require.resolve('cordova-android/templates/project/res/drawable/' + destFileNameExt);
@@ -575,7 +579,7 @@ function updateProjectSplashScreenImage (locations, themeKey, cdvConfigPrefKey, 
         }
 
         events.emit(emitType, emmitMessage);
-        const cleanupOnly = themeKey === 'windowSplashScreenBrandingImage';
+        const cleanupOnly = themeKey === 'android:windowSplashScreenBrandingImage';
         cleanupAndSetProjectSplashScreenImage(defaultSrcFilePath, destFilePath, possiblePreviousDestFilePath, cleanupOnly);
         return;
     }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -422,6 +422,7 @@ function updateProjectSplashScreen (platformConfig, locations) {
             // force the themes value to `@color/cdv_splashscreen_icon_background`
             if (!cdvConfigPrefValue && themeTargetNode) {
                 splashScreenTheme.remove(themeTargetNode);
+                delete themes.getroot().attrib['xmlns:tools'];
             } else if (cdvConfigPrefValue) {
                 // if there is no current node, create a new node.
                 if (!themeTargetNode) {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -386,6 +386,7 @@ function updateProjectSplashScreen (platformConfig, locations) {
         const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
         const cdvConfigPrefValue = platformConfig.getPreference(cdvConfigPrefKey, this.platform);
         let themeTargetNode = splashScreenTheme.find(`item[@name="${themeKey}"]`);
+
         switch (themeKey) {
         case 'windowSplashScreenBackground':
             // use the user defined value for "colors.xml"

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -382,7 +382,7 @@ function updateProjectSplashScreen (platformConfig, locations) {
         'windowSplashScreenIconBackgroundColor',
         'postSplashScreenTheme'
     ].forEach(themeKey => {
-        let index = themeKey.indexOf(':') + 1;
+        const index = themeKey.indexOf(':') + 1;
         const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
         const cdvConfigPrefValue = platformConfig.getPreference(cdvConfigPrefKey, this.platform);
         let themeTargetNode = splashScreenTheme.find(`item[@name="${themeKey}"]`);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -425,10 +425,10 @@ function updateProjectSplashScreen (platformConfig, locations) {
             } else if (cdvConfigPrefValue) {
                 // if there is no current node, create a new node.
                 if (!themeTargetNode) {
-                    themeTargetNode = themes.getroot().makeelement('item', { name: themeKey });
+                    themeTargetNode = themes.getroot().makeelement('item', { name: themeKey, 'tools:targetApi': '31' });
                     splashScreenTheme.append(themeTargetNode);
                 }
-
+                themes.getroot().attrib['xmlns:tools'] = "http://schemas.android.com/tools";
                 // set the user defined color.
                 themeTargetNode.text = '@drawable/ic_cdv_splashscreen_branding';
             }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -428,7 +428,7 @@ function updateProjectSplashScreen (platformConfig, locations) {
                     themeTargetNode = themes.getroot().makeelement('item', { name: themeKey, 'tools:targetApi': '31' });
                     splashScreenTheme.append(themeTargetNode);
                 }
-                themes.getroot().attrib['xmlns:tools'] = "http://schemas.android.com/tools";
+                themes.getroot().attrib['xmlns:tools'] = 'http://schemas.android.com/tools';
                 // set the user defined color.
                 themeTargetNode.text = '@drawable/ic_cdv_splashscreen_branding';
             }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -427,8 +427,8 @@ function updateProjectSplashScreen (platformConfig, locations) {
                 if (!themeTargetNode) {
                     themeTargetNode = themes.getroot().makeelement('item', { name: themeKey, 'tools:targetApi': '31' });
                     splashScreenTheme.append(themeTargetNode);
+                    themes.getroot().attrib['xmlns:tools'] = 'http://schemas.android.com/tools';
                 }
-                themes.getroot().attrib['xmlns:tools'] = 'http://schemas.android.com/tools';
                 // set the user defined color.
                 themeTargetNode.text = '@drawable/ic_cdv_splashscreen_branding';
             }


### PR DESCRIPTION
closes https://github.com/apache/cordova-android/issues/1475

`windowSplashScreenBrandingImage` is not valid, it should be `android:windowSplashScreenBrandingImage`.

All other values should also include the `android:`, but the support library allows to use them without the `android:` part, but since `windowSplashScreenBrandingImage` is not supported by the support library apps fail to compile.

This PR adds the `android:` prefix to the value so it gets added to the styles file with the prefix.
Needed to patch how the cdvConfigPrefKey is generated to strip the android: part of the themeKey