### PR TITLE
doc(readme): Remove redundant link `Required Software & Tools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Cordova Android is an Android application library that allows for Cordova-based 
 > Refer to the official Apache Cordova documentation for details on the requirements and prerequisites for building Cordova-Android applications. These resources outline the necessary tools, supported versions, and platform requirements:
 >
 > * [System Requirements](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#system-requirements)
-> * [Required Software & Tools](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#the-required-software-&-tools)
 > * [Android API Level Support](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support)
 
 ## Create a Cordova project


### PR DESCRIPTION
- The link for `System Requirements` already point to the right location and the section `Required Software & Tools` follows right after.

This is screenshot for `System Requirements` section:

<img width="881" height="408" alt="image" src="https://github.com/user-attachments/assets/3550bd1e-8c59-408b-bd43-72819359b84a" />

The next section underneath `Required Software & Tools` would be the second link where the link points to, which this PR removes.

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
