### PR TITLE
feat: add web view version check by preference `AndroidMinimumWebViewVersion`

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -48,6 +48,10 @@ import androidx.core.splashscreen.SplashScreen;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.webkit.WebViewCompat;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 
 /**
  * This class is the main Android activity that represents the Cordova
@@ -120,6 +124,9 @@ public class CordovaActivity extends AppCompatActivity {
 
         // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
         loadConfig();
+
+        // Check WebView version requirement
+        checkWebViewVersion();
 
         canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
                 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
@@ -586,6 +593,112 @@ public class CordovaActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
+    }
+
+    /**
+     * Check if the WebView version meets the minimum required version.
+     * If not, display an error dialog and exit the app.
+     */
+    private void checkWebViewVersion() {
+        String minimumWebViewVersion = preferences.getString("AndroidMinimumWebViewVersion", null);
+        if (minimumWebViewVersion == null || minimumWebViewVersion.isEmpty()) {
+            return; // No minimum version requirement set
+        }
+
+        try {
+            String currentWebViewVersion = getWebViewVersion();
+            if (currentWebViewVersion != null && !isWebViewVersionSufficient(currentWebViewVersion, minimumWebViewVersion)) {
+                String title = getWebViewVersionTitle();
+                String message = getWebViewVersionMessage();
+                String button = getWebViewVersionButtonText();
+                displayError(title, message, button, true);
+            }
+        } catch (Exception e) {
+            LOG.e(TAG, "Error checking WebView version: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Get the WebView version check dialog title from string resources.
+     */
+    private String getWebViewVersionTitle() {
+        int resId = getResources().getIdentifier("webview_version_too_old_title", "string", getPackageName());
+        return resId != 0 ? getString(resId) : "WebView Update Required";
+    }
+
+    /**
+     * Get the WebView version check dialog message from string resources.
+     */
+    private String getWebViewVersionMessage() {
+        int resId = getResources().getIdentifier("webview_version_too_old_message", "string", getPackageName());
+        return resId != 0 ? getString(resId) : "Your Android System WebView version is too old. Please update it through the Google Play Store.";
+    }
+
+    /**
+     * Get the WebView version check dialog button text from string resources.
+     */
+    private String getWebViewVersionButtonText() {
+        int resId = getResources().getIdentifier("webview_version_ok_button", "string", getPackageName());
+        return resId != 0 ? getString(resId) : "OK";
+    }
+
+    /**
+     * Get the current WebView version string.
+     * @return Version string (e.g., "80.0.1234.56") or null if unable to determine
+     */
+    private String getWebViewVersion() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            try {
+                String webViewPackageName = WebViewCompat.getCurrentWebViewPackage(this).packageName;
+                PackageManager pm = getPackageManager();
+                PackageInfo pi = pm.getPackageInfo(webViewPackageName, 0);
+                return pi.versionName;
+            } catch (Exception e) {
+                LOG.d(TAG, "Could not get WebView version using WebViewCompat: " + e.getMessage());
+            }
+        }
+
+        // Fallback for older API levels
+        try {
+            PackageManager pm = getPackageManager();
+            PackageInfo pi = pm.getPackageInfo("com.google.android.webview", 0);
+            return pi.versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            LOG.d(TAG, "Could not find WebView package");
+        }
+
+        return null;
+    }
+
+    /**
+     * Compare two version strings and determine if current version is >= minimum version.
+     * @param currentVersion Current version string (e.g., "80.0.1234.56")
+     * @param minimumVersion Minimum required version string (e.g., "80.0")
+     * @return true if currentVersion >= minimumVersion
+     */
+    private boolean isWebViewVersionSufficient(String currentVersion, String minimumVersion) {
+        try {
+            String[] currentParts = currentVersion.split("\\.");
+            String[] minimumParts = minimumVersion.split("\\.");
+
+            int maxLength = Math.max(currentParts.length, minimumParts.length);
+
+            for (int i = 0; i < maxLength; i++) {
+                int currentPart = i < currentParts.length ? Integer.parseInt(currentParts[i]) : 0;
+                int minimumPart = i < minimumParts.length ? Integer.parseInt(minimumParts[i]) : 0;
+
+                if (currentPart > minimumPart) {
+                    return true;
+                } else if (currentPart < minimumPart) {
+                    return false;
+                }
+            }
+
+            return true; // Versions are equal
+        } catch (NumberFormatException e) {
+            LOG.e(TAG, "Error parsing version strings: " + e.getMessage());
+            return true; // If we can't parse, assume it's OK
+        }
     }
 
     /**

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -664,23 +664,33 @@ public class CordovaActivity extends AppCompatActivity {
     private String getWebViewVersion() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             try {
-                String webViewPackageName = WebViewCompat.getCurrentWebViewPackage(this).packageName;
-                PackageManager pm = getPackageManager();
-                PackageInfo pi = pm.getPackageInfo(webViewPackageName, 0);
-                return pi.versionName;
+                PackageInfo webViewPackage = WebViewCompat.getCurrentWebViewPackage(this);
+                if (webViewPackage != null) {
+                    return webViewPackage.versionName;
+                }
             } catch (Exception e) {
                 LOG.d(TAG, "Could not get WebView version using WebViewCompat: " + e.getMessage());
             }
         }
 
         // Fallback for older API levels
-        try {
-            PackageManager pm = getPackageManager();
-            PackageInfo pi = pm.getPackageInfo("com.google.android.webview", 0);
-            return pi.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            LOG.d(TAG, "Could not find WebView package");
+        PackageManager pm = getPackageManager();
+        String[] fallbackPackages = new String[] {
+            "com.google.android.webview",
+            "com.android.webview",
+            "com.android.chrome"
+        };
+
+        for (String packageName : fallbackPackages) {
+            try {
+                PackageInfo pi = pm.getPackageInfo(packageName, 0);
+                return pi.versionName;
+            } catch (PackageManager.NameNotFoundException ignored) {
+                // Try next package
+            }
         }
+
+        LOG.d(TAG, "Could not find WebView package");
 
         return null;
     }

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -111,6 +111,11 @@ public class CordovaActivity extends AppCompatActivity {
 
     private boolean canEdgeToEdge = false;
     private boolean isFullScreen = false;
+    /**
+     * Flag set in {@link #checkWebViewVersion} indicating whether the WebView version
+     * is below the minimum required version specified in config.xml.
+     */
+    private boolean isWebViewVersionBlocked = false;
 
     /**
      * Called when the activity is first created.
@@ -172,6 +177,10 @@ public class CordovaActivity extends AppCompatActivity {
     }
 
     protected void init() {
+        if (isWebViewVersionBlocked) {
+            return;
+        }
+
         appView = makeWebView();
         createViews();
         if (!appView.isInitialized()) {
@@ -286,6 +295,10 @@ public class CordovaActivity extends AppCompatActivity {
      * Load the url into the WebView.
      */
     public void loadUrl(String url) {
+        if (isWebViewVersionBlocked) {
+            return;
+        }
+
         if (appView == null) {
             init();
         }
@@ -596,8 +609,9 @@ public class CordovaActivity extends AppCompatActivity {
     }
 
     /**
-     * Check if the WebView version meets the minimum required version.
-     * If not, display an error dialog and exit the app.
+     * Check if the WebView version meets the minimum required version specified by
+     * preference `AndroidMinimumWebViewVersion` in config.xml.
+     * If not, display an error dialog and block the app from loading further.
      */
     private void checkWebViewVersion() {
         String minimumWebViewVersion = preferences.getString("AndroidMinimumWebViewVersion", null);
@@ -608,6 +622,7 @@ public class CordovaActivity extends AppCompatActivity {
         try {
             String currentWebViewVersion = getWebViewVersion();
             if (currentWebViewVersion != null && !isWebViewVersionSufficient(currentWebViewVersion, minimumWebViewVersion)) {
+                isWebViewVersionBlocked = true;
                 String title = getWebViewVersionTitle();
                 String message = getWebViewVersionMessage();
                 String button = getWebViewVersionButtonText();

--- a/templates/project/res/values/cdv_strings.xml
+++ b/templates/project/res/values/cdv_strings.xml
@@ -24,4 +24,8 @@
     <string name="launcher_name">@string/app_name</string>
     <!-- App label shown on the task switcher. -->
     <string name="activity_name">@string/launcher_name</string>
+    <!-- WebView version check messages -->
+    <string name="webview_version_too_old_title">WebView Update Required</string>
+    <string name="webview_version_too_old_message">Your Android System WebView version is too old. Please update it through the Google Play Store.</string>
+    <string name="webview_version_ok_button">OK</string>
 </resources>


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context

I often had the problem when deploying an Android app to an older emulator like Android version 7/8/9, where the WebView does not update in the emulator and using more recent JavaScript features like for e.g. optional chaining `?.` which is available in Chrome 80, i got stuck in the splash screen and nothing happens. I also didn't see a JS alert, when I tried to catch errors. I tried to solve this in JS by checking the web view before, but I would have to check the web view version first and the had to load all scripts after, which is not a nice solution. Also, this feature could be made available more easy for others in this way.

### Description
<!-- Describe your changes in detail -->

- If preference `AndroidMinimumWebViewVersion` is set, it will check if the current installed web view suits the version. If not, an error message is shown and the app exists, after the user clicks on OK.
- The strings can be internationalized by adding a `strings.xml` with appropriates strings to the appropriate `values` directory.
- Generated-By: Claude Haiku 4.5, Visual Studio Code

# Overview of WebView Version Check Feature - Generated by Claude Haiku 4.5

## Overview

This feature adds support for enforcing a minimum WebView version requirement in Cordova Android apps. If the installed WebView version is older than the specified minimum, a dialog will be shown to the user prompting them to update through the Google Play Store, and the app will close.

## Usage

### 1. Add the Preference to config.xml

Add the `AndroidMinimumWebViewVersion` preference to your `config.xml` file:

```xml
<?xml version='1.0' encoding='utf-8'?>
<widget id="io.cordova.hellocordova" version="1.0.0"
        xmlns="http://www.w3.org/ns/widgets">
    <name>Hello Cordova</name>
    
    <!-- Set minimum WebView version to 80.0 -->
    <preference name="AndroidMinimumWebViewVersion" value="80.0" />
    
    <!-- ... rest of config.xml ... -->
</widget>
```

### 2. Version Format

- The version string should start with the major version number: `"80.0"`, `"90.0"`, `"100.0"`, etc.
- You can use full versions with patch numbers: `"80.0.1234.56"` - only the relevant parts will be compared
- The comparison is done numerically, part-by-part (e.g., 80.0 < 90.0 < 100.0)

### 3. What Happens

If a user's WebView version is too old:
1. A dialog appears with the title: "WebView Update Required"
2. Message: "Your Android System WebView version is too old. Please update it through the Google Play Store."
3. An "OK" button closes the dialog and exits the app
4. The user must update their WebView before they can use the app

### 4. Internationalization

The strings used in the dialog can be customized by overriding the string resources in your project's `res/values/` directory:

```xml
<!-- res/values/strings.xml -->
<string name="webview_version_too_old_title">Your Custom Title</string>
<string name="webview_version_too_old_message">Your custom message here</string>
<string name="webview_version_ok_button">Continue</string>
```

For other languages, create localized versions:

```xml
<!-- res/values-de/strings.xml (German) -->
<string name="webview_version_too_old_title">WebView-Update erforderlich</string>
<string name="webview_version_too_old_message">Ihre Android System WebView-Version ist zu alt. Bitte aktualisieren Sie sie über den Google Play Store.</string>
<string name="webview_version_ok_button">OK</string>
```

```xml
<!-- res/values-fr/strings.xml (French) -->
<string name="webview_version_too_old_title">Mise à jour de WebView requise</string>
<string name="webview_version_too_old_message">Votre version Android System WebView est trop ancienne. Veuillez la mettre à jour via le Google Play Store.</string>
<string name="webview_version_ok_button">OK</string>
```

### 5. Examples

#### Example 1: Require WebView 80.0 or newer
```xml
<preference name="AndroidMinimumWebViewVersion" value="80.0" />
```

#### Example 2: Require WebView 100.0 with specific patch
```xml
<preference name="AndroidMinimumWebViewVersion" value="100.0.4896.26" />
```

#### Example 3: No version requirement (feature disabled)
```xml
<!-- Omit the preference entirely or leave it empty -->
<!-- No dialog will be shown -->
```

## Technical Details

### How it Works

1. **Version Detection**: The feature uses `WebViewCompat.getCurrentWebViewPackage()` (API 26+) to get the installed WebView package, or falls back to querying the `com.google.android.webview` package directly
2. **Version Comparison**: Versions are parsed and compared numerically, part by part (e.g., 80.0.1234 is compared as [80, 0, 1234])
3. **Timing**: The check is performed in `CordovaActivity.onCreate()` after preferences are loaded but before any WebView content is loaded
4. **Dialog**: Uses Android's standard `AlertDialog` for the warning message

### Error Handling

- If the WebView version cannot be determined, the check is skipped (app continues normally)
- If version parsing fails, the app assumes the version is acceptable and continues
- All exceptions during the check are caught and logged

### Supported Android Versions

This feature works on all supported Android versions. The WebView version checking uses Android 8+ optimized methods when available, with graceful fallbacks for older API levels.

## Implementation Files Changed

1. **CordovaActivity.java** - Added WebView version checking logic
2. **cdv_strings.xml** - Added localized string resources for the dialog (optional - defaults are built-in)

## API Details

The implementation includes four new private methods in `CordovaActivity`:

- `checkWebViewVersion()` - Main method called from onCreate
- `getWebViewVersion()` - Retrieves the current WebView version string
- `isWebViewVersionSufficient()` - Compares version strings
- `getWebViewVersionTitle()`, `getWebViewVersionMessage()`, `getWebViewVersionButtonText()` - Get localized strings with fallback defaults

## String Customization

The dialog strings can be customized in three ways (in order of precedence):

1. **Via app's string resources** (highest priority):
   - Add `webview_version_too_old_title`, `webview_version_too_old_message`, `webview_version_ok_button` to your app's `res/values/strings.xml`

2. **Via template string resources**:
   - Defined in `cordova-android/templates/project/res/values/cdv_strings.xml`
   - These are used when building new projects from the template

3. **Built-in defaults** (lowest priority):
   - Default English strings are hardcoded in CordovaActivity if resources are not found
   - Title: "WebView Update Required"
   - Message: "Your Android System WebView version is too old. Please update it through the Google Play Store."
   - Button: "OK"

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Tested on Android 9 with WebView 66 and using WebView 80 features and setting `<preference name="AndroidMinimumWebViewVersion" value="80.0" />`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
