### PR TITLE
refactor: replace deprecated Handler constructor

### DIFF
--- a/framework/src/org/apache/cordova/SplashScreenPlugin.java
+++ b/framework/src/org/apache/cordova/SplashScreenPlugin.java
@@ -127,7 +127,7 @@ public class SplashScreenPlugin extends CordovaPlugin {
 
         // auto hide splash screen when custom delay is defined.
         if (autoHide && delayTime != DEFAULT_DELAY_TIME) {
-            Handler splashScreenDelayHandler = new Handler();
+            Handler splashScreenDelayHandler = new Handler(cordova.getContext().getMainLooper());
             splashScreenDelayHandler.postDelayed(() -> keepOnScreen = false, delayTime);
         }
 


### PR DESCRIPTION
Handler without arguments is deprecated, pass Cordova's Context mainLooper