### PR TITLE
chore: update RELEASENOTES.md

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -66,6 +66,8 @@
 
 **Chores:**
 
+* chore: add license header to template gitignore ([#1893](https://github.com/apache/cordova-android/pull/1893)) [[ffa77cad](https://github.com/apache/cordova-android/commit/ffa77cad)]
+* chore: update RELEASENOTES.md ([#1892](https://github.com/apache/cordova-android/pull/1892)) [[5003275b](https://github.com/apache/cordova-android/commit/5003275b)]
 * chore: license, license headers & CI & draft workflow improvements ([#1891](https://github.com/apache/cordova-android/pull/1891)) [[d426e0ff](https://github.com/apache/cordova-android/commit/d426e0ff)]
 * chore: update changelog ([#1890](https://github.com/apache/cordova-android/pull/1890)) [[aaf46bb2](https://github.com/apache/cordova-android/commit/aaf46bb2)]
 * chore(ci): get npm package filename from json output ([#1889](https://github.com/apache/cordova-android/pull/1889)) [[7fbdee1e](https://github.com/apache/cordova-android/commit/7fbdee1e)]


### PR DESCRIPTION
Updated RELEASENOTES.md for adding license header to templated gitignore file.