### PR TITLE
feat: add plugin hooks for WebViewClient.onRenderProcessGone

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -31,6 +31,8 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -441,5 +443,18 @@ public class CordovaPlugin {
      */
     public CordovaPluginPathHandler getPathHandler() {
         return null;
+    }
+
+    /**
+     * Called when the WebView's render process has exited.
+     *
+     * See <a href="https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)">WebViewClient#onRenderProcessGone</a>
+     *
+     * @return  true if the host application handled the situation that process has exited,
+     *          otherwise, application will crash if render process crashed, or be killed
+     *          if render process was killed by the system.
+     */
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        return false;
     }
 }

--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -446,9 +446,11 @@ public class CordovaPlugin {
     }
 
     /**
-     * Called when the WebView's render process has exited.
+     * Called when the WebView's render process has exited. Can be used to collect information regarding the crash for crashlytics or optionally attempt to gracefully handle/recover the crashed webview by recreating it.
      *
      * See <a href="https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)">WebViewClient#onRenderProcessGone</a>
+     *
+     * Note: A plugin must not attempt to recover a webview that it does not own/manage.
      *
      * @return  true if the host application handled the situation that process has exited,
      *          otherwise, application will crash if render process crashed, or be killed

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -32,6 +32,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Debug;
 import android.os.Build;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
 
 /**
  * PluginManager is exposed to JavaScript in the Cordova WebView.
@@ -605,5 +607,30 @@ public class PluginManager {
             }
         }
         return handlers;
+    }
+
+    /**
+     * Called when the WebView's render process has exited.
+     *
+     * See https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)
+     *
+     * @return  true if the host application handled the situation that process has exited,
+     *          otherwise, application will crash if render process crashed, or be killed 
+     *          if render process was killed by the system.
+     */
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        boolean result = false;
+        synchronized (this.entryMap) {
+            for (PluginEntry entry : this.entryMap.values()) {
+                CordovaPlugin plugin = pluginMap.get(entry.service);
+                if (plugin != null) {
+                    if (plugin.onRenderProcessGone(view, detail)) {
+                        result = true;
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -28,6 +28,7 @@ import android.net.http.SslError;
 import android.webkit.ClientCertRequest;
 import android.webkit.HttpAuthHandler;
 import android.webkit.MimeTypeMap;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -421,5 +422,16 @@ public class SystemWebViewClient extends WebViewClient {
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
         return this.assetLoader.shouldInterceptRequest(request.getUrl());
+    }
+
+    @Override
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        // Check if there is some plugin which can handle this event
+        PluginManager pluginManager = this.parentEngine.pluginManager;
+        if (pluginManager != null && pluginManager.onRenderProcessGone(view, detail)) {
+            return true;
+        }
+
+        return super.onRenderProcessGone(view, detail);
     }
 }


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
This change allows more advanced handling of the webview render process termination. This can be useful for capturing additional information, or even conceivably allow the crash to be prevented should a plugin choose to.


### Description
Expose the [WebViewClient.onRenderProcessGone](https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)) method down to plugins, and allow a plugin to interrupt the crash should it choose so.


### Testing
I created the hello world cordova application and added a javascript call to load `chrome://crash` (recommended by Android docs as the best way to trigger a renderer crash).


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
