### PR TITLE
fix: correctly flag API dependency on AppCompat for Maven

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -78,7 +78,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:${cordovaConfig.ANDROIDX_APP_COMPAT_VERSION}"
+    api "androidx.appcompat:appcompat:${cordovaConfig.ANDROIDX_APP_COMPAT_VERSION}"
     implementation "androidx.webkit:webkit:${cordovaConfig.ANDROIDX_WEBKIT_VERSION}"
     implementation "androidx.core:core-splashscreen:${cordovaConfig.ANDROIDX_CORE_SPLASHSCREEN_VERSION}"
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -75,6 +75,12 @@ android {
         exclude 'META-INF/DEPENDENCIES'
         exclude 'META-INF/NOTICE'
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {

--- a/framework/cordova-publish.gradle
+++ b/framework/cordova-publish.gradle
@@ -46,73 +46,69 @@ if (project.hasProperty('signEnabled')) {
     }
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
+afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId = 'org.apache.cordova'
+                artifactId = 'framework'
+                version = getCordovaAndroidVersion()
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId = 'org.apache.cordova'
-            artifactId = 'framework'
-            version = getCordovaAndroidVersion()
+                from components.release
 
-            artifact(sourcesJar)
-            artifact("$buildDir/outputs/aar/framework-release.aar")
+                pom {
+                    name = 'Cordova'
+                    description = 'A library to build Cordova-based projects for the Android platform.'
+                    url = 'https://cordova.apache.org'
 
-            pom {
-                name = 'Cordova'
-                description = 'A library to build Cordova-based projects for the Android platform.'
-                url = 'https://cordova.apache.org'
-
-                licenses {
-                    license {
-                        name = 'Apache License, Version 2.0'
-                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    licenses {
+                        license {
+                            name = 'Apache License, Version 2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
                     }
-                }
 
-                developers {
-                    developer {
-                        id = 'stevengill'
-                        name = 'Steve Gill'
+                    developers {
+                        developer {
+                            id = 'stevengill'
+                            name = 'Steve Gill'
+                        }
+                        developer {
+                            id = 'erisu'
+                            name = 'Bryan Ellis'
+                            email = 'erisu@apache.org'
+                        }
                     }
-                    developer {
-                        id = 'erisu'
-                        name = 'Bryan Ellis'
-                        email = 'erisu@apache.org'
-                    }
-                }
 
-                scm {
-                    connection = 'scm:git:https://github.com/apache/cordova-android.git'
-                    developerConnection = 'scm:git:git@github.com:apache/cordova-android.git'
-                    url = 'https://github.com/apache/cordova-android'
+                    scm {
+                        connection = 'scm:git:https://github.com/apache/cordova-android.git'
+                        developerConnection = 'scm:git:git@github.com:apache/cordova-android.git'
+                        url = 'https://github.com/apache/cordova-android'
+                    }
                 }
             }
         }
-    }
 
-    repositories {
-        maven {
-            def releasesRepoUrl = 'https://repository.apache.org/content/repositories/releases'
-            def snapshotsRepoUrl = 'https://repository.apache.org/content/repositories/snapshots'
+        repositories {
+            maven {
+                def releasesRepoUrl = 'https://repository.apache.org/content/repositories/releases'
+                def snapshotsRepoUrl = 'https://repository.apache.org/content/repositories/snapshots'
 
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-            credentials {
-                if (project.hasProperty('apacheUsername') && project.hasProperty('apachePassword')) {
-                    username apacheUsername
-                    password apachePassword
+                credentials {
+                    if (project.hasProperty('apacheUsername') && project.hasProperty('apachePassword')) {
+                        username apacheUsername
+                        password apachePassword
+                    }
                 }
             }
         }
-    }
 
-    signing {
-        if (Boolean.valueOf(cdvEnableSigning)) {
-            sign publishing.publications.mavenJava
+        signing {
+            if (Boolean.valueOf(cdvEnableSigning)) {
+                sign publishing.publications.mavenJava
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently when cordova-android is published to Maven, it lists no dependencies. However, `CordovaActivity` extends `AppCompatActivity` which requires that the AndroidX AppCompat library be available.


### Description
<!-- Describe your changes in detail -->
Marking AndroidX AppCompat as an API dependency (rather than an implementation/compile dependency) should cause the AndroidX AppCompat library to be installed when the cordova-android framework is added to the build.gradle of an existing Android application.


### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested publishing to my local Maven repository, and confirmed that dependencies are correctly captured in the pom.xml.
