### PR TITLE
fix: replace fs-extra.ensureFileSync with fs.writeFileSync

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -301,7 +301,7 @@ class ProjectBuilder {
 
                 if (fs.existsSync(signingPropertiesPath)) fs.rmSync(signingPropertiesPath);
                 if (opts.packageInfo) {
-                    fs.ensureFileSync(signingPropertiesPath);
+                    fs.writeFileSync(signingPropertiesPath, '', 'utf8');
                     const signingProperties = createEditor(signingPropertiesPath);
                     signingProperties.addHeadComment(TEMPLATE);
                     opts.packageInfo.appendToProperties(signingProperties);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix undefined `ensureFileSync` method.

### Description
<!-- Describe your changes in detail -->

The `fs-extra` npm package was removed which caused `ensureFileSync` to be not a function.

This PR replaces `ensureFileSync` with `writeFileSync`. The signing properties file is always removed before being recreated, and the platform directory should always exist, so it should be safe to call `writeFileSync`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- npm t
- created a testing debug keystore file
- configured `build.json` to use the testing debug keystore. 
- cordova build android
- cordova run android

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
