### PR TITLE
chore: Add lint:fix script for fixing lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "cordova-js build > templates/project/assets/www/cordova.js",
     "test": "npm run lint && npm run cover && npm run java-unit-tests",
     "lint": "eslint lib spec test \"templates/cordova/**/!(*.*)\"",
+    "fmt": "eslint lib spec test \"templates/cordova/**/!(*.*)\" --fix",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
     "cover": "nyc jasmine --config=spec/coverage.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "cordova-js build > templates/project/assets/www/cordova.js",
     "test": "npm run lint && npm run cover && npm run java-unit-tests",
     "lint": "eslint lib spec test \"templates/cordova/**/!(*.*)\"",
-    "fmt": "eslint lib spec test \"templates/cordova/**/!(*.*)\" --fix",
+    "lint:fix": "npm run lint -- --fix",
     "unit-tests": "jasmine --config=spec/unit/jasmine.json",
     "cover": "nyc jasmine --config=spec/coverage.json",
     "e2e-tests": "jasmine --config=spec/e2e/jasmine.json",


### PR DESCRIPTION
At the moment we have the lint script that tells you all the lint errors the code has, but you have to fix all the problems manually, which is tedious.
Since we are already using eslint for the linting, we can use the `--fix` parameter to automatically fix the errors (or at least most of them).

With this PR users will be able to run `npm run fmt` (I'm open for using other name), and fix the lint errors without having to manually change the code.

We could probably add this to all repositories that are already using eslint.