### PR TITLE
test(plugins): remove old deprecated android_studio option

### DIFF
--- a/spec/unit/pluginHandlers/handlers.spec.js
+++ b/spec/unit/pluginHandlers/handlers.spec.js
@@ -113,73 +113,73 @@ describe('android project handler', function () {
 
             // TODO: renumber these tests and other tests below
             it('Test#00a6 : should allow installing sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'), false);
             });
 
             it('Test#006b : should allow installing jar lib file from sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/TestLib.jar', temp, path.join('app/libs/TestLib.jar'), false);
             });
 
             it('Test#006c : should allow installing aar lib file from sources with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/TestAar.aar', temp, path.join('app/libs/TestAar.aar'), false);
             });
 
             it('Test#006d : should allow installing xml file from sources with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/mysettings.xml', temp,
                     path.join('app/src/main/res/xml/mysettings.xml'), false);
             });
 
             it('Test#006e : should allow installing file with other extension from sources with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/other.extension', temp,
                     path.join('app/src/main/res/values/other.extension'), false);
             });
 
             it('Test#006f : should allow installing aidl file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/myapi.aidl', temp,
                     path.join('app/src/main/aidl/com/mytest/myapi.aidl'), false);
             });
 
             it('Test#006g : should allow installing aar lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/testaar2.aar', temp,
                     path.join('app/libs/testaar2.aar'), false);
             });
 
             it('Test#006h : should allow installing jar lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/testjar2.jar', temp,
                     path.join('app/libs/testjar2.jar'), false);
             });
 
             it('Test#006i : should allow installing .so lib file from sources with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin,
                     'src/android/jniLibs/x86/libnative.so', temp,
                     path.join('app/src/main/jniLibs/x86/libnative.so'), false);
             });
 
             it('Test#006j : should allow installing sources with target-dir that includes "app"', function () {
-                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/com/appco/DummyPlugin2.java'), false);
             });
 
             it('Test#006k : should allow installing sources with target-dir that includes "app" in its first directory', function () {
-                android['source-file'].install(valid_source[11], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[11], dummyPluginInfo, dummyProject);
                 expect(copyFileSpy)
                     .toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin2.java', temp, path.join('app/src/main/java/appco/src/DummyPlugin2.java'), false);
             });
@@ -333,62 +333,62 @@ describe('android project handler', function () {
             });
 
             it('Test#019a : should remove stuff by calling common.deleteJava for Android Studio projects, with specific app target-dir', function () {
-                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[1], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[1], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[1], dummyPluginInfo, dummyProject);
                 expect(deleteJavaSpy).toHaveBeenCalledWith(temp, path.join('app/src/main/src/com/phonegap/plugins/dummyplugin/DummyPlugin2.java'));
             });
 
             it('Test#019b : should remove stuff by calling removeFileF for Android Studio projects, of jar with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[2], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[2], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[2], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestLib.jar'), { recursive: true, force: true });
             });
 
             it('Test#019c : should remove stuff by calling removeFileF for Android Studio projects, of aar with new app target-dir scheme', function () {
-                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[3], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[3], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[3], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/TestAar.aar'), { recursive: true, force: true });
             });
 
             it('Test#019d : should remove stuff by calling removeFileF for Android Studio projects, of xml with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[4], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[4], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[4], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/xml/mysettings.xml'), { recursive: true, force: true });
             });
 
             it('Test#019e : should remove stuff by calling removeFileF for Android Studio projects, of file with other extension with old target-dir scheme', function () {
-                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[5], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[5], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[5], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/res/values/other.extension'), { recursive: true, force: true });
             });
 
             it('Test#019f : should remove stuff by calling removeFileF for Android Studio projects, of aidl with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[6], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[6], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/aidl/com/mytest/myapi.aidl'), { recursive: true, force: true });
             });
 
             it('Test#019g : should remove stuff by calling removeFileF for Android Studio projects, of aar with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[7], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[7], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[7], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testaar2.aar'), { recursive: true, force: true });
             });
 
             it('Test#019h : should remove stuff by calling removeFileF for Android Studio projects, of jar with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[8], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[8], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[8], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/libs/testjar2.jar'), { recursive: true, force: true });
             });
 
             it('Test#019i : should remove stuff by calling removeFileF for Android Studio projects, of .so lib file with old target-dir scheme (GH-547)', function () {
-                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[9], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[9], dummyPluginInfo, dummyProject);
                 expect(rmSyncSpy).toHaveBeenCalledWith(path.join(dummyProject.projectDir, 'app/src/main/jniLibs/x86/libnative.so'), { recursive: true, force: true });
             });
 
             it('Test#019j : should remove stuff by calling common.deleteJava for Android Studio projects, with target-dir that includes "app"', function () {
-                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
-                android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject, { android_studio: true });
+                android['source-file'].install(valid_source[10], dummyPluginInfo, dummyProject);
+                android['source-file'].uninstall(valid_source[10], dummyPluginInfo, dummyProject);
                 expect(deleteJavaSpy).toHaveBeenCalledWith(dummyProject.projectDir, path.join('app/src/main/java/com/appco/DummyPlugin2.java'));
             });
         });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Cleanup test test spec.

### Description
<!-- Describe your changes in detail -->

Remove deprecated flag `android_studio` from test spec.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
