### PR TITLE
doc(statusbar.js): document `visible` property and `setBackgroundColor` method

### DIFF
--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -26,6 +26,12 @@ var statusBar = {};
 const statusBarScript = document.createElement('script');
 document.head.appendChild(statusBarScript);
 
+/**
+ * Sets the visibility of the status bar, which will only work if Android EdgeToEdge is disabled.
+ * If cordova-plugin-statusbar is used, it works also on Android EdgeToEdge.
+ * If the plugin is used, the call will be forwarded to `window.StatusBar.show` or
+ * `window.StatusBar.hide` of the plugin.
+ */
 Object.defineProperty(statusBar, 'visible', {
     configurable: false,
     enumerable: true,

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -28,8 +28,7 @@ document.head.appendChild(statusBarScript);
 
 /**
  * Sets the visibility of the status bar, which will only work if Android EdgeToEdge is disabled.
- * If cordova-plugin-statusbar is used, it works also on Android EdgeToEdge.
- * If the plugin is used, the call will be forwarded to `window.StatusBar.show` or
+ * If cordova-plugin-statusbar the call will be forwarded to `window.StatusBar.show` or
  * `window.StatusBar.hide` of the plugin.
  */
 Object.defineProperty(statusBar, 'visible', {

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -52,6 +52,14 @@ Object.defineProperty(statusBar, 'visible', {
     }
 });
 
+/**
+ * Sets the background color of the status bar, which will visually only have an impact,
+ * if the status bar is visible. The supported format is any valid CSS color value,
+ * like `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ * If cordova-plugin-statusbar is installed, the call will be forwarded to
+ * `window.StatusBar.backgroundColorByHexString`, where alpha is only supported if
+ * `StatusBar.overlaysWebView` is set to `true`.
+ */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,
     enumerable: false,

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -28,7 +28,7 @@ document.head.appendChild(statusBarScript);
 
 /**
  * Sets the visibility of the status bar, which will only work if Android EdgeToEdge is disabled.
- * If cordova-plugin-statusbar the call will be forwarded to `window.StatusBar.show` or
+ * If cordova-plugin-statusbar is used, the call will be forwarded to `window.StatusBar.show` or
  * `window.StatusBar.hide` of the plugin.
  */
 Object.defineProperty(statusBar, 'visible', {

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -58,12 +58,12 @@ Object.defineProperty(statusBar, 'visible', {
 });
 
 /**
- * Sets the background color of the status bar, which will visually only have an impact,
- * if the status bar is visible. The supported format is any valid CSS color value,
- * like `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- * If cordova-plugin-statusbar is installed, the call will be forwarded to
- * `window.StatusBar.backgroundColorByHexString`, where alpha is only supported if
- * `StatusBar.overlaysWebView` is set to `true`.
+ * Sets the background color of the visible status bar.
+ * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ * 
+ * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
+ * `window.StatusBar.backgroundColorByHexString`
+ * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.
  */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Document `visible` property that it will not work when Android EdgeToEdge is enabled.
- Document that the supported format for `setBackgroundColor` is any valid CSS color and adding some examples.
- If `cordova-plugin-statusbar` is installed, the call will be forwarded to `window.StatusBar.backgroundColorByHexString` , where alpha is only supported if `StatusBar.overlaysWebView` is set to `true`.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
