### PR TITLE
fix: remove pollOnce from NativeToJsMessageQueue.popAndEncodeAsJs

### DIFF
--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -205,9 +205,6 @@ public class NativeToJsMessageQueue {
                     sb.append("}finally{");
                 }
             }
-            if (!willSendAllMessages) {
-                sb.append("window.setTimeout(function(){cordova.require('cordova/plugin/android/polling').pollOnce();},0);");
-            }
             for (int i = willSendAllMessages ? 1 : 0; i < numMessagesToSend; ++i) {
                 sb.append('}');
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove the require block for `cordova/plugin/android/polling`, a module that doesn't exist.

Resolves #1735 

### Description
<!-- Describe your changes in detail -->

The `cordova/plugin/android/polling` module appears to have been removed since 2012.

The last known version of Cordova-JS where this module existed was **[cordova-js@2.1.0 - polling.js](https://github.com/apache/cordova-js/blob/2.1.0/lib/android/plugin/android/polling.js)** in the `polling.js` file, with the version tag created on Sep 13, 2012.

The module was removed in `cordova-js@2.2.0rc1`, a tag/release created on Oct 16, 2012.

The **[exact commit](https://github.com/apache/cordova-js/commit/01a2683adffd6198f6d28344b1d2c87ba98023b7)** that removed the module from Cordova-JS does not have an associated PR, GitHub issue, or CB ticket to explain the reason for this change.

Additionally, the platform-specific Cordova-JS modules, which reside in the `cordova-js-src` directory of this repository ([originally labeled as `platform_modules`](https://github.com/apache/cordova-android/commit/828edb3a439ace4ecd169ee8e87a93418fc623b9)), were not created until 2015—2 years and 4 months later. This directory has also never contained the polling module as far as I can see.

Since this part of the code has not been functional since 2012, I believe it is safe to remove it.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
