### PR TITLE
feat(SystemBarPlugin): add setNavigationBarBackgroundColor to change the navigation bar

### DIFF
--- a/cordova-js-src/platform.js
+++ b/cordova-js-src/platform.js
@@ -41,6 +41,10 @@ module.exports = {
         // see the file under plugin/android/statusbar.js
         modulemapper.clobbers('cordova/plugin/android/statusbar', 'window.statusbar');
 
+        // Attach the internal navigationBar utility to window.navigationbar
+        // see the file under plugin/android/navigationbar.js
+        modulemapper.clobbers('cordova/plugin/android/navigationbar', 'window.navigationbar');
+
         var APP_PLUGIN_NAME = Number(cordova.platformVersion.split('.')[0]) >= 4 ? 'CoreAndroid' : 'App';
 
         // Inject a listener for the backbutton on the document.

--- a/cordova-js-src/plugin/android/navigationbar.js
+++ b/cordova-js-src/plugin/android/navigationbar.js
@@ -1,0 +1,53 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var exec = require('cordova/exec');
+
+var navigationBar = {};
+
+// This <script> element is explicitly used by Cordova's navigationbar for computing color. (Do not use this element)
+const navigationBarScript = document.createElement('script');
+document.head.appendChild(navigationBarScript);
+
+/**
+ * Sets the background color of the navigation bar, this will only work on old Android devices or if gesture navigation is disabled (3 button navigation).
+ * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ */
+Object.defineProperty(navigationBar, 'setBackgroundColor', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: function (value) {
+        navigationBarScript.style.color = value;
+        var rgbStr = window.getComputedStyle(navigationBarScript).getPropertyValue('color');
+
+        if (!rgbStr.match(/^rgb/)) {
+            return;
+        }
+
+        var rgbVals = rgbStr.match(/[\d.]+/g).map(function (v, i) { return (i < 3) ? parseInt(v, 10) : parseFloat(v); });
+        if (rgbVals.length < 3) {
+            return;
+        }
+
+        exec(null, null, 'SystemBarPlugin', 'setNavigationBarBackgroundColor', rgbVals);
+    }
+});
+
+module.exports = navigationBar;

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -103,29 +103,4 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
     }
 });
 
-/**
- * Sets the background color of the navigation bar, this will only work if Android old devices or if gesture navigation is disabled (3 button navigation).
- * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- */
-Object.defineProperty(statusBar, 'setNavigationBarBackgroundColor', {
-    configurable: false,
-    enumerable: false,
-    writable: false,
-    value: function (value) {
-        statusBarScript.style.color = value;
-        var rgbStr = window.getComputedStyle(statusBarScript).getPropertyValue('color');
-
-        if (!rgbStr.match(/^rgb/)) {
-            return;
-        }
-
-        var rgbVals = rgbStr.match(/[\d.]+/g).map(function (v, i) { return (i < 3) ? parseInt(v, 10) : parseFloat(v); });
-        if (rgbVals.length < 3) {
-            return;
-        }
-
-        exec(null, null, 'SystemBarPlugin', 'setNavigationBarBackgroundColor', rgbVals);
-    }
-});
-
 module.exports = statusBar;

--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -103,4 +103,29 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
     }
 });
 
+/**
+ * Sets the background color of the navigation bar, this will only work if Android old devices or if gesture navigation is disabled (3 button navigation).
+ * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ */
+Object.defineProperty(statusBar, 'setNavigationBarBackgroundColor', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: function (value) {
+        statusBarScript.style.color = value;
+        var rgbStr = window.getComputedStyle(statusBarScript).getPropertyValue('color');
+
+        if (!rgbStr.match(/^rgb/)) {
+            return;
+        }
+
+        var rgbVals = rgbStr.match(/[\d.]+/g).map(function (v, i) { return (i < 3) ? parseInt(v, 10) : parseFloat(v); });
+        if (rgbVals.length < 3) {
+            return;
+        }
+
+        exec(null, null, 'SystemBarPlugin', 'setNavigationBarBackgroundColor', rgbVals);
+    }
+});
+
 module.exports = statusBar;

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -48,6 +48,7 @@ public class SystemBarPlugin extends CordovaPlugin {
     private Context context;
     private Resources resources;
     private Integer overrideStatusBarBackgroundColor = null;
+    private boolean hasNavigationBarBackgroundColorOverride = false;
 
     private boolean canEdgeToEdge = false;
 
@@ -182,9 +183,11 @@ public class SystemBarPlugin extends CordovaPlugin {
     private void updateRootView(int bgColor) {
         Window window = cordova.getActivity().getWindow();
 
-        // Set the root view's background color. Works on SDK 36+
-        View root = cordova.getActivity().findViewById(android.R.id.content);
-        if (root != null) root.setBackgroundColor(bgColor);
+        // Keep root background controlled by navigation override once it has been explicitly set.
+        if (!hasNavigationBarBackgroundColorOverride) {
+            View root = cordova.getActivity().findViewById(android.R.id.content);
+            if (root != null) root.setBackgroundColor(bgColor);
+        }
 
         // Automatically set the font and icon color of the system bars based on background color.
         boolean isBackgroundColorLight;
@@ -204,13 +207,15 @@ public class SystemBarPlugin extends CordovaPlugin {
                 }
             }
         }
-        WindowInsetsControllerCompat controllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
-        controllerCompat.setAppearanceLightNavigationBars(isBackgroundColorLight);
+        if (!hasNavigationBarBackgroundColorOverride) {
+            WindowInsetsControllerCompat controllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
+            controllerCompat.setAppearanceLightNavigationBars(isBackgroundColorLight);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            window.setNavigationBarColor(bgColor);
-        } else {
-            window.setNavigationBarColor(Color.BLACK);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                window.setNavigationBarColor(bgColor);
+            } else {
+                window.setNavigationBarColor(Color.BLACK);
+            }
         }
     }
 
@@ -373,6 +378,7 @@ public class SystemBarPlugin extends CordovaPlugin {
          try {
             if (Build.VERSION.SDK_INT >= 21) {
                 if (argbVals != null && argbVals.length() >= 3) {
+                    hasNavigationBarBackgroundColorOverride = true;
                     int r = argbVals.getInt(0);
                     int g = argbVals.getInt(1);
                     int b = argbVals.getInt(2);
@@ -382,6 +388,10 @@ public class SystemBarPlugin extends CordovaPlugin {
                     int opaqueNavigationBarColor = Color.rgb(r, g, b);
                     boolean useLightNavigationBarIcons = isColorLight(Color.rgb(r, g, b));
                     boolean shouldUseTransparentNavigationBar = Color.alpha(navigationBarColor) == 0;
+
+                    // Set the root view's background color.
+                    View root = cordova.getActivity().findViewById(android.R.id.content);
+                    if (root != null) root.setBackgroundColor(opaqueNavigationBarColor);
 
                     final Window window = cordova.getActivity().getWindow();
                     final View decorView = window.getDecorView();

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -85,6 +85,8 @@ public class SystemBarPlugin extends CordovaPlugin {
             cordova.getActivity().runOnUiThread(() -> setStatusBarVisible(visible));
         } else if ("setStatusBarBackgroundColor".equals(action)) {
             cordova.getActivity().runOnUiThread(() -> setStatusBarBackgroundColor(args));
+        } else if ("setNavigationBarBackgroundColor".equals(action)) {
+            cordova.getActivity().runOnUiThread(() -> setNavigationBarBackgroundColor(args));
         } else {
             return false;
         }
@@ -357,6 +359,64 @@ public class SystemBarPlugin extends CordovaPlugin {
         } catch (IllegalArgumentException ignore) {
             LOG.e(PLUGIN_NAME, "Invalid color hex code. Valid format: #RRGGBB or #AARRGGBB");
             return null;
+        }
+    }
+
+    /**
+     * Allow the app to override the navigation bar background color from JS API.
+     * If the supplied ARGB is invalid or fails to parse, it will silently ignore
+     * the change request.
+     *
+     * @param argbVals {R, G, B, A}
+     */
+    private void setNavigationBarBackgroundColor(JSONArray argbVals) {
+         try {
+            if (Build.VERSION.SDK_INT >= 21) {
+                if (argbVals != null && argbVals.length() >= 3) {
+                    int r = argbVals.getInt(0);
+                    int g = argbVals.getInt(1);
+                    int b = argbVals.getInt(2);
+                    int a = Math.round(255 * (float)argbVals.optDouble(3, 1.0));
+
+                    int navigationBarColor = Color.argb(a, r, g, b);
+                    int opaqueNavigationBarColor = Color.rgb(r, g, b);
+                    boolean useLightNavigationBarIcons = isColorLight(Color.rgb(r, g, b));
+                    boolean shouldUseTransparentNavigationBar = Color.alpha(navigationBarColor) == 0;
+
+                    final Window window = cordova.getActivity().getWindow();
+                    final View decorView = window.getDecorView();
+                    int uiOptions = decorView.getSystemUiVisibility();
+
+                    // 0x80000000 FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+                    // 0x00000010 SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                    // 0x00000200 FLAG_LAYOUT_NO_LIMITS
+
+                    uiOptions = uiOptions | 0x80000000;
+
+                    if(Build.VERSION.SDK_INT >= 26) {
+                        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, decorView);
+                        if(useLightNavigationBarIcons) {
+                            windowInsetsControllerCompat.setAppearanceLightNavigationBars(true);
+                        } else {
+                            windowInsetsControllerCompat.setAppearanceLightNavigationBars(false);
+                        }
+                    } else {
+                        uiOptions = uiOptions & ~0x00000010;
+                    }
+
+                    if(Build.VERSION.SDK_INT >= 30 && shouldUseTransparentNavigationBar) {
+                        uiOptions = uiOptions | 0x00000200; // window.addFlags(0x00000200);
+                    } else {
+                        uiOptions = uiOptions & ~0x00000200; // window.clearFlags(0x00000200);
+                    }
+
+                    decorView.setSystemUiVisibility(uiOptions);
+                    window.setNavigationBarColor(Build.VERSION.SDK_INT < 30 ? opaqueNavigationBarColor : navigationBarColor);
+                }
+            }
+
+        } catch (JSONException e) {
+            // Silently skip
         }
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Since status bar handling has been added directly to cordova, navigation bar control should also be included.

### Description
<!-- Describe your changes in detail -->

The changes add `window.statusbar.setNavigationBarBackgroundColor('#ffffff00')` to change the navigation bar color on older devices or when gesture navigation is disabled (3-button navigation).

The navigation buttons color is detected automatically, just like with `setBackgroundColor`. `transparentNavigationBar` is also applied automatically if the provided color is fully transparent.

The color is also applied as the background color of the view. This should mitigate/resolve the following issue https://github.com/apache/cordova-android/issues/1946

Example usage:


``` js
window.statusbar.setNavigationBarBackgroundColor('#1f2933');
```

Android 11:

<img width="534" height="89" alt="Captura desde 2026-07-27 11-59-16" src="https://github.com/user-attachments/assets/aa0782bd-7668-499f-bd99-5bafcda7b4e8" />


Android 17:

<img width="534" height="86" alt="Captura desde 2026-07-27 11-59-06" src="https://github.com/user-attachments/assets/42161669-8af7-4899-aadb-d088f0221326" />




``` js
window.statusbar.setNavigationBarBackgroundColor('#fafafa')
```

Android 11:

<img width="534" height="89" alt="Captura desde 2026-07-27 11-59-23" src="https://github.com/user-attachments/assets/3cd6bba7-1870-47dd-9096-a5050da0a068" />


Android 17:

<img width="534" height="85" alt="Captura desde 2026-07-27 11-58-54" src="https://github.com/user-attachments/assets/d5388861-3ac1-4563-a0b9-661def31ca67" />


### Testing
<!-- Please describe in detail how you tested your changes. -->

I tested it on the Android 11 and Android 17 emulators.

### Note

 I'm not sure if this is intentional, but I wanted to mention it. If `#00000000` is passed to `setBackgroundColor`, the following code treats it as fully transparent, so the navigation bar color is not changed to the expected one (White icons). For now, I'm using `#01010100` as a workaround.

https://github.com/apache/cordova-android/blob/ed4e629e9da5721fdaa10dd6da5c85049723686e/framework/src/org/apache/cordova/SystemBarPlugin.java#L189-L193

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
