### PR TITLE
fix: configure gradle java.home

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -286,14 +286,49 @@ class ProjectBuilder {
     prepEnv (opts) {
         const self = this;
         const config = this._getCordovaConfig();
+        const configPropertiesPath = path.join(self.root, 'tools', '.gradle', 'config.properties');
+
         return check_reqs.check_gradle()
             .then(function () {
                 events.emit('verbose', `Using Gradle: ${config.GRADLE_VERSION}`);
                 return self.installGradleWrapper(config.GRADLE_VERSION);
             }).then(async function () {
+                try {
+                    // Try to create "config.properties" file if missing
+                    const fd = fs.openSync(configPropertiesPath, 'wx+', 0o600);
+                    fs.writeFileSync(fd, '', 'utf8');
+                    fs.closeSync(fd);
+                } catch {
+                    // File already existed, nothing to do.
+                }
+
+                // Loads "config.properties"for editing
+                const configProperties = createEditor(configPropertiesPath);
+                /*
+                 * File is replaced on each build. "before_build" hook scripts can inject
+                 * custom settings before this step runs. This step will still overwrite
+                 * the "java.home" setting. Ensure environment variables are properly
+                 * configured if want to use custom "java.home".
+                 *
+                 * Sets "java.home" using the "CORDOVA_JAVA_HOME" environment variable.
+                 * If unavailable, fallback to "JAVA_HOME".
+                 * If neither is set, "java.home" is removed (if previously set),
+                 * allowing Android Studio to display a warning and auto-configure
+                 * to use its internal (bundled) Java.
+                 */
+                const javaHome = process.env.CORDOVA_JAVA_HOME || process.env.JAVA_HOME || false;
+                if (javaHome) {
+                    configProperties.set('java.home', javaHome);
+                } else {
+                    configProperties.unset('java.home');
+                }
+                // Saves changes
+                configProperties.save();
+            }).then(async function () {
                 await fsp.cp(path.join(self.root, 'tools', 'gradle'), path.join(self.root, 'gradle'), { recursive: true, force: true });
                 await fsp.cp(path.join(self.root, 'tools', 'gradlew'), path.join(self.root, 'gradlew'), { recursive: true, force: true });
                 await fsp.cp(path.join(self.root, 'tools', 'gradlew.bat'), path.join(self.root, 'gradlew.bat'), { recursive: true, force: true });
+                await fsp.cp(path.join(self.root, 'tools', '.gradle'), path.join(self.root, '.gradle'), { recursive: true, force: true });
             }).then(function () {
                 return self.prepBuildFiles();
             }).then(() => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix an issue mentioned in a [discussion thread](https://github.com/apache/cordova/discussions/530#discussioncomment-12605698).

1. Ensure that Cordova-Android properly creates `config.properties`.
2. Ensure that `java.home` is set correctly:
   1. Check and use the `CORDOVA_JAVA_HOME` environment variable.
   2. If `CORDOVA_JAVA_HOME` is missing, fall back to `JAVA_HOME`.
   3. If neither is set, remove the `java.home` property (if previously set), allowing Android Studio to display a warning and configure its internal Java automatically.
3. Copy the `tools/.gradle` directory up one level.

**Note:** Step 2.3 should not occur under normal conditions, but was included as a safeguard. When running `cordova build`, if `JAVA_HOME` is missing, its expected to not continue as its apart of the requirement checks.

This change also ensures that Cordova-Android uses the correct Java version specified by the user via environment variables. According to the Cordova documentation, these variables must be configured for Cordova-Android setup. Defaulting to Android Studio's bundled Java could lead to unexpected results and not using versions that the App developer configured.

### Additional Feedback

It appears that the change came from AGP 8.2. It created a [new way to specify the JDK path](https://developer.android.com/build/releases/past-releases/agp-8-2-0-release-notes#jdk-macro) was added and became default. This new macro is called `GRADLE_LOCAL_JAVA_HOME`

From [Android Developer - Java versions in Android builds](https://developer.android.com/build/jdks):

> The macros enable dynamic project JDK path selection:
> - `JAVA_HOME`: uses the environment variable with the same name
> - `GRADLE_LOCAL_JAVA_HOME`: uses the java.home property in the .gradle/config.properties file which defaults to the JetBrains Runtime.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Create project
- Add cordova-android platform with changes
- Build for Android

1. Use Case 1.a

Confirmed that `java.home` was set with configured environment variables.

2. Use Case 1.b

Re-run build with `CORDOVA_JAVA_HOME` set to another version of Java and confirmed the `java.home` was updated.

3. Use Case 2

Created a `before_build` hookscript  which would run before  `cordova build`.
Confirm that the additional properties, defined in the hookscript, were injected in the `config.properties` file and that `java.home` was set correctly by the build script.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
