### PR TITLE
feat: allow disabling splash screen for embedded Cordova

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -106,7 +106,9 @@ public class CordovaActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         // Handle the splash screen transition.
-        splashScreen = SplashScreen.installSplashScreen(this);
+        if (showInitialSplashScreen()) {
+            splashScreen = SplashScreen.installSplashScreen(this);
+        }
 
         // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
         loadConfig();
@@ -157,7 +159,9 @@ public class CordovaActivity extends AppCompatActivity {
         cordovaInterface.onCordovaInit(appView.getPluginManager());
 
         // Setup the splash screen based on preference settings
-        cordovaInterface.pluginManager.postMessage("setupSplashScreen", splashScreen);
+        if (showInitialSplashScreen()) {
+            cordovaInterface.pluginManager.postMessage("setupSplashScreen", splashScreen);
+        }
 
         // Wire the hardware volume controls to control media if desired.
         String volumePref = preferences.getString("DefaultVolumeStream", "");
@@ -536,5 +540,21 @@ public class CordovaActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
+    }
+
+    /**
+     * Indicates whether to show the splash screen while the WebView is initially loading.
+     * <p>
+     * This method is available for native apps that embed a Cordova WebView.
+     * Native apps most likely already have their own splash screen setup.
+     * This option is not configurable for Cordova CLI–created apps.
+     *
+     * @return {@code true}
+     * <p>
+     * To disable the initial splash screen, override this method and return {@code false}
+     * in your activity that extends {@link CordovaActivity}.
+     */
+    protected boolean showInitialSplashScreen() {
+        return true;
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Provide a way for native apps that embed a Cordova WebView to disable Cordova's Splash Screen.

This is not intended for apps created with Cordova CLI.

### Description
<!-- Describe your changes in detail -->

Added `showInitialSplashScreen` method to return `true` by default.

Native apps that embed a Cordova WebView can override this method inside the Activity that extends `CordovaActivity`.

E.g.

```kotlin
override fun showInitialSplashScreen(): Boolean {
    return false
}
```

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Built native app
- Override method `showInitialSplashScreen`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
