### PR TITLE
fix: Deprecation warning in PluginManager for using Class.newInstance

### DIFF
--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -564,7 +564,7 @@ public class PluginManager {
                 c = Class.forName(className);
             }
             if (c != null & CordovaPlugin.class.isAssignableFrom(c)) {
-                ret = (CordovaPlugin) c.newInstance();
+                ret = (CordovaPlugin) c.getDeclaredConstructor().newInstance();
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
In `instantiatePlugin`, `Class.getInstance` was called, but is [deprecated since Java 9](https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--). Instead `Class.getDeclaredConstructor().newInstance()` should be called.

### Platforms affected
Android

### Motivation and Context
Resolving deprecation warnings for cordova-android

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
