### PR TITLE
feat: InspectableWebview preference

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -175,9 +175,20 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
         String databasePath = webView.getContext().getApplicationContext().getDir("database", Context.MODE_PRIVATE).getPath();
         settings.setDatabaseEnabled(true);
 
-        //Determine whether we're in debug or release mode, and turn on Debugging!
-        ApplicationInfo appInfo = webView.getContext().getApplicationContext().getApplicationInfo();
-        if ((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
+        // The default is to use the module's debuggable state to decide if the webview inspecter
+        // should be enabled. However, users can configure InspectableWebview preference to forcefully enable
+        // or disable the webview inspecter.
+        String inspectableWebview = preferences.getString("InspectableWebview", null);
+        boolean shouldEnableInspector = false;
+        if (inspectableWebview == null) {
+            ApplicationInfo appInfo = webView.getContext().getApplicationContext().getApplicationInfo();
+            shouldEnableInspector = (appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+        }
+        else if ("true".equals(inspectableWebview)) {
+            shouldEnableInspector = true;
+        }
+
+        if (shouldEnableInspector) {
             enableRemoteDebugging();
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Sister PR of https://github.com/apache/cordova-ios/pull/1300
Makes cordova-android honour the `InspectableWebview` preference in a similar fashion the iOS platform.

### Description
<!-- Describe your changes in detail -->

Like iOS, android will default to the original method of choosing if the inspecter should be enabled based on the module's debuggable flag. So if the preference is unset, the inspecter will be enabled on debug builds, and disabled on release builds.

If the preference is set and if, and only if the value is `"true"`, the webview inspecter will be forcefully enabled.
If the preference is set but is not `"true"` (including any invalid value), the webview inspector will be forcefully disabled.

Unlike iOS, Android has had the ability to independently control the inspecter programmatically for some time, so there is no Android OS limitation.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran npm test
Manual obesrvations in HelloWorld test app.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
