### PR TITLE
feat!: deprecate CordovaPlugin's method initialize

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -64,7 +64,11 @@ public class CordovaPlugin {
      * Called after plugin construction and fields have been initialized.
      * Prefer to use pluginInitialize instead since there is no value in
      * having parameters on the initialize() function.
+     *
+     * @deprecated Use {@link #pluginInitialize()} instead. This method is no longer recommended
+     *             and will be removed in future versions.
      */
+    @Deprecated
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     }
 
@@ -416,7 +420,7 @@ public class CordovaPlugin {
      * @param requestCode
      * @param permissions
      * @param grantResults
-     * 
+     *
      * @deprecated Use {@link #onRequestPermissionsResult} instead.
      */
     @Deprecated


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It is recommended to use `pluginInitialize` and not `initialize`.

At one point `initialize` was deprecated but later the flag was removed. This PR is re-adding the flag to make aware that the `initialize` method is deprecated and will be removed in a future release. Plugin developers should switch to `pluginInitialize`.

The question about this originated from doc repo: https://github.com/apache/cordova-docs/issues/1386

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
