### PR TITLE
fix: some static analysis warnings in Java code

### DIFF
--- a/framework/src/org/apache/cordova/PluginManager.java
+++ b/framework/src/org/apache/cordova/PluginManager.java
@@ -560,10 +560,10 @@ public class PluginManager {
         CordovaPlugin ret = null;
         try {
             Class<?> c = null;
-            if ((className != null) && !("".equals(className))) {
+            if (className != null && !className.isBlank()) {
                 c = Class.forName(className);
             }
-            if (c != null & CordovaPlugin.class.isAssignableFrom(c)) {
+            if (c != null && CordovaPlugin.class.isAssignableFrom(c)) {
                 ret = (CordovaPlugin) c.getDeclaredConstructor().newInstance();
             }
         } catch (Exception e) {

--- a/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
+++ b/framework/src/org/apache/cordova/engine/SystemWebChromeClient.java
@@ -231,7 +231,7 @@ public class SystemWebChromeClient extends WebChromeClient {
         Intent fileIntent = fileChooserParams.createIntent();
 
         // Check if multiple-select is specified
-        Boolean selectMultiple = false;
+        boolean selectMultiple = false;
         if (fileChooserParams.getMode() == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {
             selectMultiple = true;
         }

--- a/test/androidx/app/src/androidTest/java/org/apache/cordova/unittests/IFrameTest.java
+++ b/test/androidx/app/src/androidTest/java/org/apache/cordova/unittests/IFrameTest.java
@@ -71,6 +71,7 @@ public class IFrameTest {
         onWebView().withElement(findElement(Locator.ID, "google_maps")).perform(webClick());
         sleep(WEBVIEW_LOAD_DELAY);
         mActivityRule.runOnUiThread(new Runnable() {
+            @Override
             public void run()
             {
                 String url = cordovaWebView.getUrl();
@@ -80,6 +81,7 @@ public class IFrameTest {
         sleep(WEBVIEW_LOAD_DELAY);
         onWebView().withElement(findElement(Locator.ID, "javascript_load")).perform(webClick());
         mActivityRule.runOnUiThread(new Runnable() {
+            @Override
             public void run()
             {
                 String url = cordovaWebView.getUrl();
@@ -90,6 +92,7 @@ public class IFrameTest {
         //Espresso will kill the application and not trigger the backHistory method, which correctly
         //navigates the iFrame history.  backHistory is tied to the back button.
         mActivityRule.runOnUiThread(new Runnable() {
+            @Override
             public void run()
             {
                 assertTrue(cordovaWebView.backHistory());


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Static analysis identified a few warnings in our Java code. These were the easy ones to fix.


### Description
<!-- Describe your changes in detail -->
* Add `@Override` annotations where needed in a test
* Fix improper if condition chaining in `PluginManager`
* Fix inefficient empty string check in `PluginManager`
* Don't use boxed `Boolean` type where simple `boolean` will do


### Checklist

- [x] I've run the tests to see all new and existing tests pass
