### PR TITLE
doc(CordovaPreferences): Improve documentation for using Long.decode instead of Integer.decode

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPreferences.java
+++ b/framework/src/org/apache/cordova/CordovaPreferences.java
@@ -74,7 +74,10 @@ public class CordovaPreferences {
         name = name.toLowerCase(Locale.ENGLISH);
         String value = prefs.get(name);
         if (value != null) {
-            // Use Integer.decode() can't handle it if the highest bit is set.
+            // Some 32-bit hex values (for example, 0x80000000) are valid int bit patterns
+            // but exceed Integer.MAX_VALUE when read as positive numbers. Integer.decode()
+            // rejects such values with NumberFormatException, so decode as long first and
+            // cast to int to preserve the intended 32-bit value.
             return (int)(long)Long.decode(value);
         }
         return defaultValue;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Document why Integer.decode cannot be used for hex values when thy exceed Integer.MAX_VALUE when parsed as positive number and Long.decode has to be used instead

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
