### PR TITLE
Android: Fix gradle deprecation warnings about property assignment

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -44,7 +44,7 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'org.apache.cordova'
+    namespace = 'org.apache.cordova'
 
     compileSdkVersion cordovaConfig.COMPILE_SDK_VERSION
     buildToolsVersion cordovaConfig.BUILD_TOOLS_VERSION

--- a/templates/project/app/build.gradle
+++ b/templates/project/app/build.gradle
@@ -183,10 +183,10 @@ task cdvPrintProps {
 }
 
 android {
-    namespace cordovaConfig.PACKAGE_NAMESPACE
+    namespace = cordovaConfig.PACKAGE_NAMESPACE
 
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
 
     defaultConfig {
@@ -202,7 +202,7 @@ android {
     }
 
     lintOptions {
-      abortOnError false
+      abortOnError = false
     }
 
     buildToolsVersion cordovaConfig.BUILD_TOOLS_VERSION

--- a/test/androidx/app/build.gradle
+++ b/test/androidx/app/build.gradle
@@ -24,7 +24,7 @@ android {
     compileSdkVersion cordovaConfig.COMPILE_SDK_VERSION
     buildToolsVersion cordovaConfig.BUILD_TOOLS_VERSION
 
-    namespace 'org.apache.cordova.unittests'
+    namespace = 'org.apache.cordova.unittests'
 
     defaultConfig {
         applicationId "org.apache.cordova.unittests"


### PR DESCRIPTION
When building a plain Android Cordova app without plugins, there will be Gradle depraction warnings: `Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.`. Compiling it with `--warning-mode all` shows, that some properties are assigned without an `=`, which will not be supported any longer with Gradle 10.0.

### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
