### PR TITLE
fix: apply repositories.gradle for cordova.gradle dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ example
 
 /test/.externalNativeBuild
 /test/androidx/cdv-gradle-config.json
+/test/androidx/repositories.gradle
+/test/androidx/app/repositories.gradle
 /test/androidx/tools
 /test/androidx/build
 /test/assets/www/.tmp*

--- a/framework/cordova.gradle
+++ b/framework/cordova.gradle
@@ -240,10 +240,8 @@ ext {
 }
 
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
+    apply from: 'repositories.gradle'
+    repositories repos
 
     dependencies {
         classpath 'io.github.g00fy2:versioncompare:1.4.1@jar'

--- a/test/run_java_unit_tests.js
+++ b/test/run_java_unit_tests.js
@@ -62,6 +62,8 @@ class AndroidTestRunner {
             .then(_ => {
                 // TODO we should probably not only copy these files, but instead create a new project from scratch
                 fs.copyFileSync(path.resolve(this.projectDir, '../../framework/cdv-gradle-config-defaults.json'), path.resolve(this.projectDir, 'cdv-gradle-config.json'));
+                fs.copyFileSync(path.resolve(this.projectDir, '../../framework/repositories.gradle'), path.resolve(this.projectDir, 'repositories.gradle'));
+                fs.copyFileSync(path.resolve(this.projectDir, '../../framework/repositories.gradle'), path.resolve(this.projectDir, 'app', 'repositories.gradle'));
                 fs.cpSync(path.resolve(this.projectDir, '../../templates/project/tools'), path.resolve(this.projectDir, 'tools'), { recursive: true });
                 fs.copyFileSync(
                     path.join(__dirname, '../templates/project/assets/www/cordova.js'),


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #1759

Use repos defined in `repositories.gradle` for the `cordova.gradle` dependencies

### Description
<!-- Describe your changes in detail -->

Replaced:

```groovy
repositories {
    google()
    mavenCentral()
}
```

With:

```groovy
apply from: 'repositories.gradle'
repositories repos
```

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- Created and built sample Cordova app with changes

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Updated automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
