### PR TITLE
chore: Use gradle 7.4.2 distribution url

### DIFF
--- a/spec/fixtures/android_studio_project/gradle/wrapper/gradle-wrapper.properties
+++ b/spec/fixtures/android_studio_project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip


### PR DESCRIPTION
The default gradle version is 7.4.2 (https://github.com/apache/cordova-android/blob/606e9c482687dc3818186a02974a747cb183f73c/framework/cdv-gradle-config-defaults.json#L5)

But when creating new project, it still points to 7.1.1 until you run build that then updates the distribution url to 7.4.2

I think both versions should match.