### PR TITLE
WIP Simplify Android colour structure

### DIFF
--- a/templates/project/res/values-night-v34/cdv_colors.xml
+++ b/templates/project/res/values-night-v34/cdv_colors.xml
@@ -18,6 +18,5 @@
  under the License.
 -->
 <resources>
-    <color name="cdv_background_color">@android:color/system_background_dark</color>
-    <color name="cdv_splashscreen_background">@color/cdv_background_color</color>
+    <color name="cdv_system_background_color">@android:color/system_background_dark</color>
 </resources>

--- a/templates/project/res/values-night/cdv_colors.xml
+++ b/templates/project/res/values-night/cdv_colors.xml
@@ -18,6 +18,5 @@
  under the License.
 -->
 <resources>
-    <color name="cdv_background_color">#121318</color>
-    <color name="cdv_splashscreen_background">@color/cdv_background_color</color>
+    <color name="cdv_system_background_color">#FF121318</color>
 </resources>

--- a/templates/project/res/values-v34/cdv_colors.xml
+++ b/templates/project/res/values-v34/cdv_colors.xml
@@ -18,6 +18,5 @@
  under the License.
 -->
 <resources>
-    <color name="cdv_background_color">@android:color/system_background_light</color>
-    <color name="cdv_splashscreen_background">@color/cdv_background_color</color>
+    <color name="cdv_system_background_color">@android:color/system_background_light</color>
 </resources>

--- a/templates/project/res/values/cdv_colors.xml
+++ b/templates/project/res/values/cdv_colors.xml
@@ -18,6 +18,9 @@
  under the License.
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <color name="cdv_background_color">#FAF8FF</color>
+    <color name="cdv_system_background_color">#FFFAF8FF</color>
+
+    <color name="cdv_background_color">@color/cdv_system_background_color</color>
     <color name="cdv_splashscreen_background">@color/cdv_background_color</color>
+    <color name="cdv_status_bar_background">@android:color/transparent</color>
 </resources>

--- a/templates/project/res/values/cdv_themes.xml
+++ b/templates/project/res/values/cdv_themes.xml
@@ -34,6 +34,6 @@
 
     <style name="Theme.Cordova.App.DayNight" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:colorBackground">@color/cdv_background_color</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/cdv_status_bar_background</item>
     </style>
 </resources>


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To avoid run-time parsing of colours from config.xml, it would be best if the prepare step could set the colours properly in cdv_colors.xml as resources.


### Description
<!-- Describe your changes in detail -->
Restructured the cdv_colors.xml file so that the default/system background is a separate variable that gets changed based on .

* Set up `cdv_background_color` so it defaults to the system background
    * To be set from the `BackgroundColor` preference in config.xml
* Added a `cdv_status_bar_background` color resource that defaults to transparent
    * To be set from the `StatusBarBackgroundColor` preference in config.xml
* Retain `cdv_splashscreen_background` defaulting to the `cdv_background_color`
    * To be set from the `SplashScreenBackgroundColor` preference in config.xml

### TODO

- [ ] Actually setting the colour override values during prepare based on the preferences


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
