### PR TITLE
fix(BuildHelper): get package name from ApplicationInfo

### DIFF
--- a/framework/src/org/apache/cordova/BuildHelper.java
+++ b/framework/src/org/apache/cordova/BuildHelper.java
@@ -51,7 +51,8 @@ public class BuildHelper {
     {
         try
         {
-            Class<?> clazz = Class.forName(ctx.getClass().getPackage().getName() + ".BuildConfig");
+            String packageName = ctx.getApplicationInfo().packageName;
+            Class<?> clazz = Class.forName(packageName + ".BuildConfig");
             Field field = clazz.getField(key);
             return field.get(null);
         } catch (ClassNotFoundException e) {


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
for example
if the Activity is not at the to  level of the package,like this. 

<img width="341" alt="image" src="https://user-images.githubusercontent.com/18605757/227781474-03f0aa96-299c-4409-862a-7b09ecbd38bf.png">

The package name of my project is com/yzq/cordovademo.  But I get  the `Unable to get the BuildConfig, is this built with ANT?` exception when I use the camera plugin.

<img width="676" alt="image" src="https://user-images.githubusercontent.com/18605757/227782034-9f7efdf0-3b71-4971-90d5-780f4e35a0a3.png">

<!-- If it fixes an open issue, please link to the issue here. -->





### Description
<!-- Describe your changes in detail -->
We don't have to worry about the Activity hierarchy by getting the package name like `ctx.getApplicationInfo().packageName`


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
