### PR TITLE
fix(docs): Incorrect JDK requirement stated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Cordova Android is an Android application library that allows for Cordova-based 
 
 ## Requirements
 
-* Java Development Kit (JDK) 11
+* Java Development Kit (JDK) 17
 * [Android SDK](https://developer.android.com/)
 * [Node.js](https://nodejs.org)
 


### PR DESCRIPTION
README still stated that JDK 11 is required, when cordova-android@13 now requires JDK 17.