### PR TITLE
fix: re-expose and support pollOnce

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -131,6 +131,8 @@ function pollOnce (opt_fromOnlineEvent) {
     }
 }
 
+androidExec.pollOnce = pollOnce;
+
 function pollingTimerFunc () {
     if (pollEnabled) {
         pollOnce();

--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -204,7 +204,7 @@ public class NativeToJsMessageQueue {
                 }
             }
             if (!willSendAllMessages) {
-                sb.append("window.setTimeout(function(){cordova.require('cordova/plugin/android/polling').pollOnce();},0);");
+                sb.append("window.setTimeout(function(){cordova.require('cordova/exec').pollOnce();},0);");
             }
             for (int i = willSendAllMessages ? 1 : 0; i < numMessagesToSend; ++i) {
                 sb.append('}');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Re-add support for pollOnce which was broken for 13 years and not used.

Resolves #1735
Closes #1746

### Description
<!-- Describe your changes in detail -->

- Expose the `pollOnce` method that was relocated into `cordova-js-src/exec.js` 13 years ago.
- Update `framework/src/org/apache/cordova/NativeToJsMessageQueue.java` to require the new location of `pollOnce`

### Testing
<!-- Please describe in detail how you tested your changes. -->

 - `npm t`
 - Built app and called manually from DevTools `window.setTimeout(function(){cordova.require('cordova/exec').pollOnce();},0);`
   - I don't have a specific use case to invoke the native function `popAndEncodeAsJs` in order to confirm its expected behavior.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
