### PR TITLE
feat(splash): Support SplashScreenBackgroundColor preference

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -378,10 +378,24 @@ function updateProjectSplashScreen (platformConfig, locations) {
     const themes = xmlHelpers.parseElementtreeSync(locations.themes);
     const splashScreenTheme = themes.find('style[@name="Theme.App.SplashScreen"]');
 
+    let splashBg = platformConfig.getPreference('AndroidWindowSplashScreenBackground', this.platform);
+    if (!splashBg) {
+        splashBg = platformConfig.getPreference('SplashScreenBackgroundColor', this.platform);
+    }
+    if (!splashBg) {
+        splashBg = platformConfig.getPreference('BackgroundColor', this.platform);
+    }
+
+    // use the user defined value for "colors.xml"
+    updateProjectSplashScreenBackgroundColor(splashBg, locations);
+
+    // force the themes value to `@color/cdv_splashscreen_background`
+    const splashBgNode = splashScreenTheme.find('item[@name="windowSplashScreenBackground"]');
+    splashBgNode.text = '@color/cdv_splashscreen_background';
+
     [
         'windowSplashScreenAnimatedIcon',
         'windowSplashScreenAnimationDuration',
-        'windowSplashScreenBackground',
         'android:windowSplashScreenBrandingImage',
         'windowSplashScreenIconBackgroundColor',
         'postSplashScreenTheme'
@@ -392,14 +406,6 @@ function updateProjectSplashScreen (platformConfig, locations) {
         let themeTargetNode = splashScreenTheme.find(`item[@name="${themeKey}"]`);
 
         switch (themeKey) {
-        case 'windowSplashScreenBackground':
-            // use the user defined value for "colors.xml"
-            updateProjectSplashScreenBackgroundColor(cdvConfigPrefValue, locations);
-
-            // force the themes value to `@color/cdv_splashscreen_background`
-            themeTargetNode.text = '@color/cdv_splashscreen_background';
-            break;
-
         case 'windowSplashScreenAnimatedIcon':
             // handle here the cases of "png" vs "xml" (drawable)
             // If "png":


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Adds support for the more general `SplashScreenBackgroundColor` preference.


### Description
<!-- Describe your changes in detail -->
Sets the splashscreen background based on the following options (in order):
* `AndroidWindowSplashScreenBackground` preference
* `SplashScreenBackgroundColor` preference
* `BackgroundColor` preference
* `#ffffff` hardcoded


### Testing
<!-- Please describe in detail how you tested your changes. -->
Didn't seem like there were any existing unit tests for the splashscreen stuff, so I didn't update any tests.

- [x] This still needs to be tested manually in an Android project.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
