### PR TITLE
fix: Potential NPE when handling generic exceptions

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewClient.java
@@ -112,7 +112,7 @@ public class SystemWebViewClient extends WebViewClient {
                 return new WebResourceResponse(mimeType, null, is);
             } catch (Exception e) {
                 e.printStackTrace();
-                LOG.e(TAG, e.getMessage());
+                LOG.e(TAG, "Exception handling Web resource at \"" + path + "\"", e);
             }
             return null;
         });

--- a/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java
@@ -317,7 +317,7 @@ public class SystemWebViewEngine implements CordovaWebViewEngine {
             try {
                 webView.getContext().unregisterReceiver(receiver);
             } catch (Exception e) {
-                LOG.e(TAG, "Error unregistering configuration receiver: " + e.getMessage(), e);
+                LOG.e(TAG, "Error unregistering configuration receiver", e);
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Java's [Throwable.getMessage()](https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getMessage--) may return null, therefore when handling generic `Exception` instances, it is unsafe to assume that `getMessage()` will return a string.

In some cases, this result gets passed to the LOG apis which does not handle nulls and thus will error with a NullPointerException.

Reproduction steps is unknown but this was discovered in my app via Sentry report:

<img width="573" height="113" alt="image" src="https://github.com/user-attachments/assets/a86ca9c5-1588-40c3-b8fa-b3e4125781a5" />

<img width="1425" height="581" alt="image" src="https://github.com/user-attachments/assets/a155358d-bc20-4b4e-a371-84f272b24a6c" />

### Description
<!-- Describe your changes in detail -->

I searched for usages of `Exception e` and any place where it used `.getMessage()` API. The `.getMessage()` usage was removed, and used the [LOG.e(String tag, String message, Throwable e)](https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/LOG.java#L185) signature to log the exception where applicable.

### Testing
<!-- Please describe in detail how you tested your changes. -->

NPM test runs successfully.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
