### PR TITLE
fix(statusbar): hide status bar correctly

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -223,7 +223,8 @@ public class CordovaActivity extends AppCompatActivity {
                     WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
             );
 
-            boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE;
+            boolean isStatusBarVisible = statusBarView.getVisibility() != View.GONE
+                    && insets.isVisible(WindowInsetsCompat.Type.statusBars());
             int top = isStatusBarVisible && !canEdgeToEdge && !isFullScreen ? bars.top : 0;
             int left = !canEdgeToEdge && !isFullScreen ? bars.left : 0;
             int right = !canEdgeToEdge && !isFullScreen ? bars.right : 0;

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -34,6 +34,7 @@ import android.widget.FrameLayout;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
 import org.json.JSONArray;
@@ -101,6 +102,16 @@ public class SystemBarPlugin extends CordovaPlugin {
      * @param visible should the status bar be visible?
      */
     private void setStatusBarVisible(final boolean visible) {
+        Window window = cordova.getActivity().getWindow();
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, window.getDecorView());
+        if (visible) {
+            controller.show(WindowInsetsCompat.Type.statusBars());
+        } else {
+            // Reveal the hidden bar temporarily as an overlay when swiped from the top.
+            controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            controller.hide(WindowInsetsCompat.Type.statusBars());
+        }
+
         View statusBar = getStatusBarView(webView);
         if (statusBar != null) {
             statusBar.setVisibility(visible ? View.VISIBLE : View.GONE);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Calling `window.statusbar.visible = false` sets the background of the statusbar transparent, but the content of the statusbar is still visible (clock, connectivity, battery and such). The webapp content fills the freed-up space, but now overlaps with the remaining statusbar content. When the user slides down from the top, nothing happens. There's no way to make the statusbar content disappear.

### Description
<!-- Describe your changes in detail -->

- Hide the real Android status bar through the built-in API and allow it to be temporarily revealed by swipe. Respect the system status-bar visibility when calculating Cordova's faux status-bar inset, preserving compatibility with cordova-plugin-statusbar.
- Fixes #1999

Generated-By: GPT-5.6 Terra

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
