### PR TITLE
fixed maxBuildToolVersion calculation

### DIFF
--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -58,7 +58,7 @@ String doFindLatestInstalledBuildTools(String minBuildToolsVersionString) {
     }
 
     def minBuildToolsVersion = new Version(minBuildToolsVersionString)
-    def maxVersion = new Version((minBuildToolsVersion.getMajor() + 1) + ".0.0")
+    def maxVersion = new Version("999.0.0")
 
     def highestBuildToolsVersion = buildToolsDirContents
         .collect { new Version(it) }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The `doFindLatestInstalledBuildTools` function in `cordova.gradle` has a bug: it can exclude valid Build Tools versions.
I installed a version newer than MIN_BUILD_TOOLS_VERSION but within the same major version, in my case the minimum version is 34.0.0, my installed version is 35.0.1. The script considers 35.0.1 not within 34.0.0-35.0.0, which is a range that incorrectly calculates its upper bound.



### Description
<!-- Describe your changes in detail -->
changed line:70 `def maxVersion = new Version((minBuildToolsVersion.getMajor() + 1) + ".0.0")`
to `def maxVersion = new Version("999.0.0")`


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `cordova build android`


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
