### PR TITLE
fix: only do fadeout animation if FadeSplashScreen is true

### DIFF
--- a/framework/src/org/apache/cordova/SplashScreenPlugin.java
+++ b/framework/src/org/apache/cordova/SplashScreenPlugin.java
@@ -137,27 +137,29 @@ public class SplashScreenPlugin extends CordovaPlugin {
         // If auto hide is disabled (false), the hiding of the splash screen must be determined &
         // triggered by the front-end code with the `navigator.splashscreen.hide()` method.
 
-        // Setup the fade
-        splashScreen.setOnExitAnimationListener(new SplashScreen.OnExitAnimationListener() {
-            @Override
-            public void onSplashScreenExit(@NonNull SplashScreenViewProvider splashScreenViewProvider) {
-                View splashScreenView = splashScreenViewProvider.getView();
+        if (isFadeEnabled) {
+            // Setup the fade
+            splashScreen.setOnExitAnimationListener(new SplashScreen.OnExitAnimationListener() {
+                @Override
+                public void onSplashScreenExit(@NonNull SplashScreenViewProvider splashScreenViewProvider) {
+                    View splashScreenView = splashScreenViewProvider.getView();
 
-                splashScreenView
-                    .animate()
-                    .alpha(0.0f)
-                    .setDuration(isFadeEnabled ? fadeDuration : 0)
-                    .setStartDelay(isFadeEnabled ? 0 : fadeDuration)
-                    .setInterpolator(new AccelerateInterpolator())
-                    .setListener(new AnimatorListenerAdapter() {
-                        @Override
-                        public void onAnimationEnd(Animator animation) {
-                            super.onAnimationEnd(animation);
-                            splashScreenViewProvider.remove();
-                        }
-                    }).start();
-            }
-        });
+                    splashScreenView
+                            .animate()
+                            .alpha(0.0f)
+                            .setDuration(fadeDuration)
+                            .setStartDelay(0)
+                            .setInterpolator(new AccelerateInterpolator())
+                            .setListener(new AnimatorListenerAdapter() {
+                                @Override
+                                public void onAnimationEnd(Animator animation) {
+                                    super.onAnimationEnd(animation);
+                                    splashScreenViewProvider.remove();
+                                }
+                            }).start();
+                }
+            });
+        }
     }
 
     private void attemptCloseOnPageFinished() {


### PR DESCRIPTION
Configuring the status bar at startup no longer works on Android 13 if the splash screen has a configured `setOnExitAnimationListener`.

Current implementation creates an animation with no duration if FadeSplashScreen is false, and delays the hide of the splash screen for the configured amount on FadeSplashScreenDuration. 
But if FadeSplashScreen is false it should not have an animation listener and should not delay the splash screen hide.

related: https://github.com/apache/cordova-android/issues/1501