### PR TITLE
fix(windows): Escape back-slashes for gradle config jdk path

### DIFF
--- a/lib/builders/ProjectBuilder.js
+++ b/lib/builders/ProjectBuilder.js
@@ -319,7 +319,9 @@ class ProjectBuilder {
                  */
                 const javaHome = process.env.CORDOVA_JAVA_HOME || process.env.JAVA_HOME || false;
                 if (javaHome) {
-                    configProperties.set('java.home', javaHome);
+                    // Double escape back-slashes so that it is written as escaped back-slashes
+                    // in the gradle config. Primary an issue in window environments.
+                    configProperties.set('java.home', javaHome.replace(/\\/g, '\\\\'));
                 } else {
                     configProperties.unset('java.home');
                 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Windows

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/apache/cordova-android/issues/1842

### Description
<!-- Describe your changes in detail -->

Run the JDK path through a regex which matches all `\` occurrences, and replaces it with `\\` (or `"\\\\"` JS runtime value) so that they are escaped for the `config.properties` print out.

These values needs to be escaped properly for gradle to read them.

This primary affects windows users, but on unix if there are back-slashes, they should be escaped as well, so I figured there isn't a need for an OS guard.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test` on windows.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
