### PR TITLE
fix(splash-screen): support navigator.splashscreen.hide w/ AutoHideSplashScreen set to true

### DIFF
--- a/framework/src/org/apache/cordova/SplashScreenPlugin.java
+++ b/framework/src/org/apache/cordova/SplashScreenPlugin.java
@@ -67,6 +67,11 @@ public class SplashScreenPlugin extends CordovaPlugin {
      */
     private boolean keepOnScreen = true;
 
+    /**
+     * @param boolean delayHandlerCondition flag determins if the handler should continut to run
+     */
+    private boolean delayHandlerCondition = true;
+
     @Override
     protected void pluginInitialize() {
         // Auto Hide & Delay Settings
@@ -92,11 +97,8 @@ public class SplashScreenPlugin extends CordovaPlugin {
         JSONArray args,
         CallbackContext callbackContext
     ) throws JSONException {
-        if (action.equals("hide") && autoHide == false) {
-            /*
-             * The `.hide()` method can only be triggered if the `splashScreenAutoHide`
-             * is set to `false`.
-             */
+        if (action.equals("hide")) {
+            delayHandlerCondition = false;
             keepOnScreen = false;
         } else {
             return false;
@@ -127,8 +129,11 @@ public class SplashScreenPlugin extends CordovaPlugin {
 
         // auto hide splash screen when custom delay is defined.
         if (autoHide && delayTime != DEFAULT_DELAY_TIME) {
-            Handler splashScreenDelayHandler = new Handler();
-            splashScreenDelayHandler.postDelayed(() -> keepOnScreen = false, delayTime);
+            Handler delayHandler = new Handler();
+            delayHandler.postDelayed(
+                () -> delayHandlerCondition ? keepOnScreen = false : null,
+                delayTime
+            );
         }
 
         // auto hide splash screen with default delay (-1) delay is controlled by the


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Allow developers to call the `.hide()` method while also using automatic hide settings

Closes #1463

### Testing
<!-- Please describe in detail how you tested your changes. -->

None

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
