### PR TITLE
fix: updateStatusBar(int bgColor) to work on non edge-to-edge android…

### DIFF
--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -231,6 +231,10 @@ public class SystemBarPlugin extends CordovaPlugin {
     private void updateStatusBar(int bgColor) {
         Window window = cordova.getActivity().getWindow();
 
+        if (Build.VERSION.SDK_INT <= 35) {
+            window.setStatusBarColor(bgColor);
+        }
+
         View statusBar = getStatusBarView(webView);
         if (statusBar != null) {
             statusBar.setBackgroundColor(bgColor);


### PR DESCRIPTION
… versions

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is a fix for what I believe to be a bug introduced in this PR: https://github.com/apache/cordova-android/pull/1817

With the recent changes to support edge to edge, an android view was added above and below the webview that contains web content. updateStatusBar(int bgColor) successfully sets the color for those views, but will not set the color on a device that doesn't support edge-to-edge, so any device running android 14 and below.

Here is the effect on an android 10 devices with the new changes:
<img width="1164" height="1099" alt="image" src="https://github.com/user-attachments/assets/2b2eb99e-54a6-43fb-a2c5-0b091eaedbfd" />


And here it is with what currently exists:
<img width="1193" height="1095" alt="image" src="https://github.com/user-attachments/assets/73548d61-6d1f-49db-8213-191589b336c7" />


Notice that since we also automatically set the color of the content, that having a light background color also makes the icons fully disappear as well, since they are trying to maintain contrast with the background, but the background is not being set.


### Description
<!-- Describe your changes in detail -->

Use the window.setStatusBarColor() method to correctly set the color of the native status bar where it can exist.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I tested setting the status bar color on several versions of android, and changed the value of `AndroidEdgeToEdge` to ensure compatibility with the new preference.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
