### PR TITLE
doc(statusbar.js): behaviour of `setBackgroundColor` when `AndroidEdgeToEdge` is set, added minimum cordova-android version for full CSS color formats support

### DIFF
--- a/cordova-js-src/plugin/android/statusbar.js
+++ b/cordova-js-src/plugin/android/statusbar.js
@@ -61,6 +61,13 @@ Object.defineProperty(statusBar, 'visible', {
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
  *
+ * On Android, when the preference `AndroidEdgeToEdge` is `true`, this may not produce
+ * a visible status bar background fill, but can still be used to set the
+ * light/dark status bar appearance.
+ *
+ * Note: Runtime support for all valid CSS color formats is fully functional since
+ * cordova-android 15.1.0.
+ *
  * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
  * `window.StatusBar.backgroundColorByHexString`
  * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- On Android, when the preference `AndroidEdgeToEdge` is `true`, this may not produce a visible status bar background fill, but can still be used to set the light/dark status bar appearance.
-  Added note: Runtime support for all valid CSS color formats is fully functional since cordova-android 15.1.0.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
