### PR TITLE
feat: Account for Node security patch

### DIFF
--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -110,6 +110,8 @@ module.exports.get_gradle_wrapper = function () {
     let program_dir;
     // OK, This hack only works on Windows, not on Mac OS or Linux.  We will be deleting this eventually!
     if (module.exports.isWindows()) {
+        // "spawn" option enabled for CVE-2024-27980 (Windows) Mitigation
+        // See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2 for more details
         const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { spawn: true });
         // console.log('result.stdout =' + result.stdout.toString());
         // console.log('result.stderr =' + result.stderr.toString());

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -110,7 +110,7 @@ module.exports.get_gradle_wrapper = function () {
     let program_dir;
     // OK, This hack only works on Windows, not on Mac OS or Linux.  We will be deleting this eventually!
     if (module.exports.isWindows()) {
-        const result = execa.sync(path.join(__dirname, 'getASPath.bat'));
+        const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { spawn: true });
         // console.log('result.stdout =' + result.stdout.toString());
         // console.log('result.stderr =' + result.stderr.toString());
 

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -110,7 +110,7 @@ module.exports.get_gradle_wrapper = function () {
     let program_dir;
     // OK, This hack only works on Windows, not on Mac OS or Linux.  We will be deleting this eventually!
     if (module.exports.isWindows()) {
-        // "spawn" option enabled for CVE-2024-27980 (Windows) Mitigation
+        // "shell" option enabled for CVE-2024-27980 (Windows) Mitigation
         // See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2 for more details
         const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { shell: true });
         // console.log('result.stdout =' + result.stdout.toString());

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -112,7 +112,7 @@ module.exports.get_gradle_wrapper = function () {
     if (module.exports.isWindows()) {
         // "spawn" option enabled for CVE-2024-27980 (Windows) Mitigation
         // See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2 for more details
-        const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { spawn: true });
+        const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { shell: true });
         // console.log('result.stdout =' + result.stdout.toString());
         // console.log('result.stderr =' + result.stderr.toString());
 


### PR DESCRIPTION
As of https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high Cordova produce unrecognized error on Windows.

Fixes: https://github.com/apache/cordova-cli/issues/456