### PR TITLE
Allows additional settings to be included on settings.gradle

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -205,7 +205,8 @@ class ProjectBuilder {
             '// GENERATED FILE - DO NOT EDIT\n' +
             'apply from: "cdv-gradle-name.gradle"\n' +
             'include ":"\n' +
-            settingsGradlePaths.join(''));
+            settingsGradlePaths.join('') +
+            '\nif (file("settings-additional.gradle").exists()) { apply from: "settings-additional.gradle" }\n');
 
         // Touch empty cdv-gradle-name.gradle file if missing.
         if (!fs.existsSync(path.join(this.root, 'cdv-gradle-name.gradle'))) {


### PR DESCRIPTION
### Motivation and Context
I'm integrating a flutter module inside a ionic cordova app. So accordingly to the [flutter guide](https://docs.flutter.dev/add-to-app/android/project-setup#depend-on-the-modules-source-code) I need to put the following config on settings.gradle.

```gradle
setBinding(new Binding([gradle: this]))
def filePath = settingsDir.parentFile.toString() + "/flutter_module/.android/include_flutter.groovy"
apply from: filePath 
```

But the file is regenerated on each build, and my changes are lost.

### Description

Sometimes we need some extra settings on settings.gradle file, but the file is regenerated on each build.
The proposed solution applies a `settings-additional.gradle` file (if it exists) to the `settings.gradle`.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
