### PR TITLE
fix: webview loses scrollability and creates empty bottom space

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -18,6 +18,7 @@
 */
 package org.apache.cordova;
 
+import java.io.ObjectInputFilter.Config;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -220,7 +221,7 @@ public class CordovaActivity extends AppCompatActivity {
         // Handle Window Insets
         ViewCompat.setOnApplyWindowInsetsListener(rootLayout, (v, insets) -> {
             Insets bars = insets.getInsets(
-                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+                    WindowInsetsCompat.Type.ime() | WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
             );
 
             boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -220,18 +220,25 @@ public class CordovaActivity extends AppCompatActivity {
         // Handle Window Insets
         ViewCompat.setOnApplyWindowInsetsListener(rootLayout, (v, insets) -> {
             Insets bars = insets.getInsets(
-                    WindowInsetsCompat.Type.ime() | WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
             );
+            Insets ime = insets.getInsets(WindowInsetsCompat.Type.ime());
 
             boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
             int top = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
-            int bottom = !canEdgeToEdge && !isFullScreen ? bars.bottom : 0;
             int left = !canEdgeToEdge && !isFullScreen ? bars.left : 0;
             int right = !canEdgeToEdge && !isFullScreen ? bars.right : 0;
 
-            FrameLayout.LayoutParams webViewParams = (FrameLayout.LayoutParams) webView.getLayoutParams();
-            webViewParams.setMargins(left, top, right, bottom);
-            webView.setLayoutParams(webViewParams);
+            int bottom = 0;
+            if (!isFullScreen) {
+                bottom = !canEdgeToEdge ? Math.max(bars.bottom, ime.bottom) : ime.bottom;
+            }
+
+            if (webViewParams.leftMargin != left || webViewParams.topMargin != top
+                    || webViewParams.rightMargin != right || webViewParams.bottomMargin != bottom) {
+                webViewParams.setMargins(left, top, right, bottom);
+                webView.setLayoutParams(webViewParams);
+            }
 
             FrameLayout.LayoutParams statusBarParams = new FrameLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -222,7 +222,6 @@ public class CordovaActivity extends AppCompatActivity {
             Insets bars = insets.getInsets(
                     WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
             );
-            Insets ime = insets.getInsets(WindowInsetsCompat.Type.ime());
 
             boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
             int top = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
@@ -230,10 +229,16 @@ public class CordovaActivity extends AppCompatActivity {
             int right = !canEdgeToEdge && !isFullScreen ? bars.right : 0;
 
             int bottom = 0;
+            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
+            // When in fullscreen mode, we ignore bottom system insets (like the navigation bar)
+            // to allow the WebView to span the entire screen and avoid being pushed up.
             if (!isFullScreen) {
-                bottom = !canEdgeToEdge ? Math.max(bars.bottom, ime.bottom) : ime.bottom;
+                bottom = canEdgeToEdge ? imeInsets.bottom : Math.max(bars.bottom, imeInsets.bottom);
             }
 
+            FrameLayout.LayoutParams webViewParams = (FrameLayout.LayoutParams) webView.getLayoutParams();
+            // Only update layout margins if the values have actually changed.
+            // This prevents redundant layout passes and potential infinite layout loops
             if (webViewParams.leftMargin != left || webViewParams.topMargin != top
                     || webViewParams.rightMargin != right || webViewParams.bottomMargin != bottom) {
                 webViewParams.setMargins(left, top, right, bottom);

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -222,18 +222,20 @@ public class CordovaActivity extends AppCompatActivity {
             Insets bars = insets.getInsets(
                     WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
             );
-            Insets ime = insets.getInsets(WindowInsetsCompat.Type.ime());
 
             boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
             int top = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
             int left = !canEdgeToEdge && !isFullScreen ? bars.left : 0;
             int right = !canEdgeToEdge && !isFullScreen ? bars.right : 0;
 
-            int bottom = 0;
-            if (!isFullScreen) {
-                bottom = !canEdgeToEdge ? Math.max(bars.bottom, ime.bottom) : ime.bottom;
-            }
+            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
+            // When in fullscreen mode, we ignore bottom system insets (like the navigation bar)
+            // to allow the WebView to span the entire screen and avoid being pushed up.
+            int bottom = isFullScreen ? 0 : canEdgeToEdge ? imeInsets.bottom : Math.max(bars.bottom, imeInsets.bottom);
 
+            FrameLayout.LayoutParams webViewParams = (FrameLayout.LayoutParams) webView.getLayoutParams();
+            // Only update layout margins if the values have actually changed.
+            // This prevents redundant layout passes and potential infinite layout loops
             if (webViewParams.leftMargin != left || webViewParams.topMargin != top
                     || webViewParams.rightMargin != right || webViewParams.bottomMargin != bottom) {
                 webViewParams.setMargins(left, top, right, bottom);

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -18,7 +18,6 @@
 */
 package org.apache.cordova;
 
-import java.io.ObjectInputFilter.Config;
 import java.util.ArrayList;
 import java.util.Locale;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
 - Android


### Motivation and Context
This change is required to fix UI layout and scrolling bug present in `cordova-android`@15.0.0. When an input field receives focus on a scrollable screen, the Android soft keyboard pushes the entire WebView upward. This leaves an empty, unrendered space at the bottom of the Activity and completely locks the page scroll, which breaks applications relying on viewport heights or scroll adjustments.

Closes https://github.com/apache/cordova-android/issues/1923



### Description
This PR adjusts how the native root layout handles window insets when the soft keyboard (IME) is displayed.

Previously, the layout did not account for the IME insets natively, causing Android to shift the entire Activity upward and cut off the `<body>` boundaries. By adding `WindowInsetsCompat.Type.ime()` to the `ViewCompat.setOnApplyWindowInsetsListener` configuration, the root layout now listens to the keyboard dimensions alongside system bars and display cutouts. This correctly applies the bottom margin dynamically to the `webViewParams`.

after adding: 

<img width="1504" height="848" alt="Captura de Tela 2026-05-14 às 16 16 07" src="https://github.com/user-attachments/assets/78e6aa37-5a12-4ce4-9747-115a73f189e2" />

This behavior is very similar to how cordova-android@14 behaves.

### Testing
 - npm t
 - Build testing


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
