### PR TITLE
fix: simplify edge-to-edge preference logic in CordovaActivity and SystemBarPlugin

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -121,8 +121,7 @@ public class CordovaActivity extends AppCompatActivity {
         // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
         loadConfig();
 
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
 
         String logLevel = preferences.getString("loglevel", "ERROR");
         LOG.setLogLevel(logLevel);

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -55,8 +55,7 @@ public class SystemBarPlugin extends CordovaPlugin {
     protected void pluginInitialize() {
         context = cordova.getContext();
         resources = context.getResources();
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
     }
 
     @Override


### PR DESCRIPTION
Simplify edge-to-edge preference logic

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
The motivation and context was described here: https://github.com/apache/cordova-discuss/issues/114

When having cordova android in Edge To Edge the app does not extend to the full height of the device in version bellow Android 15. This change allows the app to behave the same way it was possible to do with the statusbar plugin preference `StatusBarOverlaysWebView` given that this stopped having any effect in cordova-android 15. 


### Description
This PR removes the limitation for Android version <15 when preference `AndroidEdgeToEdge` is true. 



### Testing
Tested in Android 12, 13 and 16



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
