### PR TITLE
fix(statusbar): restore `StatusBarOverlaysWebView` support in non-edge-to-edge mode

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -107,6 +107,7 @@ public class CordovaActivity extends AppCompatActivity {
 
     private boolean canEdgeToEdge = false;
     private boolean isFullScreen = false;
+    private boolean statusBarOverlaysWebView = false;
 
     /**
      * Called when the activity is first created.
@@ -122,6 +123,7 @@ public class CordovaActivity extends AppCompatActivity {
         loadConfig();
 
         canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
+        statusBarOverlaysWebView = preferences.getBoolean("StatusBarOverlaysWebView", true);
 
         String logLevel = preferences.getString("loglevel", "ERROR");
         LOG.setLogLevel(logLevel);
@@ -224,7 +226,8 @@ public class CordovaActivity extends AppCompatActivity {
             );
 
             boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
-            int top = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
+            int statusBarHeight = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
+            int top = statusBarOverlaysWebView ? 0 : statusBarHeight;
             int left = !canEdgeToEdge && !isFullScreen ? bars.left : 0;
             int right = !canEdgeToEdge && !isFullScreen ? bars.right : 0;
 
@@ -244,7 +247,7 @@ public class CordovaActivity extends AppCompatActivity {
 
             FrameLayout.LayoutParams statusBarParams = new FrameLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
-                    top,
+                    statusBarHeight,
                     Gravity.TOP
             );
             statusBarView.setLayoutParams(statusBarParams);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- When using the plugin `cordova-plugin-statusbar` with `cordova-android@14.0.1`, the status bar overlays the web view by default and a translucent color can be set. Also the setting can be controlled by the preference `StatusBarOverlaysWebView` in `config.xml`. This PR restores the behaviour. `StatusBarOverlaysWebView ` will be only applied, when the status bar plugin is added or the app is not in edge-to-edge mode

### Notes

[@dpogue mentioned](https://github.com/apache/cordova-android/pull/1991#issuecomment-5220804122), that this should be done by `<meta name="viewport" content="viewport-fit=cover|contain">` by a MutationObserver in JavaScript. On iOS this behaviour can already be obtained by using `<meta name="viewport" content="viewport-fit=cover“>`. @dpogue opened PR #2010 on cordova-android which would resolve this.

## Sample

Configuration:

- Add cordova-plugin-statusbar
- Set `<preference name="StatusBarBackgroundColor" value="#22ff0000" />` in `config.xml`
 - Test on Android 10 Emulator

| cordova-android 14.0.1 | cordova-android 15.1.0 |
| --- | --- |
| <img width="400" src="https://github.com/user-attachments/assets/651f839f-8823-43ce-b5eb-bb2c24d261f1" /> |  <img width="400" src="https://github.com/user-attachments/assets/987eb52a-c02f-4b11-b925-6c18425ee7b4" /> |

Restored behaviour in this PR:

<img width="400" src="https://github.com/user-attachments/assets/a670757e-ea2d-42cd-98d0-54894f4fccfb" />


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
