### PR TITLE
Call new method `CordovaPlugin.onRequestPermissionsResult`

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -528,7 +528,7 @@ public class CordovaActivity extends AppCompatActivity {
 
         try
         {
-            cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);
+            cordovaInterface.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
         catch (JSONException e)
         {

--- a/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
+++ b/framework/src/org/apache/cordova/CordovaInterfaceImpl.java
@@ -217,11 +217,15 @@ public class CordovaInterfaceImpl implements CordovaInterface {
      * @param permissions
      * @param grantResults
      */
-    public void onRequestPermissionResult(int requestCode, String[] permissions,
+    public void onRequestPermissionsResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException {
         Pair<CordovaPlugin, Integer> callback = permissionResultCallbacks.getAndRemoveCallback(requestCode);
         if(callback != null) {
+            // This one is deprecated - see https://github.com/apache/cordova-android/issues/592
+            // and should be removed in a future release
             callback.first.onRequestPermissionResult(callback.second, permissions, grantResults);
+            // Call the new method
+            callback.first.onRequestPermissionsResult(callback.second, permissions, grantResults);
         }
     }
 

--- a/test/androidx/app/src/main/java/org/apache/cordova/unittests/EmbeddedWebViewActivity.java
+++ b/test/androidx/app/src/main/java/org/apache/cordova/unittests/EmbeddedWebViewActivity.java
@@ -87,7 +87,7 @@ public class EmbeddedWebViewActivity extends AppCompatActivity {
      * Called by the system when the user grants permissions!
      *
      * Note: The fragment gets priority over the activity, since the activity doesn't call
-     * into the parent onRequestPermissionResult, which is why there's no override.
+     * into the parent onRequestPermissionsResult, which is why there's no override.
      *
      * @param requestCode
      * @param permissions
@@ -98,7 +98,7 @@ public class EmbeddedWebViewActivity extends AppCompatActivity {
                                            int[] grantResults) {
         try
         {
-            cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);
+            cordovaInterface.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
         catch (JSONException e)
         {


### PR DESCRIPTION
- `CordovaInterfaceImpl` called the deprecated method `CordovaPlugin.onRequestPermissionResult` but not the new one `CordovaPlugin.onRequestPermissionsResult`. Now it will be called also.
- Fixes https://github.com/apache/cordova-android/issues/1388
- Renamed `CordovaInterfaceImpl.onRequestPermissionResult` to `CordovaInterfaceImpl.onRequestPermissionsResult` to reflect the new method name

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
