### PR TITLE
fix: copy gradle wrapper from tools to platform root dir

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -18,6 +18,7 @@
 */
 
 const fs = require('node:fs');
+const fsp = require('node:fs/promises');
 const path = require('node:path');
 const execa = require('execa');
 const glob = require('fast-glob');
@@ -289,6 +290,10 @@ class ProjectBuilder {
             .then(function () {
                 events.emit('verbose', `Using Gradle: ${config.GRADLE_VERSION}`);
                 return self.installGradleWrapper(config.GRADLE_VERSION);
+            }).then(async function () {
+                await fsp.cp(path.join(self.root, 'tools', 'gradle'), path.join(self.root, 'gradle'), { recursive: true, force: true });
+                await fsp.cp(path.join(self.root, 'tools', 'gradlew'), path.join(self.root, 'gradlew'), { recursive: true, force: true });
+                await fsp.cp(path.join(self.root, 'tools', 'gradlew.bat'), path.join(self.root, 'gradlew.bat'), { recursive: true, force: true });
             }).then(function () {
                 return self.prepBuildFiles();
             }).then(() => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Copy the gradle wrapper files from `platforms/android/tools` to `platforms/android`

Fixes #1760

### Description
<!-- Describe your changes in detail -->

Updated install step to just copy all the gradle files up one directory.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Created a Cordova Project
- Added Platform
- Built Android Platform

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
