### PR TITLE
fix(GH-1432): Default content src when content tag is missing

### DIFF
--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -34,6 +34,7 @@ public class ConfigXmlParser {
     private static String SCHEME_HTTP = "http";
     private static String SCHEME_HTTPS = "https";
     private static String DEFAULT_HOSTNAME = "localhost";
+    private static final String DEFAULT_CONTENT_SRC = "index.html";
 
     private String launchUrl;
     private String contentSrc;
@@ -110,6 +111,18 @@ public class ConfigXmlParser {
                 e.printStackTrace();
             }
         }
+
+        onPostParse();
+    }
+
+    private void onPostParse() {
+        // After parsing, if contentSrc is still null, it signals
+        // that <content> tag was completely missing. In this case,
+        // default it.
+        // https://github.com/apache/cordova-android/issues/1432
+        if (contentSrc == null) {
+            contentSrc = DEFAULT_CONTENT_SRC;
+        }
     }
 
     public void handleStartTag(XmlPullParser xml) {
@@ -140,7 +153,7 @@ public class ConfigXmlParser {
                 contentSrc = src;
             } else {
                 // Default
-                contentSrc = "index.html";
+                contentSrc = DEFAULT_CONTENT_SRC;
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes https://github.com/apache/cordova-android/issues/1432

If the project is missing the `<content>` tag inside their `config.xml`, Cordova will completely crash with a fatal error.

### Description
<!-- Describe your changes in detail -->

Inside `ConfigXMLParser`, I added a `onPostParse` private method in which I check to see if the `contentSrc` string is still null. If so, it can be assumed that the `<content>` tag was completely missing and the `contentSrc` string is then fallen back to the default content source, which is now powered by a constant.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test` and manually ran against a project with a missing `<content>`. Observing the crash in cordova-android@11, and observing the fix using locally packed tarball install.

Additionally I also tested renaming the `index.html` and setting `<content src>` respectfully to confirm no breakage.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
