### PR TITLE
fix: replace deprecated fs.F_OK with fs.constants.F_OK

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -173,7 +173,7 @@ class ProjectBuilder {
             // This is the future-proof way of checking if a file exists
             // This must be synchronous to satisfy a Travis test
             try {
-                fs.accessSync(subProjectGradle, fs.F_OK);
+                fs.accessSync(subProjectGradle, fs.constants.F_OK);
             } catch (e) {
                 fs.cpSync(pluginBuildGradle, subProjectGradle);
             }


### PR DESCRIPTION
### Motivation and Context
This change resolves the Node.js deprecation warning DEP0176:

> fs.F_OK is deprecated, use fs.constants.F_OK instead


The warning appears when building projects with recent versions of Node.js (v20.8.0+).
No open issue was found for this warning at the time of writing.



### Description
Replaced usage of the deprecated `fs.F_OK` with `fs.constants.F_OK` in `cordova-android/lib/builders/ProjectBuilder.js`.

This change aligns with the Node.js recommendation since v6.3.0.


### Testing
- Verified that the build still completes successfully without functional issues.
- Confirmed that the DEP0176 deprecation warning is no longer emitted during build.
- `npm test`



### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
