### PR TITLE
feat!: support previous non-E2E

### DIFF
--- a/cordova-js-src/platform.js
+++ b/cordova-js-src/platform.js
@@ -39,6 +39,10 @@ module.exports = {
         // Core Splash Screen
         modulemapper.clobbers('cordova/plugin/android/splashscreen', 'navigator.splashscreen');
 
+        // Attach the internal statusBar utility to window.statusbar
+        // see the file under plugin/android/statusbar.js
+        modulemapper.clobbers('cordova/plugin/android/statusbar', 'window.statusbar');
+
         var APP_PLUGIN_NAME = Number(cordova.platformVersion.split('.')[0]) >= 4 ? 'CoreAndroid' : 'App';
 
         // Inject a listener for the backbutton on the document.

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var exec = require('cordova/exec');
+
+var statusBarVisible = true;
+var statusBar = {};
+
+Object.defineProperty(statusBar, 'visible', {
+    configurable: false,
+    enumerable: true,
+    get: function () {
+        if (window.StatusBar) {
+            // try to let the StatusBar plugin handle it
+            return window.StatusBar.isVisible;
+        }
+
+        return statusBarVisible;
+    },
+    set: function (value) {
+        if (window.StatusBar) {
+            // try to let the StatusBar plugin handle it
+            if (value) {
+                window.StatusBar.show();
+            } else {
+                window.StatusBar.hide();
+            }
+        } else {
+            statusBarVisible = value;
+            exec(null, null, 'SystemBarPlugin', 'setStatusBarVisible', [!!value]);
+        }
+    }
+});
+
+Object.defineProperty(statusBar, 'setBackgroundColor', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: function (value) {
+        // Confirm if value is a valid hex code is before passing to native-side
+        if (!(/^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value))) {
+            console.error('Invalid color hex code. Valid format: #RRGGBB or #AARRGGBB');
+            return;
+        }
+
+        if (window.StatusBar) {
+            window.StatusBar.backgroundColorByHexString(value);
+        } else {
+            exec(null, null, 'SystemBarPlugin', 'setStatusBarBackgroundColor', [value]);
+        }
+    }
+});
+
+module.exports = statusBar;

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -54,16 +54,31 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
     enumerable: false,
     writable: false,
     value: function (value) {
-        // Confirm if value is a valid hex code is before passing to native-side
-        if (!(/^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value))) {
-            console.error('Invalid color hex code. Valid format: #RRGGBB or #AARRGGBB');
+        var script = document.querySelector('script[src$="cordova.js"]');
+        script.style.color = value;
+        var rgbStr = window.getComputedStyle(script).getPropertyValue('color');
+
+        if (!rgbStr.match(/^rgb/)) { return; }
+
+        var rgbVals = rgbStr.match(/\d+/g).map(function (v) { return parseInt(v, 10); });
+
+        if (rgbVals.length < 3) {
             return;
+        } else if (rgbVals.length === 3) {
+            rgbVals = [255].concat(rgbVals);
         }
 
+        const padRgb = (val) => val.toString(16).padStart(2, '0');
+        const a = padRgb(rgbVals[0]);
+        const r = padRgb(rgbVals[1]);
+        const g = padRgb(rgbVals[2]);
+        const b = padRgb(rgbVals[3]);
+        const hexStr = '#' + a + r + g + b;
+
         if (window.StatusBar) {
-            window.StatusBar.backgroundColorByHexString(value);
+            window.StatusBar.backgroundColorByHexString(hexStr);
         } else {
-            exec(null, null, 'SystemBarPlugin', 'setStatusBarBackgroundColor', [value]);
+            exec(null, null, 'SystemBarPlugin', 'setStatusBarBackgroundColor', rgbVals);
         }
     }
 });

--- a/framework/src/org/apache/cordova/ConfigXmlParser.java
+++ b/framework/src/org/apache/cordova/ConfigXmlParser.java
@@ -79,6 +79,14 @@ public class ConfigXmlParser {
 
         pluginEntries.add(
             new PluginEntry(
+                SystemBarPlugin.PLUGIN_NAME,
+                "org.apache.cordova.SystemBarPlugin",
+                true
+            )
+        );
+
+        pluginEntries.add(
+            new PluginEntry(
                 SplashScreenPlugin.PLUGIN_NAME,
                 "org.apache.cordova.SplashScreenPlugin",
                 true

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -29,7 +29,6 @@ import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.graphics.Color;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -221,15 +220,18 @@ public class CordovaActivity extends AppCompatActivity {
                                 | WindowInsetsCompat.Type.displayCutout()
                 );
 
+                boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
+                int top = isStatusBarVisible ? bars.top : 0;
+
                 // Update the WebView's Margin LayoutParams
                 FrameLayout.LayoutParams newParams = (FrameLayout.LayoutParams) webView.getLayoutParams();
-                newParams.setMargins(bars.left, bars.top, bars.right, bars.bottom);
+                newParams.setMargins(bars.left, top, bars.right, bars.bottom);
                 webView.setLayoutParams(newParams);
 
                 // Position the status bar view to overlay the top inset areas
                 statusBarView.setLayoutParams(new FrameLayout.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
-                        bars.top,
+                        top,
                         Gravity.TOP
                 ));
 

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -239,7 +239,7 @@ public class CordovaActivity extends AppCompatActivity {
             );
             statusBarView.setLayoutParams(statusBarParams);
 
-            return WindowInsetsCompat.CONSUMED;
+            return insets;
         });
 
         rootLayout.addView(webView);

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -239,17 +239,6 @@ public class CordovaActivity extends AppCompatActivity {
             ViewCompat.requestApplyInsets(rootLayout);
         }
 
-        if (preferences.contains("BackgroundColor")) {
-            try {
-                int backgroundColor = preferences.getInteger("BackgroundColor", Color.BLACK);
-                // Background of activity:
-                webView.setBackgroundColor(backgroundColor);
-            }
-            catch (NumberFormatException e){
-                e.printStackTrace();
-            }
-        }
-
         rootLayout.addView(webView);
         setContentView(rootLayout);
         webView.requestFocusFromTouch();

--- a/framework/src/org/apache/cordova/SplashScreenPlugin.java
+++ b/framework/src/org/apache/cordova/SplashScreenPlugin.java
@@ -155,10 +155,13 @@ public class SplashScreenPlugin extends CordovaPlugin {
                                 public void onAnimationEnd(Animator animation) {
                                     super.onAnimationEnd(animation);
                                     splashScreenViewProvider.remove();
+                                    webView.getPluginManager().postMessage("updateSystemBars", null);
                                 }
                             }).start();
                 }
             });
+        } else {
+            webView.getPluginManager().postMessage("updateSystemBars", null);
         }
     }
 

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -194,7 +194,12 @@ public class SystemBarPlugin extends CordovaPlugin {
         if (root != null) root.setBackgroundColor(bgColor);
 
         // Automatically set the font and icon color of the system bars based on background color.
-        boolean isBackgroundColorLight = isColorLight(bgColor);
+        boolean isBackgroundColorLight;
+        if(bgColor == Color.TRANSPARENT) {
+            isBackgroundColorLight = isColorLight(getUiModeColor());
+        } else {
+            isBackgroundColorLight = isColorLight(bgColor);
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             WindowInsetsController controller = window.getInsetsController();
             if (controller != null) {
@@ -232,7 +237,12 @@ public class SystemBarPlugin extends CordovaPlugin {
         }
 
         // Automatically set the font and icon color of the system bars based on background color.
-        boolean isStatusBarBackgroundColorLight = isColorLight(bgColor);
+        boolean isStatusBarBackgroundColorLight;
+        if(bgColor == Color.TRANSPARENT) {
+            isStatusBarBackgroundColorLight = isColorLight(getUiModeColor());
+        } else {
+            isStatusBarBackgroundColorLight = isColorLight(bgColor);
+        }
         WindowInsetsControllerCompat controllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
         controllerCompat.setAppearanceLightStatusBars(isStatusBarBackgroundColorLight);
     }

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -1,0 +1,225 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewParent;
+import android.view.Window;
+import android.view.WindowInsetsController;
+import android.widget.FrameLayout;
+
+import androidx.core.content.ContextCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
+public class SystemBarPlugin extends CordovaPlugin {
+    static final String PLUGIN_NAME = "SystemBarPlugin";
+
+    static final int INVALID_COLOR = -1;
+
+    // Internal variables
+    private Context context;
+    private Resources resources;
+    private int overrideStatusBarBackgroundColor = INVALID_COLOR;
+
+
+    @Override
+    protected void pluginInitialize() {
+        context = cordova.getContext();
+        resources = context.getResources();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        cordova.getActivity().runOnUiThread(this::updateSystemBars);
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        super.onResume(multitasking);
+        cordova.getActivity().runOnUiThread(this::updateSystemBars);
+    }
+
+    @Override
+    public Object onMessage(String id, Object data) {
+        if (id.equals("updateSystemBars")) {
+            cordova.getActivity().runOnUiThread(this::updateSystemBars);
+        }
+        return null;
+    }
+
+    private void updateSystemBars() {
+        // Update Root View Background Color
+        int rootViewBackgroundColor = getPreferenceBackgroundColor();
+        if (rootViewBackgroundColor == INVALID_COLOR) {
+            rootViewBackgroundColor = getUiModeColor();
+        }
+        updateRootView(rootViewBackgroundColor);
+
+        // Update StatusBar Background Color
+        int statusBarBackgroundColor;
+        if (overrideStatusBarBackgroundColor != INVALID_COLOR) {
+            statusBarBackgroundColor = overrideStatusBarBackgroundColor;
+        } else if (preferences.contains("StatusBarBackgroundColor")) {
+            statusBarBackgroundColor = getPreferenceStatusBarBackgroundColor();
+        } else if(preferences.contains("BackgroundColor")){
+            statusBarBackgroundColor =  rootViewBackgroundColor;
+        } else {
+            statusBarBackgroundColor = getUiModeColor();
+        }
+
+        updateStatusBar(statusBarBackgroundColor);
+    }
+
+    private void updateRootView(int bgColor) {
+        Window window = cordova.getActivity().getWindow();
+
+        // Set the root view's background color. Works on SDK 36+
+        View root = cordova.getActivity().findViewById(android.R.id.content);
+        if (root != null) root.setBackgroundColor(bgColor);
+
+        // Automatically set the font and icon color of the system bars based on background color.
+        boolean isBackgroundColorLight = isColorLight(bgColor);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsetsController controller = window.getInsetsController();
+            if (controller != null) {
+                int appearance = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
+                if (isBackgroundColorLight) {
+                    controller.setSystemBarsAppearance(0, appearance);
+                } else {
+                    controller.setSystemBarsAppearance(appearance, appearance);
+                }
+            }
+        }
+        WindowInsetsControllerCompat controllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
+        controllerCompat.setAppearanceLightNavigationBars(isBackgroundColorLight);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Allow custom navigation bar background color for SDK 26 and greater.
+            window.setNavigationBarColor(bgColor);
+        } else {
+            // Force navigation bar to black for SDK 25 and less.
+            window.setNavigationBarColor(Color.BLACK);
+        }
+    }
+
+    private void updateStatusBar(int bgColor) {
+        Window window = cordova.getActivity().getWindow();
+
+        if (!preferences.getBoolean("AndroidEdgeToEdge", false)) {
+            View statusBar = getStatusBarView(webView);
+            if (statusBar != null) {
+                statusBar.setBackgroundColor(bgColor);
+            }
+        }
+
+        // Automatically set the font and icon color of the system bars based on background color.
+        boolean isStatusBarBackgroundColorLight = isColorLight(bgColor);
+        WindowInsetsControllerCompat controllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
+        controllerCompat.setAppearanceLightStatusBars(isStatusBarBackgroundColorLight);
+
+        // Allow custom background color for StatusBar.
+        window.setStatusBarColor(bgColor);
+    }
+
+    private static boolean isColorLight(int color) {
+        double r = Color.red(color) / 255.0;
+        double g = Color.green(color) / 255.0;
+        double b = Color.blue(color) / 255.0;
+        double luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+        return luminance > 0.5;
+    }
+
+    private int getPreferenceStatusBarBackgroundColor() {
+        String colorString = preferences.getString("StatusBarBackgroundColor", null);
+
+        int parsedColor = parseColorFromString(colorString);
+        if (parsedColor != INVALID_COLOR) return parsedColor;
+
+        return getUiModeColor(); // fallback
+    }
+
+    private int getPreferenceBackgroundColor() {
+        try {
+            return preferences.getInteger("BackgroundColor", INVALID_COLOR);
+        } catch (NumberFormatException e) {
+            LOG.e(PLUGIN_NAME, "Invalid background color argument. Example valid string: '0x00000000'");
+            return INVALID_COLOR;
+        }
+    }
+
+    private FrameLayout getRootLayout(CordovaWebView webView) {
+        ViewParent parent = webView.getView().getParent();
+        if (parent instanceof FrameLayout) {
+            return (FrameLayout) parent;
+        }
+
+        return null;
+    }
+
+    private View getStatusBarView(CordovaWebView webView) {
+        FrameLayout rootView = getRootLayout(webView);
+        for (int i = 0; i < (rootView != null ? rootView.getChildCount() : 0); i++) {
+            View child = rootView.getChildAt(i);
+            Object tag = child.getTag();
+            if ("statusBarView".equals(tag)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private int getUiModeColor() {
+        // Hardcoded fallback values matches system ui values (R.color) which were added in SDK 34.
+        return isNightMode()
+                ? getThemeColor("cdv_background_color_dark", "#121318")
+                : getThemeColor("cdv_background_color_light", "#FAF8FF");
+    }
+
+    private boolean isNightMode() {
+        return (resources.getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    private int parseColorFromString(final String colorPref) {
+        if (colorPref.isEmpty()) return INVALID_COLOR;
+
+        try {
+            return Color.parseColor(colorPref);
+        } catch (IllegalArgumentException ignore) {
+            LOG.e(PLUGIN_NAME, "Invalid color hex code. Valid format: #RRGGBB or #AARRGGBB");
+            return INVALID_COLOR;
+        }
+    }
+
+    @SuppressLint("DiscouragedApi")
+    private int getThemeColor(String colorKey, String fallbackColor) {
+        int colorResId = resources.getIdentifier(colorKey, "color", context.getPackageName());
+        return colorResId != 0
+                ? ContextCompat.getColor(context, colorResId)
+                : Color.parseColor(fallbackColor);
+    }
+}

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -185,6 +185,7 @@ public class SystemBarPlugin extends CordovaPlugin {
      *
      * @param bgColor Background color
      */
+    @SuppressWarnings("deprecation")
     private void updateRootView(int bgColor) {
         Window window = cordova.getActivity().getWindow();
 

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -306,7 +306,11 @@ public class SystemBarPlugin extends CordovaPlugin {
      */
     private View getStatusBarView(CordovaWebView webView) {
         FrameLayout rootView = getRootLayout(webView);
-        for (int i = 0; i < (rootView != null ? rootView.getChildCount() : 0); i++) {
+        if (rootView == null) {
+            return null;
+        }
+
+        for (int i = 0; i < rootView.getChildCount(); i++) {
             View child = rootView.getChildAt(i);
             Object tag = child.getTag();
             if ("statusBarView".equals(tag)) {

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -89,8 +89,7 @@ public class SystemBarPlugin extends CordovaPlugin {
             boolean visible = args.getBoolean(0);
             cordova.getActivity().runOnUiThread(() -> setStatusBarVisible(visible));
         } else if ("setStatusBarBackgroundColor".equals(action)) {
-            String bgColor = args.getString(0);
-            cordova.getActivity().runOnUiThread(() -> setStatusBarBackgroundColor(bgColor));
+            cordova.getActivity().runOnUiThread(() -> setStatusBarBackgroundColor(args));
         } else {
             return false;
         }
@@ -120,17 +119,27 @@ public class SystemBarPlugin extends CordovaPlugin {
 
     /**
      * Allow the app to override the status bar background color from JS API.
-     * If the supplied string is invalid and fails to parse, it will silently ignore
+     * If the supplied ARGB is invalid or fails to parse, it will silently ignore
      * the change request.
      *
-     * @param colorPref hex string
+     * @param argbVals {A, R, G, B}
      */
-    private void setStatusBarBackgroundColor(final String colorPref) {
-        int parsedColor = parseColorFromString(colorPref);
-        if (parsedColor == INVALID_COLOR) return;
+    private void setStatusBarBackgroundColor(JSONArray argbVals) {
+        try {
+            int a = argbVals.getInt(0);
+            int r = argbVals.getInt(1);
+            int g = argbVals.getInt(2);
+            int b = argbVals.getInt(3);
+            String hexColor = String.format("#%02X%02X%02X%02X", a, r, g, b);
 
-        overrideStatusBarBackgroundColor = parsedColor;
-        updateStatusBar(overrideStatusBarBackgroundColor);
+            int parsedColor = parseColorFromString(hexColor);
+            if (parsedColor == INVALID_COLOR) return;
+
+            overrideStatusBarBackgroundColor = parsedColor;
+            updateStatusBar(overrideStatusBarBackgroundColor);
+        } catch (JSONException e) {
+            // Silently skip
+        }
     }
 
     /**

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -382,26 +382,6 @@ function updateProjectTheme (platformConfig, locations) {
     const themes = xmlHelpers.parseElementtreeSync(locations.themes);
     const splashScreenTheme = themes.find('style[@name="Theme.App.SplashScreen"]');
 
-    // Update edge-to-edge settings in app theme.
-    let hasE2E = false; // default case
-
-    const preferenceE2E = platformConfig.getPreference('AndroidEdgeToEdge', this.platform);
-    if (!preferenceE2E) {
-        events.emit('verbose', 'The preference name "AndroidEdgeToEdge" was not set. Defaulting to "false".');
-    } else {
-        const hasInvalidPreferenceE2E = preferenceE2E !== 'true' && preferenceE2E !== 'false';
-        if (hasInvalidPreferenceE2E) {
-            events.emit('verbose', 'Preference name "AndroidEdgeToEdge" has an invalid value. Valid values are "true" or "false". Defaulting to "false"');
-        }
-        hasE2E = hasInvalidPreferenceE2E ? false : preferenceE2E === 'true';
-    }
-
-    const optOutE2EKey = 'android:windowOptOutEdgeToEdgeEnforcement';
-    const optOutE2EItem = splashScreenTheme.find(`item[@name="${optOutE2EKey}"]`);
-    const optOutE2EValue = !hasE2E ? 'true' : 'false';
-    optOutE2EItem.text = optOutE2EValue;
-    events.emit('verbose', `Updating theme item "${optOutE2EKey}" with value "${optOutE2EValue}"`);
-
     let splashBg = platformConfig.getPreference('AndroidWindowSplashScreenBackground', this.platform);
     if (!splashBg) {
         splashBg = platformConfig.getPreference('SplashScreenBackgroundColor', this.platform);

--- a/templates/project/res/values/cdv_themes.xml
+++ b/templates/project/res/values/cdv_themes.xml
@@ -37,5 +37,6 @@
 
     <style name="Theme.Cordova.App.DayNight" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:colorBackground">@color/cdv_background_color</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Support previous non-E2E design in SDK 35+ (including SDK 36)
- Add an platform internal plugin called SystemBarPlugin
  - Statusbar (Include auto changing of font/icon color)
  - Nav/Gesture Bar
- Add Core StatusBar JS APIs

### Description
<!-- Describe your changes in detail -->

**StatusBar JS API:**

- `window.statusbar.visible = <true|false>`
- `window.statusbar.setBackgroundColor('#AARRGGBB')`

**`config.xml preferences:**

This PR reuses all of the previous preferences. Order of imports listed below

- For **StatusBar**
  - `StatusBarBackgroundColor`
  - `BackgroundColor`
- For **Nav/Gesture Bar**
  - `BackgroundColor`

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- Build testing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
