### PR TITLE
fix(plugins): rename & match removeFileF logic with other platforms

### DIFF
--- a/lib/pluginHandlers.js
+++ b/lib/pluginHandlers.js
@@ -42,7 +42,7 @@ const handlers = {
                 deleteJava(project.projectDir, dest);
             } else {
                 // Just remove the file, not the whole parent directory
-                removeFile(path.resolve(project.projectDir, dest));
+                removeFileF(path.resolve(project.projectDir, dest));
             }
         }
     },
@@ -53,7 +53,7 @@ const handlers = {
         },
         uninstall: function (obj, plugin, project, options) {
             const dest = path.join('app/libs', path.basename(obj.src));
-            removeFile(path.resolve(project.projectDir, dest));
+            removeFileF(path.resolve(project.projectDir, dest));
         }
     },
     'resource-file': {
@@ -63,7 +63,7 @@ const handlers = {
         },
         uninstall: function (obj, plugin, project, options) {
             const dest = path.join('app', 'src', 'main', obj.target);
-            removeFile(path.resolve(project.projectDir, dest));
+            removeFileF(path.resolve(project.projectDir, dest));
         }
     },
     framework: {
@@ -102,7 +102,7 @@ const handlers = {
 
             if (obj.custom) {
                 const subRelativeDir = project.getCustomSubprojectRelativeDir(plugin.id, src);
-                removeFile(path.resolve(project.projectDir, subRelativeDir));
+                removeFileF(path.resolve(project.projectDir, subRelativeDir));
                 subDir = path.resolve(project.projectDir, subRelativeDir);
                 // If it's the last framework in the plugin, remove the parent directory.
                 const parDir = path.dirname(subDir);
@@ -247,8 +247,8 @@ function symlinkFileOrDirTree (src, dest) {
     }
 }
 
-function removeFile (file) {
-    fs.rmSync(file);
+function removeFileF (file) {
+    fs.rmSync(file, { recursive: true, force: true });
 }
 
 // Sometimes we want to remove some java, and prune any unnecessary empty directories
@@ -261,7 +261,7 @@ function removeFileAndParents (baseDir, destFile, stopper) {
     const file = path.resolve(baseDir, destFile);
     if (!fs.existsSync(file)) return;
 
-    removeFile(file);
+    removeFileF(file);
 
     // check if directory is empty
     let curDir = path.dirname(file);

--- a/spec/unit/pluginHandlers/common.spec.js
+++ b/spec/unit/pluginHandlers/common.spec.js
@@ -150,7 +150,7 @@ describe('common platform handler', function () {
             const s = spyOn(fs, 'rmSync').and.callThrough();
             deleteJava(project_dir, java_file);
             expect(s).toHaveBeenCalled();
-            expect(s).toHaveBeenCalledWith(path.resolve(project_dir, java_file));
+            expect(s).toHaveBeenCalledWith(path.resolve(project_dir, java_file), { recursive: true, force: true });
         });
 
         it('Test#010 : should delete empty directories after removing source code in a java src path hierarchy', function () {

--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -313,7 +313,7 @@ describe('android project handler', function () {
             it('Test#017 : should remove jar files for Android Studio projects', function () {
                 android['lib-file'].install(valid_libs[0], dummyPluginInfo, dummyProject);
                 android['lib-file'].uninstall(valid_libs[0], dummyPluginInfo, dummyProject);
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestLib.jar'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestLib.jar'), { recursive: true, force: true });
             });
         });
 
@@ -321,7 +321,7 @@ describe('android project handler', function () {
             it('Test#018 : should remove files for Android Studio projects', function () {
                 android['resource-file'].install(valid_resources[0], dummyPluginInfo, dummyProject);
                 android['resource-file'].uninstall(valid_resources[0], dummyPluginInfo, dummyProject);
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app', 'src', 'main', 'res', 'xml', 'dummy.xml'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app', 'src', 'main', 'res', 'xml', 'dummy.xml'), { recursive: true, force: true });
             });
         });
 
@@ -338,52 +338,52 @@ describe('android project handler', function () {
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'));
             });
 
-            it('Test#019b : should remove stuff by calling common.removeFile for Android Studio projects, of jar with new app target-dir scheme', function () {
+            it('Test#019b : should remove stuff by calling removeFileF for Android Studio projects, of jar with new app target-dir scheme', function () {
                 android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestLib.jar'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestLib.jar'), { recursive: true, force: true });
             });
 
-            it('Test#019c : should remove stuff by calling common.removeFile for Android Studio projects, of aar with new app target-dir scheme', function () {
+            it('Test#019c : should remove stuff by calling removeFileF for Android Studio projects, of aar with new app target-dir scheme', function () {
                 android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestAar.aar'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestAar.aar'), { recursive: true, force: true });
             });
 
-            it('Test#019d : should remove stuff by calling common.removeFile for Android Studio projects, of xml with old target-dir scheme', function () {
+            it('Test#019d : should remove stuff by calling removeFileF for Android Studio projects, of xml with old target-dir scheme', function () {
                 android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/xml/mysettings.xml'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/xml/mysettings.xml'), { recursive: true, force: true });
             });
 
-            it('Test#019e : should remove stuff by calling common.removeFile for Android Studio projects, of file with other extension with old target-dir scheme', function () {
+            it('Test#019e : should remove stuff by calling removeFileF for Android Studio projects, of file with other extension with old target-dir scheme', function () {
                 android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/values/other.extension'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/values/other.extension'), { recursive: true, force: true });
             });
 
-            it('Test#019f : should remove stuff by calling common.removeFile for Android Studio projects, of aidl with old target-dir scheme (GH-547)', function () {
+            it('Test#019f : should remove stuff by calling removeFileF for Android Studio projects, of aidl with old target-dir scheme (GH-547)', function () {
                 android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/aidl/com/mytest/myapi.aidl'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/aidl/com/mytest/myapi.aidl'), { recursive: true, force: true });
             });
 
-            it('Test#019g : should remove stuff by calling common.removeFile for Android Studio projects, of aar with old target-dir scheme (GH-547)', function () {
+            it('Test#019g : should remove stuff by calling removeFileF for Android Studio projects, of aar with old target-dir scheme (GH-547)', function () {
                 android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testaar2.aar'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testaar2.aar'), { recursive: true, force: true });
             });
 
-            it('Test#019h : should remove stuff by calling common.removeFile for Android Studio projects, of jar with old target-dir scheme (GH-547)', function () {
+            it('Test#019h : should remove stuff by calling removeFileF for Android Studio projects, of jar with old target-dir scheme (GH-547)', function () {
                 android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testjar2.jar'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testjar2.jar'), { recursive: true, force: true });
             });
 
-            it('Test#019i : should remove stuff by calling common.removeFile for Android Studio projects, of .so lib file with old target-dir scheme (GH-547)', function () {
+            it('Test#019i : should remove stuff by calling removeFileF for Android Studio projects, of .so lib file with old target-dir scheme (GH-547)', function () {
                 android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
                 android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/jniLibs/x86/libnative.so'));
+                expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/jniLibs/x86/libnative.so'), { recursive: true, force: true });
             });
 
             it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "app"', function () {
@@ -424,13 +424,13 @@ describe('android project handler', function () {
                 const framework = { src: 'plugin-lib', custom: true };
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
                 expect(dummyProject.removeSubProject).toHaveBeenCalledWith(dummyProject.projectDir, someString);
-                expect(rmSyncSpy).toHaveBeenCalledWith(someString);
+                expect(rmSyncSpy).toHaveBeenCalledWith(someString, { recursive: true, force: true });
             });
 
             it('Test#24 : should install gradleReference using project.removeGradleReference', function () {
                 const framework = { src: 'plugin-lib', custom: true, type: 'gradleReference' };
                 android.framework.uninstall(framework, dummyPluginInfo, dummyProject);
-                expect(rmSyncSpy).toHaveBeenCalledWith(someString);
+                expect(rmSyncSpy).toHaveBeenCalledWith(someString, { recursive: true, force: true });
                 expect(dummyProject.removeGradleReference).toHaveBeenCalledWith(dummyProject.projectDir, someString);
             });
         });
@@ -453,14 +453,14 @@ describe('android project handler', function () {
 
             it('Test#025 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
                 android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest);
-                expect(rmSyncSpy).toHaveBeenCalledWith(platformWwwDest);
+                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(rmSyncSpy).toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
 
             it('Test#026 : should put module to www only when options.usePlatformWww flag is not specified', function () {
                 android['js-module'].uninstall(jsModule, dummyPluginInfo, dummyProject);
-                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest);
-                expect(rmSyncSpy).not.toHaveBeenCalledWith(platformWwwDest);
+                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(rmSyncSpy).not.toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
         });
 
@@ -481,14 +481,14 @@ describe('android project handler', function () {
 
             it('Test#027 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
                 android.asset.uninstall(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
-                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest);
-                expect(rmSyncSpy).toHaveBeenCalledWith(platformWwwDest);
+                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(rmSyncSpy).toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
 
             it('Test#028 : should put module to www only when options.usePlatformWww flag is not specified', function () {
                 android.asset.uninstall(asset, dummyPluginInfo, dummyProject);
-                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest);
-                expect(rmSyncSpy).not.toHaveBeenCalledWith(platformWwwDest);
+                expect(rmSyncSpy).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(rmSyncSpy).not.toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
         });
     });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update Android's plugin handler to be a bit more closer to iOS's plugin handler.

### Description
<!-- Describe your changes in detail -->

- Renamed `removeFile` to `removeFileF`. (The trailing `F` refers to the `force` flag that is used.)

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
