### PR TITLE
fix: opaque navigation bar in edge to edge

### DIFF
--- a/templates/project/res/values/cdv_themes.xml
+++ b/templates/project/res/values/cdv_themes.xml
@@ -30,9 +30,6 @@
 
         <!-- Required: Set the theme of the Activity that directly follows your splash screen. -->
         <item name="postSplashScreenTheme">@style/Theme.Cordova.App.DayNight</item>
-
-        <!-- Disable Edge-to-Edge for SDK 35 -->
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="Theme.Cordova.App.DayNight" parent="Theme.AppCompat.DayNight.NoActionBar">


### PR DESCRIPTION
### Platforms affected

Android 15


### Motivation and Context

Resolves #1866 


### Description

When in edge to edge, i.e. using `AndroidEdgeToEdge` preference as `true` and a `BackgroundColor` is provided, the navigation bar is opaque with a background color set.

| `AndroidEdgeToEdge = false` and `android:windowOptOutEdgeToEdgeEnforcement = true` | `AndroidEdgeToEdge = true` and `android:windowOptOutEdgeToEdgeEnforcement = true` | `AndroidEdgeToEdge = false` and `android:windowOptOutEdgeToEdgeEnforcement = false` | `AndroidEdgeToEdge = true` and `android:windowOptOutEdgeToEdgeEnforcement = false` |
|--------|--------|--------|--------|
|<img width="1280" height="2856" alt="Image" src="https://github.com/user-attachments/assets/71daeadb-a9cc-4881-a4ab-c2a26a22c182" /> | <img width="1280" height="2856" alt="Image" src="https://github.com/user-attachments/assets/55da4e6c-f5ba-48bf-a1df-f2e29c35436d" /> | <img width="1280" height="2856" alt="Image" src="https://github.com/user-attachments/assets/fb532d02-9ce5-4f15-adf1-32779f1d4c59" /> | <img width="1280" height="2856" alt="Image" src="https://github.com/user-attachments/assets/f894590b-709f-4e77-bddb-85f9bebc5dea" /> |

### Testing

Manually tested the change by creating a cordova application using cordova-android@15.0.0-nightly.20251114002605023.sha.655aa0a5, modified the theme and ran the app on an emulator



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
