### PR TITLE
deprecate: CoreAndroid.getBuildConfigValue

### DIFF
--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -19,6 +19,8 @@
 
 package org.apache.cordova;
 
+import org.apache.cordova.BuildHelper;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -30,7 +32,6 @@ import android.content.IntentFilter;
 import android.telephony.TelephonyManager;
 import android.view.KeyEvent;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 
 /**
@@ -376,35 +377,19 @@ public class CoreAndroid extends CordovaPlugin {
         }
     }
 
-      /*
+    /*
      * This needs to be implemented if you wish to use the Camera Plugin or other plugins
      * that read the Build Configuration.
      *
      * Thanks to Phil@Medtronic and Graham Borland for finding the answer and posting it to
      * StackOverflow.  This is annoying as hell!
      *
+     * @deprecated Use {@link BuildHelper#getBuildConfigValue} instead.
      */
-
+    @Deprecated
     public static Object getBuildConfigValue(Context ctx, String key)
     {
-        try
-        {
-            Class<?> clazz = Class.forName(ctx.getClass().getPackage().getName() + ".BuildConfig");
-            Field field = clazz.getField(key);
-            return field.get(null);
-        } catch (ClassNotFoundException e) {
-            LOG.d(TAG, "Unable to get the BuildConfig, is this built with ANT?");
-            e.printStackTrace();
-        } catch (NoSuchFieldException e) {
-            LOG.d(TAG, key + " is not a valid field. Check your build.gradle");
-        } catch (IllegalAccessException e) {
-            LOG.d(TAG, "Illegal Access Exception: Let's print a stack trace.");
-            e.printStackTrace();
-        } catch (NullPointerException e) {
-            LOG.d(TAG, "Null Pointer Exception: Let's print a stack trace.");
-            e.printStackTrace();
-        }
-
-        return null;
+        LOG.w(TAG, "CoreAndroid.getBuildConfigValue is deprecated and will be removed in a future release. Use BuildHelper.getBuildConfigValue instead.");
+        return BuildHelper.getBuildConfigValue(ctx, key);
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We have 2 copies of an implementation of `getBuildConfigValue`, one inside `CoreAndroid` and another in `BuildConfig`.
The `BuildConfig` variant was directly migrated from our old deprecated `cordova-plugin-compat` package, so it is more likely that the `BuildConfig` variant is used more than the `CoreAndroid` version.

### Description
<!-- Describe your changes in detail -->

Added `@Deprecated` decorator for build compilation warning.

![Screenshot from 2023-04-14 09-30-16](https://user-images.githubusercontent.com/11200662/232045484-b43b7d56-b1e2-4b86-a790-f797e0e6fe41.png)


Add `@deprecated` JavaDoc for code editor hints and information on how to migrate.

![Screenshot from 2023-04-14 09-31-06](https://user-images.githubusercontent.com/11200662/232045584-3475aeae-65d1-4a2f-b02e-db0d1ab8eece.png)

![Screenshot from 2023-04-14 09-30-50](https://user-images.githubusercontent.com/11200662/232045523-d15264a6-d3a8-42e0-9df1-65a2a9046dee.png)

Changed `CoreAndroid.getBuildConfigValue` to simply call and return the result of `BuildHelper.getBuildConfigValue`

Note that the screenshots are from a test app that was changed to use the deprecated API in the `MainActivity`. `MainActivity` template doesn't actually use the deprecated API.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm test` and manual testing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
