### PR TITLE
doc: improve documentation of `onRequestPermissionResult` and `onRequestPermissionsResult`

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -416,7 +416,11 @@ public class CordovaPlugin {
     }
 
     /**
-     * Called by the system when the user grants permissions
+     * Forwarded system call to {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])}
+     * and from there to the plugin that requested permissions, when the user granted them, denied them,
+     * or when the request was interrupted.
+     * This is a legacy method that will be called if a plugin overrides it,
+     * but new plugins should override {@link #onRequestPermissionsResult} instead.
      *
      * @param requestCode
      * @param permissions
@@ -430,11 +434,14 @@ public class CordovaPlugin {
     }
 
     /**
-     * Called by the system when the user grants permissions
+     * Forwarded system call to {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])}
+     * and from there to the plugin that requested permissions, when the user granted them, denied them,
+     * or when the request was interrupted.
      *
      * @param requestCode
      * @param permissions
      * @param grantResults
+     * @see https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])
      */
     public void onRequestPermissionsResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException {

--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -416,11 +416,14 @@ public class CordovaPlugin {
     }
 
     /**
-     * Forwarded system call to {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])}
-     * and from there to the plugin that requested permissions, when the user granted them, denied them,
-     * or when the request was interrupted.
-     * This is a legacy method that will be called if a plugin overrides it,
-     * but new plugins should override {@link #onRequestPermissionsResult} instead.
+     * Forwarded system call to the plugin when the user grants permissions,
+     * denies them or the request was interrupted.
+     * This is a legacy method and should not be used anymore.
+     * Instead {@link #onRequestPermissionsResult} should be used.
+     * 
+     * Note: The system calls {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])},
+     * which calls {@link CordovaInterfaceImpl#onRequestPermissionsResult(int, String[], int[])},
+     * and finally this method.
      *
      * @param requestCode
      * @param permissions
@@ -434,9 +437,12 @@ public class CordovaPlugin {
     }
 
     /**
-     * Forwarded system call to {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])}
-     * and from there to the plugin that requested permissions, when the user granted them, denied them,
-     * or when the request was interrupted.
+     * Forwarded system call to the plugin when the user grants permissions,
+     * denies them or the request was interrupted.
+     * 
+     * Note: The system calls {@link CordovaActivity#onRequestPermissionsResult(int, String[], int[])},
+     * which calls {@link CordovaInterfaceImpl#onRequestPermissionsResult(int, String[], int[])},
+     * and finally this method.
      *
      * @param requestCode
      * @param permissions


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Make clear, that these methods are not only called, when the user grants permissions, but also when he denies them or the request was interrupted.
- Add note, how the call chain ist
- Make clear, that `onRequestPermissionResult` is legacy and should not be used anymore
- Add Android Developer documentation link for the new `onRequestPermissionsResult`

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
