### PR TITLE
Document onRequestPermissionResult (need clarification)

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -416,11 +416,13 @@ public class CordovaPlugin {
     }
 
     /**
-     * Called by the system when the user grants permissions
+     * Called when the user grants permissions.
+     * Forwarded from {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])}.
      *
      * @param requestCode
      * @param permissions
      * @param grantResults
+     * @see https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])
      * @deprecated Use {@link #onRequestPermissionsResult} instead.
      */
     @Deprecated
@@ -430,11 +432,13 @@ public class CordovaPlugin {
     }
 
     /**
-     * Called by the system when the user grants permissions
+     * Called when the user grants permissions. Do not use it.
+     * This is currently not called by {@link CordovaActivity}, just by {@link PermissionHelper}, which is not used currently.
      *
      * @param requestCode
      * @param permissions
      * @param grantResults
+     * @see https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])
      */
     public void onRequestPermissionsResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException {


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
- Make clear, that only `onRequestPermissionResult` is currently save to use
- Document, that `onRequestPermissionResult` is called from `CordovaActivity` after called from the system
- Add document link for Android method `onRequestPermissionsResult `


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
