### PR TITLE
Deprecate `PermissionHelper`

### DIFF
--- a/framework/src/org/apache/cordova/PermissionHelper.java
+++ b/framework/src/org/apache/cordova/PermissionHelper.java
@@ -25,8 +25,18 @@ import org.json.JSONException;
 import android.content.pm.PackageManager;
 
 /**
- * This class provides reflective methods for permission requesting and checking so that plugins
+ * This class is permission helper class when compiling against older versions of cordova-android pre 5.0.0
+ * and provides reflective methods for permission requesting and checking so that plugins
  * written for cordova-android 5.0.0+ can still compile with earlier cordova-android versions.
+ * 
+ * Some Cordova plugins still use this class, for example:
+ * - https://github.com/apache/cordova-plugin-file/blob/master/src/android/FileUtils.java#L42
+ * - https://github.com/apache/cordova-plugin-geolocation/blob/master/src/android/Geolocation.java#L27
+ * - https://github.com/apache/cordova-plugin-camera/blob/master/src/android/CameraLauncher.java#L52
+ * Before this class can be removed, those plugins need to be updated to call {@link CordovaInterface} methods directly.
+ *
+ * @deprecated As of cordova-android 5.0.0, this class is no longer needed and will be removed in a future release.
+ * You can call directly into {@link CordovaInterface} methods instead with {@link CordovaPlugin#cordova}.
  */
 public class PermissionHelper {
     private static final String LOG_TAG = "CordovaPermissionHelper";
@@ -40,6 +50,7 @@ public class PermissionHelper {
      * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
      *                      along with the result of the permission request
      * @param permission    The permission to be requested
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermission()} instead.
      */
     public static void requestPermission(CordovaPlugin plugin, int requestCode, String permission) {
         PermissionHelper.requestPermissions(plugin, requestCode, new String[] {permission});
@@ -54,6 +65,7 @@ public class PermissionHelper {
      * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
      *                      along with the result of the permissions request
      * @param permissions   The permissions to be requested
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermissions()} instead.
      */
     public static void requestPermissions(CordovaPlugin plugin, int requestCode, String[] permissions) {
         plugin.cordova.requestPermissions(plugin, requestCode, permissions);
@@ -67,6 +79,7 @@ public class PermissionHelper {
      * @param plugin        The plugin the permission is being checked against
      * @param permission    The permission to be checked
      * @return              True if the permission has already been granted and false otherwise
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#hasPermission()} instead.
      */
     public static boolean hasPermission(CordovaPlugin plugin, String permission) {
         return plugin.cordova.hasPermission(permission);


### PR DESCRIPTION
- The `PermissionHelper` was for cordova-android versions pre 5.0.0. Since cordova-anroid 5.0.0 the relevant permission methods can be called directly on `CordovaInterface`.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
