### PR TITLE
fix(windows): get gradle path with which command

### DIFF
--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -17,7 +17,6 @@
        under the License.
 */
 
-const execa = require('execa');
 const path = require('node:path');
 const fs = require('node:fs');
 const { forgivingWhichSync, isWindows, isDarwin } = require('./utils');
@@ -104,46 +103,7 @@ function getUserCompileSdkVersion (projectRoot) {
 }
 
 module.exports.get_gradle_wrapper = function () {
-    let androidStudioPath;
-    let i = 0;
-    let foundStudio = false;
-    let program_dir;
-    // OK, This hack only works on Windows, not on Mac OS or Linux.  We will be deleting this eventually!
-    if (module.exports.isWindows()) {
-        // "shell" option enabled for CVE-2024-27980 (Windows) Mitigation
-        // See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2 for more details
-        const result = execa.sync(path.join(__dirname, 'getASPath.bat'), { shell: true });
-        // console.log('result.stdout =' + result.stdout.toString());
-        // console.log('result.stderr =' + result.stderr.toString());
-
-        if (result.stderr.toString().length > 0) {
-            const androidPath = path.join(process.env.ProgramFiles, 'Android') + '/';
-            if (fs.existsSync(androidPath)) {
-                program_dir = fs.readdirSync(androidPath);
-                while (i < program_dir.length && !foundStudio) {
-                    if (program_dir[i].startsWith('Android Studio')) {
-                        foundStudio = true;
-                        androidStudioPath = path.join(process.env.ProgramFiles, 'Android', program_dir[i], 'gradle');
-                    } else { ++i; }
-                }
-            }
-        } else {
-            // console.log('got android studio path from registry');
-            // remove the (os independent) new line char at the end of stdout
-            // add gradle to match the above.
-            androidStudioPath = path.join(result.stdout.toString().split('\r\n')[0], 'gradle');
-        }
-    }
-
-    if (androidStudioPath !== null && fs.existsSync(androidStudioPath)) {
-        const dirs = fs.readdirSync(androidStudioPath);
-        if (dirs[0].split('-')[0] === 'gradle') {
-            return path.join(androidStudioPath, dirs[0], 'bin', 'gradle');
-        }
-    } else {
-        // OK, let's try to check for Gradle!
-        return forgivingWhichSync('gradle');
-    }
+    return forgivingWhichSync('gradle');
 };
 
 // Returns a promise. Called only by build and clean commands.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #1792

### Description
<!-- Describe your changes in detail -->

Before Android Studio 3.5, Gradle was bundled with the IDE.

In the past, for Windows environments, we attempted to locate the Android Studio installation path to use its bundled Gradle executable.

However, Cordova has not supported old versions of Android Studio for a long time, making this logic obsolete. Additionally, past release announcements have indicated increasing Android Studio requirements:

- Cordova-Android 13 required a minimum of Android Studio Jellyfish.
- Cordova-Android 14 required a minimum of Android Studio Ladybug.

Documentation also stated that since Cordova-Android 6.4.0, a system-level Gradle installation is required. Cordova would then uses this to generate the project-level Gradle wrapper.

Given these changes, this PR will remove the outdated Windows-specific logic. The `.bat` file will remain for now but will be removed in the next major release.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Create cordova project in a directory with spaces
- Added cordova platform which contains this PR changes.
- Built app with `cordova build android` command on Windows.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
