### PR TITLE
fix(statusbar): inject script block to compute color & replace padStart w/ logic supported on SDK 24

### DIFF
--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -23,6 +23,10 @@ var exec = require('cordova/exec');
 var statusBarVisible = true;
 var statusBar = {};
 
+// This <script> element is explicitly used by Cordova's statusbar for computing color. (Do not use this element)
+const statusBarScript = document.createElement('script');
+document.head.appendChild(statusBarScript);
+
 Object.defineProperty(statusBar, 'visible', {
     configurable: false,
     enumerable: true,
@@ -54,9 +58,8 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
     enumerable: false,
     writable: false,
     value: function (value) {
-        var script = document.querySelector('script[src$="cordova.js"]');
-        script.style.color = value;
-        var rgbStr = window.getComputedStyle(script).getPropertyValue('color');
+        statusBarScript.style.color = value;
+        var rgbStr = window.getComputedStyle(statusBarScript).getPropertyValue('color');
 
         if (!rgbStr.match(/^rgb/)) { return; }
 
@@ -68,7 +71,11 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
             rgbVals = [255].concat(rgbVals);
         }
 
-        const padRgb = (val) => val.toString(16).padStart(2, '0');
+        // TODO: Use `padStart(2, '0')` once SDK 24 is dropped.
+        const padRgb = (val) => {
+            const hex = val.toString(16);
+            return hex.length === 1 ? '0' + hex : hex;
+        };
         const a = padRgb(rgbVals[0]);
         const r = padRgb(rgbVals[1]);
         const g = padRgb(rgbVals[2]);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixing of the following cases in status bar implementation:

- `padStart` is not supported in SDK 24's default WebView version.
- Project's that some how renames`cordova.js` and wouldn't be detected.

### Description
<!-- Describe your changes in detail -->

- Replaced `padStart` with logic that is supported by SDK 24. This should be replaced with `padStart` when SDK 24 is dropped.
- When `cordova.js` is loaded, or what ever the file name maybe, the statusbar portion will automatically create a script block and inject it to the head. The reference of this block is stored internally so that the `setBackgroundColor` may use it to compute the color. It no longer relies on the filename.

> Note: Third-party plugins should not try to locate and manipulate this script block as the implementation could change in the future, depending on what JS support we have access to in the future.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- Running emulators, 24, 25, 26, ... 34, 35, 36 and changing statusbar background color.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
