### PR TITLE
Fix for app restart when BT keyboard is connected in some devices

### DIFF
--- a/templates/project/AndroidManifest.xml
+++ b/templates/project/AndroidManifest.xml
@@ -39,7 +39,7 @@
                 android:launchMode="singleTop"
                 android:theme="@style/Theme.App.SplashScreen"
                 android:windowSoftInputMode="adjustResize"
-                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
                 android:exported="true">
             <intent-filter android:label="@string/launcher_name">
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
### Platforms affected
From API 13


### Motivation and Context
To avoid app restart on connecting/disconnecting BT keyboard in some devices. Issue is faced by many and is also described here: https://stackoverflow.com/questions/25735227/bluetooth-keyboard-will-cause-activity-destroy-and-recreate/27238892#27238892

There is no easy way to extend this using config's.

### Description
In some devices (especially pixel) connecting with BT keyboard is resulting in application being restarted. The existing "keyboard" seems to be not sufficient as in this case it was triggering "navigation" change.


### Testing
Tested on problematic devices by connecting and disconnecting keyboards


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
