### PR TITLE
refactor: Removed obsolete version code checks

### DIFF
--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -237,14 +237,6 @@ public class CordovaInterfaceImpl implements CordovaInterface {
 
     public boolean hasPermission(String permission)
     {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-        {
-            int result = activity.checkSelfPermission(permission);
-            return PackageManager.PERMISSION_GRANTED == result;
-        }
-        else
-        {
-            return true;
-        }
+        return PackageManager.PERMISSION_GRANTED == activity.checkSelfPermission(permission);
     }
 }

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -339,22 +339,11 @@ public class PluginManager {
     public Object postMessage(String id, Object data) {
         LOG.d(TAG, "postMessage: " + id);
         synchronized (this.pluginMap) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                this.pluginMap.forEach((s, plugin) -> {
-                    if (plugin != null) {
-                        plugin.onMessage(id, data);
-                    }
-                });
-            } else {
-                for (CordovaPlugin plugin : this.pluginMap.values()) {
-                    if (plugin != null) {
-                        Object obj = plugin.onMessage(id, data);
-                        if (obj != null) {
-                            return obj;
-                        }
-                    }
+            this.pluginMap.forEach((s, plugin) -> {
+                if (plugin != null) {
+                    plugin.onMessage(id, data);
                 }
-            }
+            });
         }
         return ctx.onMessage(id, data);
     }


### PR DESCRIPTION
Now that our Min SDK is 24, testing for >= N (API 24) and >= M (API 22) is obsolete as it will always be true. Simplify the codebase by removing the conditions and keeping only the API 24 or later codepath.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual build + npm test

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
