### PR TITLE
chore(dependabot): remove semver-major-days from github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
     directory: "/"
     cooldown:
       default-days: 5
-      semver-major-days: 14
     schedule:
       interval: "weekly" # Every Monday
     groups:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Correct mistake in last dependabot config update

### Description
<!-- Describe your changes in detail -->

I initially misunderstood the [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown) configuration. The `semver-major-days` parameter is only supported for package ecosystems that support SemVer, and GitHub Actions does not support this parameter.

This PR removes the unsupported `semver-major-days` parameter from the GitHub Actions configuration.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
