### PR TITLE
fix(test): Native test namespace refactor

### DIFF
--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -24,6 +24,8 @@ android {
     compileSdkVersion cordovaConfig.COMPILE_SDK_VERSION
     buildToolsVersion cordovaConfig.BUILD_TOOLS_VERSION
 
+    namespace 'org.apache.cordova.unittests'
+
     defaultConfig {
         applicationId "org.apache.cordova.unittests"
         minSdkVersion cordovaConfig.MIN_SDK_VERSION

--- a/test/androidx/app/src/main/AndroidManifest.xml
+++ b/test/androidx/app/src/main/AndroidManifest.xml
@@ -17,8 +17,7 @@
        specific language governing permissions and limitations
        under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.apache.cordova.unittests">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android Tests

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/apache/cordova-android/pull/1539 forgot to refactor the native test

With the newer AGP version, specifying the package id inside `AndroidManifest.xml` is deprecated and should be defined in the gradle file under `android.namespace`

Solves:

```
package="org.apache.cordova.unittests" found in source AndroidManifest.xml: /development/cordova/breautek/cordova-android/test/androidx/app/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

### Description
<!-- Describe your changes in detail -->

Removed `package` from `AndroidManifest.xml` test project.
Add `namespace` to it's gradle file.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
