### PR TITLE
fix(statusbar): give statusBarView initial layout params so it cannot cover the WebView

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -216,6 +216,14 @@ public class CordovaActivity extends AppCompatActivity {
         // Create StatusBar view that will overlay the top inset
         View statusBarView = new View(this);
         statusBarView.setTag("statusBarView");
+        // Start with a height of 0. The inset listener below sizes the view to the status bar height, but if the window
+        // insets never reach the root layout (observed on Android 8.0 where the decor consumes them), the view would
+        // otherwise keep FrameLayout's default MATCH_PARENT params and cover the whole WebView.
+        statusBarView.setLayoutParams(new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                Gravity.TOP
+        ));
 
         // Handle Window Insets
         ViewCompat.setOnApplyWindowInsetsListener(rootLayout, (v, insets) -> {


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Fixes #1947.

`CordovaActivity.createViews` adds `statusBarView` to `rootLayout` without `LayoutParams` and only sizes it inside `rootLayout`'s `OnApplyWindowInsetsListener`, so the view starts with `FrameLayout`'s default `MATCH_PARENT x MATCH_PARENT`. On API 21–27 the listener never runs once `SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` is cleared (e.g. by cordova-plugin-statusbar's Android side for `StatusBarOverlaysWebView=false`): `WindowCompat.setDecorFitsSystemWindows(window, false)` is only emulated through that flag below API 30, and without it the decor's `fitsSystemWindows` content root consumes the insets before they reach `rootLayout` (on API 28/29 the dispatch happens to continue because of the display-cutout part of `WindowInsets.isConsumed()`, on API 30+ `Window.setDecorFitsSystemWindows(false)` makes the content root pass them through). The view then covers the whole WebView, painted in the status-bar color by `SystemBarPlugin` — the app shows only a solid color after the splash screen. Full analysis with a `dumpsys` view hierarchy in #1947.

### Description

Give `statusBarView` initial `LayoutParams(MATCH_PARENT, 0, Gravity.TOP)`. When insets arrive, the listener resizes the view exactly as before; when they never arrive, the view stays 0 px high instead of covering the WebView.

### Testing

Samsung Galaxy S7, Android 8.0.0 (API 26), Chrome WebView 138, cordova-plugin-statusbar 4.0.0 with `StatusBarOverlaysWebView=false`, app sets `StatusBarBackgroundColor=#2A95D2` (`AndroidEdgeToEdge` default). Before: full-screen colored view over the WebView (`dumpsys activity top`: `View{… 0,0-1080,1848}` above `SystemWebView{… 0,0-1080,1848}`). After: app visible, status bar as expected (`View{… 0,0-1080,0}`).

| before (top of the screen) | after |
|---|---|
| ![Galaxy S7 unpatched: status bar, then solid StatusBarBackgroundColor](https://github.com/user-attachments/assets/1733c673-6cb9-4c15-97f5-6294d1028763) | ![Galaxy S7 with the fix: app header rendered](https://github.com/user-attachments/assets/7f5398c0-d53e-4df5-b7a5-3bb8c88da23f) |

- Samsung XCover 5 (Android 14), Pixel 6a (Android 17): unchanged behavior, status bar view sized to the inset as before.
- Same S7 with the trigger removed (statusbar plugin without its Android side): the listener runs, the view is sized to the inset, soft keyboard (IME insets) behaves correctly on API 26.
- Unpatched reference on x86_64 emulators API 28 / 29 / 30: not affected (view sized 0 px / 0 px / inset height by the listener), see #1947 for the hierarchies.

The change was applied to cordova-android 15.1.0 via an `after_prepare` hook in our app for these tests (our app itself now avoids the trigger by not installing the statusbar plugin's Android side). `npm run lint` and the 337 JS specs pass; `java-unit-tests` was not run locally (no Android SDK on the machine used for the PR), the Java change was verified with the device builds above.

### Checklist

- [x] I've run the tests to see all new and existing tests pass (lint + JS specs; Java tests: see Testing)
- [ ] I added automated test coverage as appropriate for this change (no Java view tests exist for this code path)
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`) — repo convention `fix(statusbar):` used
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary (none needed)
