### PR TITLE
fix(android): add missing imports in SystemWebChromeClient

### DIFF
--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -19,7 +19,10 @@
 package org.apache.cordova.engine;
 
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import android.annotation.TargetApi;
+import android.content.pm.PackageManager;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ActivityNotFoundException;


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
`cordova-android` 12.0.1 introduced permission-handling code in `SystemWebChromeClient.java` that uses `List`, `ArrayList`, and `PackageManager`, but the corresponding import statements were not included. This causes a compilation failure for any project using `cordova-android@12.0.1`.

### Description
Added 3 missing import statements to `SystemWebChromeClient.java`:
```java
import java.util.ArrayList;
import java.util.List;
import android.content.pm.PackageManager;
```

### Testing
Built an Ionic 3 Android release with `cordova-android@12.0.1` — build previously failed with `cannot find symbol` errors for `List`, `ArrayList`, and `PackageManager`. After applying this fix, the build completes successfully.

### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ ] I've updated the documentation if necessary