### PR TITLE
feat: add AndroidEdgeToEdge preference & theme flag

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -381,6 +381,26 @@ function updateProjectTheme (platformConfig, locations) {
     const themes = xmlHelpers.parseElementtreeSync(locations.themes);
     const splashScreenTheme = themes.find('style[@name="Theme.App.SplashScreen"]');
 
+    // Update edge-to-edge settings in app theme.
+    let hasE2E = false; // default case
+
+    const preferenceE2E = platformConfig.getPreference('AndroidEdgeToEdge', this.platform);
+    if (!preferenceE2E) {
+        events.emit('verbose', 'The preference name "AndroidEdgeToEdge" was not set. Defaulting to "false".');
+    } else {
+        const hasInvalidPreferenceE2E = preferenceE2E !== 'true' && preferenceE2E !== 'false';
+        if (hasInvalidPreferenceE2E) {
+            events.emit('verbose', 'Preference name "AndroidEdgeToEdge" has an invalid value. Valid values are "true" or "false". Defaulting to "false"');
+        }
+        hasE2E = hasInvalidPreferenceE2E ? false : preferenceE2E === 'true';
+    }
+
+    const optOutE2EKey = 'android:windowOptOutEdgeToEdgeEnforcement';
+    const optOutE2EItem = splashScreenTheme.find(`item[@name="${optOutE2EKey}"]`);
+    const optOutE2EValue = !hasE2E ? 'true' : 'false';
+    optOutE2EItem.text = optOutE2EValue;
+    events.emit('verbose', `Updating theme item "${optOutE2EKey}" with value "${optOutE2EValue}"`);
+
     let splashBg = platformConfig.getPreference('AndroidWindowSplashScreenBackground', this.platform);
     if (!splashBg) {
         splashBg = platformConfig.getPreference('SplashScreenBackgroundColor', this.platform);
@@ -402,10 +422,7 @@ function updateProjectTheme (platformConfig, locations) {
         'windowSplashScreenAnimationDuration',
         'android:windowSplashScreenBrandingImage',
         'windowSplashScreenIconBackgroundColor',
-        'postSplashScreenTheme',
-
-        // Other
-        'android:windowOptOutEdgeToEdgeEnforcement'
+        'postSplashScreenTheme'
     ].forEach(themeKey => {
         const index = themeKey.indexOf(':') + 1;
         const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
@@ -479,10 +496,6 @@ function updateProjectTheme (platformConfig, locations) {
 
         case 'postSplashScreenTheme':
             themeTargetNode.text = cdvConfigPrefValue || '@style/Theme.AppCompat.NoActionBar';
-            break;
-
-        case 'android:windowOptOutEdgeToEdgeEnforcement':
-            themeTargetNode.text = cdvConfigPrefValue || 'true';
             break;
 
         default:

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -271,7 +271,7 @@ function cleanWww (projectRoot, locations) {
  */
 function updateProjectAccordingTo (platformConfig, locations) {
     updateProjectStrings(platformConfig, locations);
-    updateProjectSplashScreen(platformConfig, locations);
+    updateProjectTheme(platformConfig, locations);
 
     const name = platformConfig.name();
 
@@ -376,7 +376,7 @@ function warnForDeprecatedSplashScreen (cordovaProject) {
  *   be used to update project
  * @param   {Object}  locations       A map of locations for this platform
  */
-function updateProjectSplashScreen (platformConfig, locations) {
+function updateProjectTheme (platformConfig, locations) {
     // res/values/themes.xml
     const themes = xmlHelpers.parseElementtreeSync(locations.themes);
     const splashScreenTheme = themes.find('style[@name="Theme.App.SplashScreen"]');
@@ -397,11 +397,15 @@ function updateProjectSplashScreen (platformConfig, locations) {
     splashBgNode.text = '@color/cdv_splashscreen_background';
 
     [
+        // Splash Screen
         'windowSplashScreenAnimatedIcon',
         'windowSplashScreenAnimationDuration',
         'android:windowSplashScreenBrandingImage',
         'windowSplashScreenIconBackgroundColor',
-        'postSplashScreenTheme'
+        'postSplashScreenTheme',
+
+        // Other
+        'android:windowOptOutEdgeToEdgeEnforcement'
     ].forEach(themeKey => {
         const index = themeKey.indexOf(':') + 1;
         const cdvConfigPrefKey = 'Android' + themeKey.charAt(index).toUpperCase() + themeKey.slice(index + 1);
@@ -475,6 +479,10 @@ function updateProjectSplashScreen (platformConfig, locations) {
 
         case 'postSplashScreenTheme':
             themeTargetNode.text = cdvConfigPrefValue || '@style/Theme.AppCompat.NoActionBar';
+            break;
+
+        case 'android:windowOptOutEdgeToEdgeEnforcement':
+            themeTargetNode.text = cdvConfigPrefValue || 'true';
             break;
 
         default:

--- a/spec/unit/prepare.spec.js
+++ b/spec/unit/prepare.spec.js
@@ -950,7 +950,7 @@ describe('prepare', () => {
 
             prepare.__set__('updateWww', jasmine.createSpy('updateWww'));
             prepare.__set__('updateIcons', jasmine.createSpy('updateIcons').and.returnValue(Promise.resolve()));
-            prepare.__set__('updateProjectSplashScreen', jasmine.createSpy('updateProjectSplashScreen'));
+            prepare.__set__('updateProjectTheme', jasmine.createSpy('updateProjectTheme'));
             prepare.__set__('warnForDeprecatedSplashScreen', jasmine.createSpy('warnForDeprecatedSplashScreen')
                 .and.returnValue(Promise.resolve()));
             prepare.__set__('updateFileResources', jasmine.createSpy('updateFileResources').and.returnValue(Promise.resolve()));

--- a/templates/project/res/values/themes.xml
+++ b/templates/project/res/values/themes.xml
@@ -17,7 +17,7 @@
  specific language governing permissions and limitations
  under the License.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen.IconBackground">
       <!-- Optional: Set the splash screen background. (Default: #FFFFFF) -->
       <item name="windowSplashScreenBackground">@color/cdv_splashscreen_background</item>
@@ -30,5 +30,8 @@
 
       <!-- Required: Set the theme of the Activity that directly follows your splash screen. -->
       <item name="postSplashScreenTheme">@style/Theme.AppCompat.NoActionBar</item>
+
+      <!-- Disable Edge-to-Edge for SDK 35 -->
+      <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 </resources>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Disable the Edge-to-Edge setting that SDK 35 enabled by default.
- Allow users to opt-in to the Edge-to-Edge feature with a flag.

In the next Cordova-Android release, we will temporarily disable the Edge-to-Edge feature to maintain the same behavior that existed previously. The new feature appears to have issues with safe-area-*.

When setting `viewport-fit` to `auto` or `contain`, the content will render behind the safe-area which is believed to be an unintended behavior. iOS for example will automatically render the content below the statusbar. 

### Description
<!-- Describe your changes in detail -->

- Added theme flag `android:windowOptOutEdgeToEdgeEnforcement` and default to `true`
- Added preference flag `AndroidEdgeToEdge` to allow changing of the theme flag
  - When `AndroidEdgeToEdge` is set to `true`, `android:windowOptOutEdgeToEdgeEnforcement` will be `false`
  - When `AndroidEdgeToEdge` is set to `false`, an **empty string**, **not defined**, or **invalid entry**, `windowOptOutEdgeToEdgeEnforcement` will be `true`

### Testing
<!-- Please describe in detail how you tested your changes. -->

- build app and test flag

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
