### PR TITLE
revert PR #1902 simplify edge-to-edge preference logic in CordovaActivity and SystemBarPlugin

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -121,7 +121,9 @@ public class CordovaActivity extends AppCompatActivity {
         // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
         loadConfig();
 
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
+        // Android Edge to Edge was introduced in Android 15 and can only be used from there on
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
 
         String logLevel = preferences.getString("loglevel", "ERROR");
         LOG.setLogLevel(logLevel);

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -55,7 +55,9 @@ public class SystemBarPlugin extends CordovaPlugin {
     protected void pluginInitialize() {
         context = cordova.getContext();
         resources = context.getResources();
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
+        // Android Edge to Edge was introduced in Android 15 and can only be used from there on
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
     }
 
     @Override


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Android EdgeToEdge was introduced in Android 15 and should only be used from there on
- Add small comment to the condition
- Enabling this on pre Android 15 would create an issue on Android 7 where content is rendered behind the navigation bar, which should not happen, and results in parts of the page not being visible.
- If the status bar should be hidden on pre Android 15 the Status Bar JS API can be used: `window.statusbar.visible = false;`

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
