### PR TITLE
fix(statusbar): Properly handle CSS colours with alpha

### DIFF
--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -60,28 +60,29 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
         statusBarScript.style.color = value;
         var rgbStr = window.getComputedStyle(statusBarScript).getPropertyValue('color');
 
-        if (!rgbStr.match(/^rgb/)) { return; }
-
-        var rgbVals = rgbStr.match(/\d+/g).map(function (v) { return parseInt(v, 10); });
-
-        if (rgbVals.length < 3) {
+        if (!rgbStr.match(/^rgb/)) {
             return;
-        } else if (rgbVals.length === 3) {
-            rgbVals = [255].concat(rgbVals);
         }
 
-        // TODO: Use `padStart(2, '0')` once SDK 24 is dropped.
-        const padRgb = (val) => {
-            const hex = val.toString(16);
-            return hex.length === 1 ? '0' + hex : hex;
-        };
-        const a = padRgb(rgbVals[0]);
-        const r = padRgb(rgbVals[1]);
-        const g = padRgb(rgbVals[2]);
-        const b = padRgb(rgbVals[3]);
-        const hexStr = '#' + a + r + g + b;
+        var rgbVals = rgbStr.match(/[\d.]+/g).map(function (v, i) { return (i < 3) ? parseInt(v, 10) : parseFloat(v); });
+        if (rgbVals.length < 3) {
+            return;
+        }
 
         if (window.StatusBar) {
+            // try to let the StatusBar plugin handle it
+            // TODO: Use `padStart(2, '0')` once SDK 24 is dropped.
+            const padRgb = (val) => {
+                const hex = val.toString(16);
+                return hex.length === 1 ? '0' + hex : hex;
+            };
+
+            const r = padRgb(rgbVals[0]);
+            const g = padRgb(rgbVals[1]);
+            const b = padRgb(rgbVals[2]);
+            const a = padRgb(255 * (rgbVals[3] !== undefined ? rgbVals[3] : 1.0));
+
+            const hexStr = '#' + a + r + g + b;
             window.StatusBar.backgroundColorByHexString(hexStr);
         } else {
             exec(null, null, 'SystemBarPlugin', 'setStatusBarBackgroundColor', rgbVals);

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -121,19 +121,17 @@ public class SystemBarPlugin extends CordovaPlugin {
      * If the supplied ARGB is invalid or fails to parse, it will silently ignore
      * the change request.
      *
-     * @param argbVals {A, R, G, B}
+     * @param argbVals {R, G, B, A}
      */
     private void setStatusBarBackgroundColor(JSONArray argbVals) {
         try {
-            int a = argbVals.getInt(0);
-            int r = argbVals.getInt(1);
-            int g = argbVals.getInt(2);
-            int b = argbVals.getInt(3);
-            overrideStatusBarBackgroundColor = parseColorFromString(String.format("#%02X%02X%02X%02X", a, r, g, b));
+            int r = argbVals.getInt(0);
+            int g = argbVals.getInt(1);
+            int b = argbVals.getInt(2);
+            int a = Math.round(255 * (float)argbVals.optDouble(3, 1.0));
 
-            if (overrideStatusBarBackgroundColor != null) {
-                updateStatusBar(overrideStatusBarBackgroundColor);
-            }
+            overrideStatusBarBackgroundColor = Color.argb(a, r, g, b);
+            updateStatusBar(overrideStatusBarBackgroundColor);
         } catch (JSONException e) {
             // Silently skip
         }


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`window.statusbar.setBackgroundColor()` is intended to take a CSS colour, get its computed RGB(A) value, and send that over to the platform code. However, the code here was assuming that we were dealing with an Android-style `#AARRGGBB` hex colour (which is wrong).


### Description
<!-- Describe your changes in detail -->

This matches the implementation from https://github.com/apache/cordova-ios/pull/1661 and turns the RGB ints and A float into an Android Color before converting it back into a `AARRGGBB` integer (because apparently none of the Android View APIs actually support Color in the places where you set colour values).


### Testing
<!-- Please describe in detail how you tested your changes. -->
I was planning to write E2E tests for this, but it seems that we don't actually run our Android tests in CI...

For now it's untested


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
