### PR TITLE
CallbackContext: Add success method for boolean

### DIFF
--- a/framework/src/org/apache/cordova/CallbackContext.java
+++ b/framework/src/org/apache/cordova/CallbackContext.java
@@ -66,6 +66,15 @@ public class CallbackContext {
      *
      * @param message           The message to add to the success result.
      */
+    public void success(boolean message) {
+        sendPluginResult(new PluginResult(PluginResult.Status.OK, message));
+    }
+
+    /**
+     * Helper for success callbacks that just returns the Status.OK by default
+     *
+     * @param message           The message to add to the success result.
+     */
     public void success(JSONObject message) {
         sendPluginResult(new PluginResult(PluginResult.Status.OK, message));
     }


### PR DESCRIPTION
- Add a helper method for success callbacks that returns `Status.OK` with a boolean
- It didn't exist a `success` method for a boolean result, but for `JSONObject`, `JSONArray`, `String`, `byte[]` and `int`

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During developing the plugin of [cordova-plugin-local-notifications](https://github.com/katzer/cordova-plugin-local-notifications/blob/eb45bffdc795984dea39e6cb14a1589708a1da25/src/android/LocalNotification.java#L623-L629) I noticed that the original author implemented a helper method for `new PluginResult(PluginResult.Status.OK, success)`, but I wondered why `success` couldn't be directly called on `CallbackContext`.


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
