### PR TITLE
fix: overwritten backbutton not firing on first time by hardware button and never on back gesture

### DIFF
--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -263,7 +263,7 @@ public class CoreAndroid extends CordovaPlugin {
             @Override
             public void run() {
                 if (shouldOverride) {
-                    LOG.i("App", "WARNING: Back Button Default Behavior will be overridden.  The backbutton event will be fired!");                    
+                    LOG.i("App", "WARNING: Back Button Default Behavior will be overridden.  The backbutton event will be fired!");
                     synchronized (backButtonHandlerLock) {
                         if (backCallback == null) {
                             registerBackPressedCallback();

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -266,13 +266,21 @@ public class CoreAndroid extends CordovaPlugin {
                     LOG.i("App", "WARNING: Back Button Default Behavior will be overridden.  The backbutton event will be fired!");
                     synchronized (backButtonHandlerLock) {
                         if (backCallback == null) {
-                            registerBackPressedCallback();
+                            backCallback = new OnBackPressedCallback(true) {
+                                @Override
+                                public void handleOnBackPressed() {
+                                    dispatchBackKeyEvent();
+                                }
+                            };
+                            OnBackPressedDispatcherOwner backPressedDispatcherOwner = cordova.getActivity();
+                            backPressedDispatcherOwner.getOnBackPressedDispatcher().addCallback(backPressedDispatcherOwner, backCallback);
                         }
                     }
                 } else {
                     synchronized (backButtonHandlerLock) {
                         if (backCallback != null) {
-                            unregisterBackPressedCallback();
+                            backCallback.remove();
+                            backCallback = null;
                         }
                     }
                 }
@@ -280,24 +288,6 @@ public class CoreAndroid extends CordovaPlugin {
                 webView.setButtonPlumbedToJs(KeyEvent.KEYCODE_BACK, shouldOverride);
             }
         });
-    }
-
-    /**
-     * Registers an AndroidX back callback so Cordova can keep routing back presses through its
-     * existing key dispatch path across Android versions without directly referencing newer
-     * platform-only back APIs.
-     */
-    private void registerBackPressedCallback() {
-        final OnBackPressedDispatcherOwner backPressedDispatcherOwner = this.cordova.getActivity();
-
-        backCallback = new OnBackPressedCallback(true) {
-            @Override
-            public void handleOnBackPressed() {
-                dispatchBackKeyEvent();
-            }
-        };
-
-        backPressedDispatcherOwner.getOnBackPressedDispatcher().addCallback(backPressedDispatcherOwner, backCallback);
     }
 
     private void dispatchBackKeyEvent() {
@@ -323,11 +313,6 @@ public class CoreAndroid extends CordovaPlugin {
         } finally {
             backCallback.setEnabled(true);
         }
-    }
-
-    private void unregisterBackPressedCallback() {
-        backCallback.remove();
-        backCallback = null;
     }
 
     /**

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -254,7 +254,6 @@ public class CoreAndroid extends CordovaPlugin {
      * @param override		T=override, F=cancel override
      */
     public void overrideBackbutton(boolean override) {
-        LOG.i("App", "WARNING: Back Button Default Behavior will be overridden.  The backbutton event will be fired!");
         if (cordova.getActivity() == null) {
             return;
         }
@@ -264,6 +263,7 @@ public class CoreAndroid extends CordovaPlugin {
             @Override
             public void run() {
                 if (shouldOverride) {
+                    LOG.i("App", "WARNING: Back Button Default Behavior will be overridden.  The backbutton event will be fired!");                    
                     synchronized (backButtonHandlerLock) {
                         if (backCallback == null) {
                             registerBackPressedCallback();

--- a/framework/src/org/apache/cordova/CoreAndroid.java
+++ b/framework/src/org/apache/cordova/CoreAndroid.java
@@ -29,6 +29,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.os.SystemClock;
 import android.content.IntentFilter;
 import android.telephony.TelephonyManager;
 import android.view.KeyEvent;
@@ -292,13 +293,36 @@ public class CoreAndroid extends CordovaPlugin {
         backCallback = new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
-                // Intentionally empty.
-                // On modern Android versions, registering a callback keeps back handling
-                // routed through Cordova's existing key dispatch path.
+                dispatchBackKeyEvent();
             }
         };
 
         backPressedDispatcherOwner.getOnBackPressedDispatcher().addCallback(backPressedDispatcherOwner, backCallback);
+    }
+
+    private void dispatchBackKeyEvent() {
+        // Build a synthetic BACK key press (DOWN + UP) and route it through the WebView.
+        // This lets Cordova's existing key handling fire the JS "backbutton" event.
+        final long eventTime = SystemClock.uptimeMillis();
+        final KeyEvent downEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK, 0);
+        final KeyEvent upEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK, 0);
+
+        final boolean handledDown = webView.getView().dispatchKeyEvent(downEvent);
+        final boolean handledUp = webView.getView().dispatchKeyEvent(upEvent);
+
+        // If either event was consumed, Cordova/WebView already handled back behavior.
+        if (handledDown || handledUp) {
+            return;
+        }
+
+        // Otherwise, delegate to Android's default back dispatcher.
+        // Temporarily disable this callback to avoid recursive re-entry.
+        backCallback.setEnabled(false);
+        try {
+            cordova.getActivity().getOnBackPressedDispatcher().onBackPressed();
+        } finally {
+            backCallback.setEnabled(true);
+        }
     }
 
     private void unregisterBackPressedCallback() {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- When pressing the back button after the app starts nothing happens. When navigating to another page, the back button js event starts to fire.
- On Android versions, which support the back gesture, nothing happens
- This was due to the empty `OnBackPressedCallback.handleOnBackPressed` method, which has to forward its call to the WebView, which is done now by a synthetic back button event. If the WebView does not handle the synthetic back button event, the back button if forwarded to `cordova.getActivity().getOnBackPressedDispatcher().onBackPressed()`.
- Generated-By: GPT-5.4, GitHub Copilot Chat

### Code cleanup

- Put log warning about back button override on the right place
- resolve methods `registerBackPressedCallback` and `unregisterBackPressedCallback`. The code moved to inline code.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->
- Tested back button after first start on Android 9
- Test back button gesture on Android 14 and 16


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
