### PR TITLE
fix!: Make CoreAndroid plugin instantiate on load

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewImpl.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewImpl.java
@@ -115,7 +115,7 @@ public class CordovaWebViewImpl implements CordovaWebView {
         // This isn't enforced by the compiler, so assert here.
         assert engine.getView() instanceof CordovaWebViewEngine.EngineView;
 
-        pluginManager.addService(CoreAndroid.PLUGIN_NAME, "org.apache.cordova.CoreAndroid");
+        pluginManager.addService(CoreAndroid.PLUGIN_NAME, "org.apache.cordova.CoreAndroid", true);
         pluginManager.init();
     }
 

--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -197,7 +197,18 @@ public class PluginManager {
      * @param className         The plugin class name
      */
     public void addService(String service, String className) {
-        PluginEntry entry = new PluginEntry(service, className, false);
+        addService(service, className, false);
+    }
+
+    /**
+     * Add a plugin class that implements a service to the service entry table.
+     * 
+     * @param service           The service name
+     * @param className         The plugin class name
+     * @param onload            If true, the plugin will be instantiated immediately
+     */
+    public void addService(String service, String className, boolean onload) {
+        PluginEntry entry = new PluginEntry(service, className, onload);
         this.addService(entry);
     }
 


### PR DESCRIPTION
I don't anticipate breaking changes from this change, however it is a difference in behaviour since CoreAndroid won't be lazily loaded, therefore I've marked this commit has a breaking change.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android / CoreAndroid plugin

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

CoreAndroid was lazily loaded via  `getPlugin` call. This can create a race condition in some situations, particularly 
with a new feature in the works: https://github.com/apache/cordova-android/pull/1574 where onRenderProcessGone may be invoked before anything gets a chance to call `getPlugin` for `CoreAndroid`.

In general, because this is **Core** plugin, I feel like it should always be loaded in, not lazily loaded in.

### Description
<!-- Describe your changes in detail -->

Inside `PluginManager`, I added a new public API: `addService(String serviceName, String className, bool onload)`.
The `addService(String serviceName, String className)` implementation has been moved to the new public API.

`CordovaWebviewImpl` will now add the CoreAndroid service with `onload` set to true.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test` on linux.
Also manual test while testing the onRenderProcessGone PR.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
