### PR TITLE
fix(plugins): handle uninstalling multiple plugin assets

### DIFF
--- a/lib/pluginHandlers.js
+++ b/lib/pluginHandlers.js
@@ -141,14 +141,13 @@ const handlers = {
         uninstall: function (obj, plugin, project, options) {
             const target = obj.target || obj.src;
 
-            if (!target) throw new CordovaError(generateAttributeError('target', 'asset', plugin.id));
+            if (!target) {
+                throw new CordovaError(generateAttributeError('target', 'asset', plugin.id));
+            }
 
-            removeFile(path.resolve(project.www, target));
-            removeFile(path.resolve(project.www, 'plugins', plugin.id));
+            removeFileAndParents(project.www, target);
             if (options && options.usePlatformWww) {
-                // CB-11022 remove file from both directories if usePlatformWww is specified
-                removeFile(path.resolve(project.platformWww, target));
-                removeFile(path.resolve(project.platformWww, 'plugins', plugin.id));
+                removeFileAndParents(project.platformWww, target);
             }
         }
     },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support ability to uninstall multiple defined assets in a plugin and match recent changes with iOS platform.

### Description
<!-- Describe your changes in detail -->

Matched logic with iOS

### Testing
<!-- Please describe in detail how you tested your changes. -->

Adding and uninstalling plugins

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
