### PR TITLE
feat: AndroidShowDeprecations preference flag

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -113,7 +113,8 @@ function getUserGradleConfig (configXml) {
         { xmlKey: 'GradlePluginKotlinEnabled', gradleKey: 'IS_GRADLE_PLUGIN_KOTLIN_ENABLED', type: Boolean },
         { xmlKey: 'AndroidJavaSourceCompatibility', gradleKey: 'JAVA_SOURCE_COMPATIBILITY', type: Number },
         { xmlKey: 'AndroidJavaTargetCompatibility', gradleKey: 'JAVA_TARGET_COMPATIBILITY', type: Number },
-        { xmlKey: 'AndroidKotlinJVMTarget', gradleKey: 'KOTLIN_JVM_TARGET', type: String }
+        { xmlKey: 'AndroidKotlinJVMTarget', gradleKey: 'KOTLIN_JVM_TARGET', type: String },
+        { xmlKey: 'AndroidShowDeprecations', gradleKey: 'JAVA_SHOW_DEPRECATIONS', type: Boolean }
     ];
 
     return configXmlToGradleMapping.reduce((config, mapping) => {

--- a/templates/project/build.gradle
+++ b/templates/project/build.gradle
@@ -40,6 +40,18 @@ allprojects {
     }
 
     repositories repos
+
+    subprojects {
+        afterEvaluate {
+            tasks.withType(JavaCompile).tap {
+                configureEach {
+                    if (cordovaConfig.JAVA_SHOW_DEPRECATIONS == true) {
+                        options.compilerArgs += "-Xlint:deprecation"
+                    }
+                }
+            }
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Useful development tool for core android & plugin developers

### Description
<!-- Describe your changes in detail -->

Introduces a new `AndroidShowDeprecations` preference flag, which when `true` it will enable deprecation prints in the build output. By default, the flag is false.

See https://github.com/apache/cordova-docs/pull/1424 for documentation

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
