### PR TITLE
chore: cleanup PermissionHelper

### DIFF
--- a/framework/src/org/apache/cordova/PermissionHelper.java
+++ b/framework/src/org/apache/cordova/PermissionHelper.java
@@ -18,12 +18,6 @@
 */
 package org.apache.cordova;
 
-import java.util.Arrays;
-
-import org.json.JSONException;
-
-import android.content.pm.PackageManager;
-
 /**
  * This class is permission helper class when compiling against older versions of cordova-android pre 5.0.0
  * and provides reflective methods for permission requesting and checking so that plugins
@@ -48,7 +42,7 @@ public class PermissionHelper {
      * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
      *                      along with the result of the permission request
      * @param permission    The permission to be requested
-     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermission()} instead.
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermission(CordovaPlugin, int, String)} instead.
      */
     public static void requestPermission(CordovaPlugin plugin, int requestCode, String permission) {
         PermissionHelper.requestPermissions(plugin, requestCode, new String[] {permission});
@@ -63,7 +57,7 @@ public class PermissionHelper {
      * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
      *                      along with the result of the permissions request
      * @param permissions   The permissions to be requested
-     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermissions()} instead.
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermissions(CordovaPlugin, int, String[])} instead.
      */
     public static void requestPermissions(CordovaPlugin plugin, int requestCode, String[] permissions) {
         plugin.cordova.requestPermissions(plugin, requestCode, permissions);
@@ -77,7 +71,7 @@ public class PermissionHelper {
      * @param plugin        The plugin the permission is being checked against
      * @param permission    The permission to be checked
      * @return              True if the permission has already been granted and false otherwise
-     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#hasPermission()} instead.
+     * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#hasPermission(String)} instead.
      */
     public static boolean hasPermission(CordovaPlugin plugin, String permission) {
         return plugin.cordova.hasPermission(permission);

--- a/framework/src/org/apache/cordova/PermissionHelper.java
+++ b/framework/src/org/apache/cordova/PermissionHelper.java
@@ -32,6 +32,7 @@ package org.apache.cordova;
  * @deprecated As of cordova-android 5.0.0, this class is no longer needed and will be removed in a future release.
  * You can call directly into {@link CordovaInterface} methods instead with {@link CordovaPlugin#cordova}.
  */
+@Deprecated
 public class PermissionHelper {
     /**
      * Requests a "dangerous" permission for the application at runtime. This is a helper method
@@ -44,6 +45,7 @@ public class PermissionHelper {
      * @param permission    The permission to be requested
      * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermission(CordovaPlugin, int, String)} instead.
      */
+    @Deprecated
     public static void requestPermission(CordovaPlugin plugin, int requestCode, String permission) {
         PermissionHelper.requestPermissions(plugin, requestCode, new String[] {permission});
     }
@@ -59,6 +61,7 @@ public class PermissionHelper {
      * @param permissions   The permissions to be requested
      * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#requestPermissions(CordovaPlugin, int, String[])} instead.
      */
+    @Deprecated
     public static void requestPermissions(CordovaPlugin plugin, int requestCode, String[] permissions) {
         plugin.cordova.requestPermissions(plugin, requestCode, permissions);
     }
@@ -73,6 +76,7 @@ public class PermissionHelper {
      * @return              True if the permission has already been granted and false otherwise
      * @deprecated As of cordova-android 5.0.0, use {@link CordovaInterface#hasPermission(String)} instead.
      */
+    @Deprecated
     public static boolean hasPermission(CordovaPlugin plugin, String permission) {
         return plugin.cordova.hasPermission(permission);
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- AndroidStudio complained about methods not found linked in JavaDoc for the class CordovaInterface: requestPermission(), requestPermissions() and hasPermission(). The parameter types were missing and were added.
- Removing unused imports
- Added missing `@Deprecated` Java annotations

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
