### PR TITLE
feat!: Bump min SDK to 24

### DIFF
--- a/framework/cdv-gradle-config-defaults.json
+++ b/framework/cdv-gradle-config-defaults.json
@@ -1,5 +1,5 @@
 {
-    "MIN_SDK_VERSION": 22,
+    "MIN_SDK_VERSION": 24,
     "SDK_VERSION": 33,
     "COMPILE_SDK_VERSION": null,
     "GRADLE_VERSION": "7.4.2",


### PR DESCRIPTION
Rationale:
API 22 & API 23 both account for an insignificant part of the market share. While API 24 - API 26 has similar market share, we felt that bumping to API 26 from API 22 is too large of a jump.

Legacy devices may be completely out of support by Google and may not be able to receive the latest webview version. As of writing, Chromium's latest tag shows they are using a Min SDK version of 24. (Ref: https://chromium.googlesource.com/chromium/src/+/refs/tags/113.0.5653.1/build/config/android/config.gni#46)

Based on AOSP emulators, API 24 (Android 7.0) will ship with Chrome 52 webview, which has good support for ECMAscript 2015 (ES6) (Ref: https://caniuse.com/?search=es6)

While in most cases, app users will likely have a modern webview vesion installed, this means you can be confident that the app user will have a chrome webview version with good ES6 support, even if they happen to be running on a factory versioned device.

See the mailing thread for the full discussion:
https://lists.apache.org/thread/zcgof080hdzzo2j96mjz0qpj0gotmn57

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
