### PR TITLE
fix(SystemBarPlugin): remove `canEdgeToEdge` check for `execute` method

### DIFF
--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -80,10 +80,6 @@ public class SystemBarPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if(canEdgeToEdge) {
-            return false;
-        }
-
         if ("setStatusBarVisible".equals(action)) {
             boolean visible = args.getBoolean(0);
             cordova.getActivity().runOnUiThread(() -> setStatusBarVisible(visible));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Setting `StatusBarBackgroundColor` by `config.xml` is allowed and influences the light/dark appeareance of the status bar in edge-to-edge mode. This should also be possible by the Status Bar JS API method `setBackgroundColor`, so a user can dynamically change the light/dark appeareance of the status bar, even if the background color is not applied visually.


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
