### PR TITLE
fix: creation of cdv-gradle-config.json w/ --link flag

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -55,6 +55,7 @@ function copyJsAndLibrary (projectPath, shared, projectName, targetAPI) {
     // The www dir is nuked on each prepare so we keep cordova.js in platform_www
     fs.ensureDirSync(platform_www);
     fs.copySync(srcCordovaJsPath, path.join(platform_www, 'cordova.js'));
+    fs.copySync(path.join(ROOT, 'framework', 'cdv-gradle-config-defaults.json'), path.join(projectPath, 'cdv-gradle-config.json'));
 
     if (shared) {
         const relativeFrameworkPath = path.relative(projectPath, getFrameworkDir(projectPath, true));
@@ -69,7 +70,6 @@ function copyJsAndLibrary (projectPath, shared, projectName, targetAPI) {
         fs.copySync(path.join(ROOT, 'framework', 'cordova.gradle'), path.join(nestedCordovaLibPath, 'cordova.gradle'));
         fs.copySync(path.join(ROOT, 'framework', 'repositories.gradle'), path.join(nestedCordovaLibPath, 'repositories.gradle'));
         fs.copySync(path.join(ROOT, 'framework', 'src'), path.join(nestedCordovaLibPath, 'src'));
-        fs.copySync(path.join(ROOT, 'framework', 'cdv-gradle-config-defaults.json'), path.join(projectPath, 'cdv-gradle-config.json'));
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Able to build project when platform was installed with `--link` 

### Description
<!-- Describe your changes in detail -->

The `cdv-gradle-config.json` file was not being created when the `--link` flag was used during platform add.

This PR moved the creation logic to ensure that `cdv-gradle-config.json` was created with or without  `--link`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- Build Cordova sample application.
- Tested on Android Studio - Ladybug

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
