### PR TITLE
chore(dependabot): update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,17 +16,38 @@
 # under the License.
 
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     cooldown:
-      default-days: 4
+      default-days: 5
+      semver-major-days: 14
     schedule:
-      interval: "daily" # Every weekday, Monday to Friday
+      interval: "weekly" # Every Monday
+    groups:
+      gh-actions-patch-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/"
     cooldown:
-      default-days: 4
+      default-days: 5
+      semver-major-days: 14
     schedule:
-      interval: "weekly" # By default on a Monday
+      interval: "weekly" # Every Monday
+    groups:
+      npm-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update dependabot configs

### Description
<!-- Describe your changes in detail -->

- GH Action Interval changes from daily to weekly
- NPM Interval remains as weekly
- NPM PRs
  - Group patch releases
    - Increase cooldown from 4 to 5 days
  - Group minor releases
    - Increase cooldown from 4 to 5 days
  - Major releases will remain as single PR for each package
    - Increase cooldown from 4 to 14 days
- GH Actions PR
  - Group patch and minors
    - Increase cooldown from 4 to 5 days
  - Major releases will remain as single PR for each package
    - Increase cooldown from 4 to 14 days

Overall, the cooldown was increased to allow more time for packages to be vetted before PRs are being opened. By default, Dependabot has an open PR limit of five that would avoid spamming. Instead of increasing this limit, I believe grouping some updates is the better approach.

Major updates would still be opened as individual PRs so they can be reviewed more carefully. They also have a significantly longer cooldown (two weeks), since patch and minor updates are more likely to be our next targeted release.

One drawback of the 5 PR limit is that major update PRs could consume all available slots and prevent patch and minor update PRs from being opened. In this situation, I recommend closing major update PRs if a major release is not being targeted. We can manually revist and apply major updates when ready.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
