### PR TITLE
fix: import type definitions from obsolete cordova-plugin-splashscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cordova-android",
   "version": "11.0.1-dev",
   "description": "cordova-android release",
+  "types": "./types/index.d.ts",
   "main": "lib/Api.js",
   "repository": "github:apache/cordova-android",
   "bugs": "https://github.com/apache/cordova-android/issues",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,26 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+interface Navigator {
+    /** This plugin displays and hides a splash screen during application launch. */
+    splashscreen: {
+        /** Dismiss the splash screen. */
+        hide(): void;
+    }
+}


### PR DESCRIPTION
### Platforms affected
Affects TypeScript enabled projects only


### Motivation and Context
Type definitions to allow programmatic control of the splashscreen are needed in `cordova-android` now that `cordova-plugin-splashscreen` was obsoleted as part of the Android 12 splash support.


### Description
Import the current type definitions from `cordova-plugin-splashscreen` and expose them for use within a typescript project.



### Testing
I've imported this into an existing TypeScript-based application that has `cordova-plugin-splashscreen` removed, and ensured that TypeScript compilation produces no warnings or errors



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
